### PR TITLE
IDs present in the /api/assertions endpoint added to db records

### DIFF
--- a/molecular-oncology-almanac.json
+++ b/molecular-oncology-almanac.json
@@ -25,7 +25,11 @@
         "nct": "",
         "publication_date": "2021-05-01",
         "last_updated": "2021-09-16",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 1,
+        "feature_id": 1,
+        "source_id": 1,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Rearrangement",
@@ -53,7 +57,11 @@
         "nct": "",
         "publication_date": "2018-12-01",
         "last_updated": "2020-11-12",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 2,
+        "feature_id": 2,
+        "source_id": 2,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Rearrangement",
@@ -81,7 +89,11 @@
         "nct": "",
         "publication_date": "2018-12-01",
         "last_updated": "2020-11-12",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 3,
+        "feature_id": 3,
+        "source_id": 2,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Rearrangement",
@@ -109,7 +121,11 @@
         "nct": "",
         "publication_date": "2020-08-01",
         "last_updated": "2020-11-12",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 4,
+        "feature_id": 4,
+        "source_id": 3,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Rearrangement",
@@ -137,7 +153,11 @@
         "nct": "",
         "publication_date": "2020-08-01",
         "last_updated": "2020-11-12",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 5,
+        "feature_id": 5,
+        "source_id": 3,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Rearrangement",
@@ -156,16 +176,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": "",
         "predictive_implication": "Guideline",
-        "description": "Dasatinib (Sprycel) is recommended by the National Comprehensive Cancer Network® (NCCN®) as a treatment option for adult patients with newly diagnosed Philadelphia chromosome-positive (Ph+) chronic myeloid leukemia (CML) in chronic phase or in the setting of resistance or intolerance to prior therapy, including imatinib.",
+        "description": "Dasatinib (Sprycel) is recommended by the National Comprehensive Cancer Network\u00ae (NCCN\u00ae) as a treatment option for adult patients with newly diagnosed Philadelphia chromosome-positive (Ph+) chronic myeloid leukemia (CML) in chronic phase or in the setting of resistance or intolerance to prior therapy, including imatinib.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Chronic Myelogenous Leukemia V.2.2016. © National Comprehensive Cancer Network, Inc. 2016. All rights reserved. Accessed November 5 2016]. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Chronic Myelogenous Leukemia V.2.2016. \u00a9 National Comprehensive Cancer Network, Inc. 2016. All rights reserved. Accessed November 5 2016]. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/cml.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2016-01-01",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 6,
+        "feature_id": 6,
+        "source_id": 4,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Rearrangement",
@@ -193,7 +217,11 @@
         "nct": "NCT00471497",
         "publication_date": "2010-06-17",
         "last_updated": "2019-08-14",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 7,
+        "feature_id": 7,
+        "source_id": 5,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Rearrangement",
@@ -221,7 +249,11 @@
         "nct": "",
         "publication_date": "2024-10-29",
         "last_updated": "2024-11-06",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 8,
+        "feature_id": 8,
+        "source_id": 6,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Rearrangement",
@@ -249,7 +281,11 @@
         "nct": "NCT02075840",
         "publication_date": "2018-06-01",
         "last_updated": "2020-11-12",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 9,
+        "feature_id": 9,
+        "source_id": 7,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Rearrangement",
@@ -277,7 +313,11 @@
         "nct": "",
         "publication_date": "2011-08-26",
         "last_updated": "2024-03-04",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 10,
+        "feature_id": 10,
+        "source_id": 8,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Rearrangement",
@@ -305,7 +345,11 @@
         "nct": "",
         "publication_date": "2020-05-01",
         "last_updated": "2020-11-12",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 11,
+        "feature_id": 11,
+        "source_id": 9,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Rearrangement",
@@ -333,7 +377,11 @@
         "nct": "",
         "publication_date": "2019-03-01",
         "last_updated": "2020-11-12",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 12,
+        "feature_id": 12,
+        "source_id": 10,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Rearrangement",
@@ -352,16 +400,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": "",
         "predictive_implication": "Guideline",
-        "description": "Alectinib (Alecensa) is recommended by the National Comprehensive Cancer Network® (NCCN®) as a treatment option as a first or subsequent line of therapy for patients with metastatic non-small cell lung cancer whose tumors harbor an ALK rearrangement",
+        "description": "Alectinib (Alecensa) is recommended by the National Comprehensive Cancer Network\u00ae (NCCN\u00ae) as a treatment option as a first or subsequent line of therapy for patients with metastatic non-small cell lung cancer whose tumors harbor an ALK rearrangement",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Non-Small Lung Cancer V.5.2019. © National Comprehensive Cancer Network, Inc. 2019. All rights reserved. Accessed August 12, 2019. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Non-Small Lung Cancer V.5.2019. \u00a9 National Comprehensive Cancer Network, Inc. 2019. All rights reserved. Accessed August 12, 2019. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/nscl_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2019-01-01",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 13,
+        "feature_id": 13,
+        "source_id": 11,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Rearrangement",
@@ -389,7 +441,11 @@
         "nct": "NCT01283516",
         "publication_date": "2014-03-27",
         "last_updated": "2019-08-10",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 14,
+        "feature_id": 14,
+        "source_id": 12,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Rearrangement",
@@ -408,16 +464,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": "",
         "predictive_implication": "Guideline",
-        "description": "Crizotinib (Xalkori) is recommended by the National Comprehensive Cancer Network® (NCCN®) as a treatment option for patients with inflammatory myofibroblastic tumors and ALK translocations.",
+        "description": "Crizotinib (Xalkori) is recommended by the National Comprehensive Cancer Network\u00ae (NCCN\u00ae) as a treatment option for patients with inflammatory myofibroblastic tumors and ALK translocations.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Soft Tissue Sarcoma V.2.2019. © National Comprehensive Cancer Network, Inc. 2019. All rights reserved. Accessed August 10th, 2019. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Soft Tissue Sarcoma V.2.2019. \u00a9 National Comprehensive Cancer Network, Inc. 2019. All rights reserved. Accessed August 10th, 2019. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/sarcoma_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2019-01-01",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 15,
+        "feature_id": 15,
+        "source_id": 13,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Rearrangement",
@@ -436,16 +496,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": "",
         "predictive_implication": "Guideline",
-        "description": "Ceritinib (Zykadia) is recommended by the National Comprehensive Cancer Network® (NCCN®) as a treatment option for patients with inflammatory myofibroblastic tumors and ALK translocations.",
+        "description": "Ceritinib (Zykadia) is recommended by the National Comprehensive Cancer Network\u00ae (NCCN\u00ae) as a treatment option for patients with inflammatory myofibroblastic tumors and ALK translocations.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Soft Tissue Sarcoma V.2.2019. © National Comprehensive Cancer Network, Inc. 2019. All rights reserved. Accessed August 10th, 2019. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Soft Tissue Sarcoma V.2.2019. \u00a9 National Comprehensive Cancer Network, Inc. 2019. All rights reserved. Accessed August 10th, 2019. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/sarcoma_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2019-01-01",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 16,
+        "feature_id": 16,
+        "source_id": 13,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Rearrangement",
@@ -473,7 +537,11 @@
         "nct": "NCT00585195",
         "publication_date": "2010-10-28",
         "last_updated": "2019-08-10",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 17,
+        "feature_id": 17,
+        "source_id": 14,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Rearrangement",
@@ -501,7 +569,11 @@
         "nct": "",
         "publication_date": "2010-09-24",
         "last_updated": "2018-09-14",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 18,
+        "feature_id": 18,
+        "source_id": 15,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Rearrangement",
@@ -529,7 +601,11 @@
         "nct": "",
         "publication_date": "2016-08-17",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 19,
+        "feature_id": 19,
+        "source_id": 16,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Rearrangement",
@@ -557,7 +633,11 @@
         "nct": "",
         "publication_date": "2013-03-17",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 20,
+        "feature_id": 20,
+        "source_id": 17,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Rearrangement",
@@ -585,7 +665,11 @@
         "nct": "",
         "publication_date": "2016-08-17",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 21,
+        "feature_id": 21,
+        "source_id": 16,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Rearrangement",
@@ -604,16 +688,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": "",
         "predictive_implication": "Guideline",
-        "description": "Imatinib (Gleevec) is recommended by the National Comprehensive Cancer Network® (NCCN®) as a treatment option for patients with localized or metastatic dermatofibrosarcoma tumors containing t(17;22)(q22;q13).",
+        "description": "Imatinib (Gleevec) is recommended by the National Comprehensive Cancer Network\u00ae (NCCN\u00ae) as a treatment option for patients with localized or metastatic dermatofibrosarcoma tumors containing t(17;22)(q22;q13).",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Dermatofibrosarcoma V.1.2017. © National Comprehensive Cancer Network, Inc. 2017. All rights reserved. Accessed November 5 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Dermatofibrosarcoma V.1.2017. \u00a9 National Comprehensive Cancer Network, Inc. 2017. All rights reserved. Accessed November 5 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/dfsp_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2016-01-01",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 22,
+        "feature_id": 22,
+        "source_id": 18,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Rearrangement",
@@ -641,7 +729,11 @@
         "nct": "",
         "publication_date": "2023-10-01",
         "last_updated": "2019-08-09",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 23,
+        "feature_id": 23,
+        "source_id": 19,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Rearrangement",
@@ -660,16 +752,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": "",
         "predictive_implication": "Guideline",
-        "description": "Crizotinib (Xalkori) is recommended by the National Comprehensive Cancer Network® (NCCN®) as a treatment option as a first or subsequent line of therapy for patients with metastatic non-small cell lung cancer whose tumors harbor an ALK rearrangement, notable with EML4.",
+        "description": "Crizotinib (Xalkori) is recommended by the National Comprehensive Cancer Network\u00ae (NCCN\u00ae) as a treatment option as a first or subsequent line of therapy for patients with metastatic non-small cell lung cancer whose tumors harbor an ALK rearrangement, notable with EML4.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Non-Small Lung Cancer V.1.2017. © National Comprehensive Cancer Network, Inc. 2017. All rights reserved. Accessed November 5, 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Non-Small Lung Cancer V.1.2017. \u00a9 National Comprehensive Cancer Network, Inc. 2017. All rights reserved. Accessed November 5, 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/nscl_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2017-01-01",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 24,
+        "feature_id": 24,
+        "source_id": 20,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Rearrangement",
@@ -697,7 +793,11 @@
         "nct": "",
         "publication_date": "2010-06-06",
         "last_updated": "2019-03-07",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 25,
+        "feature_id": 25,
+        "source_id": 21,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Rearrangement",
@@ -725,7 +825,11 @@
         "nct": "",
         "publication_date": "2010-06-06",
         "last_updated": "2019-03-07",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 26,
+        "feature_id": 26,
+        "source_id": 21,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Rearrangement",
@@ -746,14 +850,18 @@
         "predictive_implication": "Guideline",
         "description": "EWS-FLI1 translocations may be associated with improved prognosis in Ewing's Sarcoma; however, current treatments result in patient outcomes indistinguishable by EWS-FLI1 status.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Bone Cancer V.1.2017. © National Comprehensive Cancer Network, Inc. 2017. All rights reserved. Accessed November 6 2016]. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Bone Cancer V.1.2017. \u00a9 National Comprehensive Cancer Network, Inc. 2017. All rights reserved. Accessed November 6 2016]. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/bone.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2017-01-01",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 27,
+        "feature_id": 27,
+        "source_id": 22,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Rearrangement",
@@ -781,7 +889,11 @@
         "nct": "",
         "publication_date": "2014-02-13",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 28,
+        "feature_id": 28,
+        "source_id": 23,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Rearrangement",
@@ -809,7 +921,11 @@
         "nct": "",
         "publication_date": "2020-04-01",
         "last_updated": "2020-10-15",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 29,
+        "feature_id": 29,
+        "source_id": 24,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Rearrangement",
@@ -837,7 +953,11 @@
         "nct": "",
         "publication_date": "2020-04-01",
         "last_updated": "2020-10-15",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 30,
+        "feature_id": 30,
+        "source_id": 24,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Rearrangement",
@@ -865,7 +985,11 @@
         "nct": "",
         "publication_date": "2021-05-01",
         "last_updated": "2021-06-01",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 31,
+        "feature_id": 31,
+        "source_id": 25,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Rearrangement",
@@ -893,7 +1017,11 @@
         "nct": "",
         "publication_date": "2024-01-19",
         "last_updated": "2024-01-25",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 32,
+        "feature_id": 32,
+        "source_id": 26,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Rearrangement",
@@ -921,7 +1049,11 @@
         "nct": "",
         "publication_date": "2013-05-16",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 33,
+        "feature_id": 33,
+        "source_id": 27,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Rearrangement",
@@ -942,14 +1074,18 @@
         "predictive_implication": "Guideline",
         "description": "A translocation between 11 and 14 [t(11;14)] has been reported to be associated with improved survival.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Multiple Myeloma V.2.2016. © National Comprehensive Cancer Network, Inc. 2016. All rights reserved. Accessed November 5 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Multiple Myeloma V.2.2016. \u00a9 National Comprehensive Cancer Network, Inc. 2016. All rights reserved. Accessed November 5 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/myeloma_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2016-01-01",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 34,
+        "feature_id": 34,
+        "source_id": 28,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Rearrangement",
@@ -970,14 +1106,18 @@
         "predictive_implication": "Guideline",
         "description": "A translocation between 4 and 14 [t(4;14)] has been reported in several studies to be associated with poor prognosis.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Multiple Myeloma V.2.2016. © National Comprehensive Cancer Network, Inc. 2016. All rights reserved. Accessed November 5 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Multiple Myeloma V.2.2016. \u00a9 National Comprehensive Cancer Network, Inc. 2016. All rights reserved. Accessed November 5 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/myeloma_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2016-01-01",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 35,
+        "feature_id": 35,
+        "source_id": 28,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Rearrangement",
@@ -1005,7 +1145,11 @@
         "nct": "NCT02122913",
         "publication_date": "2018-11-01",
         "last_updated": "2020-11-12",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 36,
+        "feature_id": 36,
+        "source_id": 29,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Rearrangement",
@@ -1033,7 +1177,11 @@
         "nct": "",
         "publication_date": "2016-03-18",
         "last_updated": "2017-03-16",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 37,
+        "feature_id": 37,
+        "source_id": 30,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Rearrangement",
@@ -1061,7 +1209,11 @@
         "nct": "",
         "publication_date": "2023-10-20",
         "last_updated": "2023-11-01",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 38,
+        "feature_id": 38,
+        "source_id": 31,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Rearrangement",
@@ -1089,7 +1241,11 @@
         "nct": "NCT02122913",
         "publication_date": "2018-11-01",
         "last_updated": "2020-11-12",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 39,
+        "feature_id": 39,
+        "source_id": 29,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Rearrangement",
@@ -1117,7 +1273,11 @@
         "nct": "",
         "publication_date": "2016-03-18",
         "last_updated": "2017-03-16",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 40,
+        "feature_id": 40,
+        "source_id": 30,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Rearrangement",
@@ -1145,7 +1305,11 @@
         "nct": "",
         "publication_date": "2023-10-20",
         "last_updated": "2023-11-01",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 41,
+        "feature_id": 41,
+        "source_id": 31,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Rearrangement",
@@ -1173,7 +1337,11 @@
         "nct": "NCT02122913",
         "publication_date": "2018-11-01",
         "last_updated": "2020-11-12",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 42,
+        "feature_id": 42,
+        "source_id": 29,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Rearrangement",
@@ -1201,7 +1369,11 @@
         "nct": "",
         "publication_date": "2016-03-18",
         "last_updated": "2017-03-16",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 43,
+        "feature_id": 43,
+        "source_id": 30,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Rearrangement",
@@ -1229,7 +1401,11 @@
         "nct": "",
         "publication_date": "2023-10-20",
         "last_updated": "2023-11-01",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 44,
+        "feature_id": 44,
+        "source_id": 31,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Rearrangement",
@@ -1257,7 +1433,11 @@
         "nct": "",
         "publication_date": "2020-08-01",
         "last_updated": "2020-11-12",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 45,
+        "feature_id": 45,
+        "source_id": 3,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Rearrangement",
@@ -1285,7 +1465,11 @@
         "nct": "",
         "publication_date": "2020-08-01",
         "last_updated": "2020-11-12",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 46,
+        "feature_id": 46,
+        "source_id": 3,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Rearrangement",
@@ -1313,7 +1497,11 @@
         "nct": "",
         "publication_date": "2003-08-23",
         "last_updated": "2019-03-19",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 47,
+        "feature_id": 47,
+        "source_id": 32,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Rearrangement",
@@ -1341,7 +1529,11 @@
         "nct": "",
         "publication_date": "2020-08-01",
         "last_updated": "2020-11-12",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 48,
+        "feature_id": 48,
+        "source_id": 3,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Rearrangement",
@@ -1360,16 +1552,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": "",
         "predictive_implication": "Guideline",
-        "description": "Imatinib (Gleevec) is recommended by the National Comprehensive Cancer Network® (NCCN®) as a treatment option for patients with Chronic Myelomonocytic Leukemia harboring an ETV6::PDGFRB translocation.",
+        "description": "Imatinib (Gleevec) is recommended by the National Comprehensive Cancer Network\u00ae (NCCN\u00ae) as a treatment option for patients with Chronic Myelomonocytic Leukemia harboring an ETV6::PDGFRB translocation.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Myelodysplastic Syndromes V.2.2023. © National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Myelodysplastic Syndromes V.2.2023. \u00a9 National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/mds_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2023-10-17",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 49,
+        "feature_id": 49,
+        "source_id": 33,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Rearrangement",
@@ -1388,16 +1584,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": "",
         "predictive_implication": "Guideline",
-        "description": "Cabozantinib (Xalkori) is recommended by the National Comprehensive Cancer Network® (NCCN®) as a treatment option for patients with metastatic non-small cell lung cancer whose tumors harbor a RET rearrangement.",
+        "description": "Cabozantinib (Xalkori) is recommended by the National Comprehensive Cancer Network\u00ae (NCCN\u00ae) as a treatment option for patients with metastatic non-small cell lung cancer whose tumors harbor a RET rearrangement.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Non-Small Lung Cancer V.5.2019. © National Comprehensive Cancer Network, Inc. 2019. All rights reserved. Accessed August 12, 2019. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Non-Small Lung Cancer V.5.2019. \u00a9 National Comprehensive Cancer Network, Inc. 2019. All rights reserved. Accessed August 12, 2019. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/nscl_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2019-01-01",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 50,
+        "feature_id": 50,
+        "source_id": 11,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Rearrangement",
@@ -1416,16 +1616,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": "",
         "predictive_implication": "Guideline",
-        "description": "Vandetanib (Caprelsa) is recommended by the National Comprehensive Cancer Network® (NCCN®) as a treatment option for patients with metastatic non-small cell lung cancer whose tumors harbor a RET rearrangement.",
+        "description": "Vandetanib (Caprelsa) is recommended by the National Comprehensive Cancer Network\u00ae (NCCN\u00ae) as a treatment option for patients with metastatic non-small cell lung cancer whose tumors harbor a RET rearrangement.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Non-Small Lung Cancer V.5.2019. © National Comprehensive Cancer Network, Inc. 2019. All rights reserved. Accessed August 12, 2019. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Non-Small Lung Cancer V.5.2019. \u00a9 National Comprehensive Cancer Network, Inc. 2019. All rights reserved. Accessed August 12, 2019. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/nscl_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2019-01-01",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 51,
+        "feature_id": 51,
+        "source_id": 11,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Rearrangement",
@@ -1453,7 +1657,11 @@
         "nct": "NCT01639508",
         "publication_date": "2013-06-06",
         "last_updated": "2019-01-29",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 52,
+        "feature_id": 52,
+        "source_id": 34,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Rearrangement",
@@ -1481,7 +1689,11 @@
         "nct": "",
         "publication_date": "2020-05-08",
         "last_updated": "2024-06-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 53,
+        "feature_id": 53,
+        "source_id": 35,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Rearrangement",
@@ -1509,7 +1721,11 @@
         "nct": "",
         "publication_date": "2024-06-12",
         "last_updated": "2024-07-11",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 54,
+        "feature_id": 54,
+        "source_id": 36,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Rearrangement",
@@ -1537,7 +1753,11 @@
         "nct": "",
         "publication_date": "2023-08-09",
         "last_updated": "2023-09-06",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 55,
+        "feature_id": 55,
+        "source_id": 37,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Rearrangement",
@@ -1565,7 +1785,11 @@
         "nct": "",
         "publication_date": "2020-12-01",
         "last_updated": "2020-12-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 56,
+        "feature_id": 56,
+        "source_id": 38,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Rearrangement",
@@ -1593,7 +1817,11 @@
         "nct": "",
         "publication_date": "2016-03-11",
         "last_updated": "2024-03-04",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 57,
+        "feature_id": 57,
+        "source_id": 39,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Rearrangement",
@@ -1621,7 +1849,11 @@
         "nct": "",
         "publication_date": "2019-08-01",
         "last_updated": "2020-11-12",
-        "_deprecated": true
+        "_deprecated": true,
+        "assertion_id": 58,
+        "feature_id": 58,
+        "source_id": 40,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Rearrangement",
@@ -1640,16 +1872,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": "",
         "predictive_implication": "Preclinical",
-        "description": "Azacitidine (Vidaza) in combination with Panobinostat (Farydak) is recommended by the National Comprehensive Cancer Network® (NCCN®) as a treatment option for patients with myelodysplasia syndromes harboring a t(8;21)(q22;q22) translocation. t(8;21)(q22;q22) results in the expression of fusion protein RUNX1-RUNX1T1, which recruits histone deacetylases (HDAC) to silence RUNX1 target genes (such as IL-3). Combined use of HDAC inhibitors and DNMT inhibitors may rescue RUNX1 target genes.",
+        "description": "Azacitidine (Vidaza) in combination with Panobinostat (Farydak) is recommended by the National Comprehensive Cancer Network\u00ae (NCCN\u00ae) as a treatment option for patients with myelodysplasia syndromes harboring a t(8;21)(q22;q22) translocation. t(8;21)(q22;q22) results in the expression of fusion protein RUNX1-RUNX1T1, which recruits histone deacetylases (HDAC) to silence RUNX1 target genes (such as IL-3). Combined use of HDAC inhibitors and DNMT inhibitors may rescue RUNX1 target genes.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Myelodysplastic Syndromes V.2.2023. © National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Myelodysplastic Syndromes V.2.2023. \u00a9 National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/mds_blocks.pdf",
         "doi": "",
         "pmid": 15735013,
         "nct": "",
         "publication_date": "2023-10-17",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 59,
+        "feature_id": 59,
+        "source_id": 41,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Rearrangement",
@@ -1677,7 +1913,11 @@
         "nct": "",
         "publication_date": "2010-06-06",
         "last_updated": "2019-03-07",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 60,
+        "feature_id": 60,
+        "source_id": 21,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Rearrangement",
@@ -1705,7 +1945,11 @@
         "nct": "",
         "publication_date": "2010-06-06",
         "last_updated": "2019-03-07",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 61,
+        "feature_id": 61,
+        "source_id": 21,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Rearrangement",
@@ -1733,7 +1977,11 @@
         "nct": "",
         "publication_date": "2013-04-02",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 62,
+        "feature_id": 62,
+        "source_id": 42,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Rearrangement",
@@ -1761,7 +2009,11 @@
         "nct": "",
         "publication_date": "2007-01-22",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 63,
+        "feature_id": 63,
+        "source_id": 43,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Rearrangement",
@@ -1789,7 +2041,11 @@
         "nct": "NCT01576172",
         "publication_date": "2017-12-20",
         "last_updated": "2019-01-29",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 64,
+        "feature_id": 64,
+        "source_id": 44,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Rearrangement",
@@ -1817,7 +2073,11 @@
         "nct": "NCT01576172",
         "publication_date": "2017-12-20",
         "last_updated": "2019-01-29",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 65,
+        "feature_id": 65,
+        "source_id": 44,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -1852,7 +2112,11 @@
         "nct": "",
         "publication_date": "2001-06-21",
         "last_updated": "2023-11-30",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 66,
+        "feature_id": 66,
+        "source_id": 45,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -1887,7 +2151,11 @@
         "nct": "",
         "publication_date": "2011-08-04",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 67,
+        "feature_id": 67,
+        "source_id": 46,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -1922,7 +2190,11 @@
         "nct": "",
         "publication_date": "2011-08-04",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 68,
+        "feature_id": 68,
+        "source_id": 46,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -1957,7 +2229,11 @@
         "nct": "",
         "publication_date": "2011-08-04",
         "last_updated": "2023-11-30",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 69,
+        "feature_id": 69,
+        "source_id": 46,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -1992,7 +2268,11 @@
         "nct": "",
         "publication_date": "2011-08-04",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 70,
+        "feature_id": 70,
+        "source_id": 46,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -2027,7 +2307,11 @@
         "nct": "",
         "publication_date": "2011-08-04",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 71,
+        "feature_id": 71,
+        "source_id": 46,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -2062,7 +2346,11 @@
         "nct": "",
         "publication_date": "2011-08-04",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 72,
+        "feature_id": 72,
+        "source_id": 46,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -2097,7 +2385,11 @@
         "nct": "",
         "publication_date": "2011-08-04",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 73,
+        "feature_id": 73,
+        "source_id": 46,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -2132,7 +2424,11 @@
         "nct": "",
         "publication_date": "2011-08-04",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 74,
+        "feature_id": 74,
+        "source_id": 46,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -2167,7 +2463,11 @@
         "nct": "",
         "publication_date": "2011-08-04",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 75,
+        "feature_id": 75,
+        "source_id": 46,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -2202,7 +2502,11 @@
         "nct": "",
         "publication_date": "2011-08-04",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 76,
+        "feature_id": 76,
+        "source_id": 46,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -2237,7 +2541,11 @@
         "nct": "",
         "publication_date": "2011-08-04",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 77,
+        "feature_id": 77,
+        "source_id": 46,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -2272,7 +2580,11 @@
         "nct": "",
         "publication_date": "2011-08-04",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 78,
+        "feature_id": 78,
+        "source_id": 46,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -2307,7 +2619,11 @@
         "nct": "",
         "publication_date": "2011-08-04",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 79,
+        "feature_id": 79,
+        "source_id": 46,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -2342,7 +2658,11 @@
         "nct": "",
         "publication_date": "2011-08-04",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 80,
+        "feature_id": 80,
+        "source_id": 46,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -2368,16 +2688,20 @@
         "therapy_resistance": 1,
         "favorable_prognosis": "",
         "predictive_implication": "Guideline",
-        "description": "Dasatinib (Sprycel) is not recommended by the National Comprehensive Cancer Network® (NCCN®) as a treatment option for patients with CML in the context of secondary resistance variants. Selection of an alternate TKI in the context of TKI-resistant or possible-TKI resistant BCR::ABL1 mutant CML may be based on mutantion profile.",
+        "description": "Dasatinib (Sprycel) is not recommended by the National Comprehensive Cancer Network\u00ae (NCCN\u00ae) as a treatment option for patients with CML in the context of secondary resistance variants. Selection of an alternate TKI in the context of TKI-resistant or possible-TKI resistant BCR::ABL1 mutant CML may be based on mutantion profile.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Chronic Myelogenous Leukemia V.2.2016. © National Comprehensive Cancer Network, Inc. 2016. All rights reserved. Accessed August 9 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Chronic Myelogenous Leukemia V.2.2016. \u00a9 National Comprehensive Cancer Network, Inc. 2016. All rights reserved. Accessed August 9 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/cml_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2016-01-01",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 81,
+        "feature_id": 81,
+        "source_id": 47,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -2403,16 +2727,20 @@
         "therapy_resistance": 1,
         "favorable_prognosis": "",
         "predictive_implication": "Guideline",
-        "description": "Dasatinib (Sprycel) is not recommended by the National Comprehensive Cancer Network® (NCCN®) as a treatment option for patients with CML in the context of secondary resistance variants. Selection of an alternate TKI in the context of TKI-resistant or possible-TKI resistant BCR::ABL1 mutant CML may be based on mutantion profile.",
+        "description": "Dasatinib (Sprycel) is not recommended by the National Comprehensive Cancer Network\u00ae (NCCN\u00ae) as a treatment option for patients with CML in the context of secondary resistance variants. Selection of an alternate TKI in the context of TKI-resistant or possible-TKI resistant BCR::ABL1 mutant CML may be based on mutantion profile.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Chronic Myelogenous Leukemia V.2.2016. © National Comprehensive Cancer Network, Inc. 2016. All rights reserved. Accessed August 9 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Chronic Myelogenous Leukemia V.2.2016. \u00a9 National Comprehensive Cancer Network, Inc. 2016. All rights reserved. Accessed August 9 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/cml_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2016-01-01",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 82,
+        "feature_id": 82,
+        "source_id": 47,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -2438,16 +2766,20 @@
         "therapy_resistance": 1,
         "favorable_prognosis": "",
         "predictive_implication": "Guideline",
-        "description": "Dasatinib (Sprycel) is not recommended by the National Comprehensive Cancer Network® (NCCN®) as a treatment option for patients with CML in the context of secondary resistance variants. Selection of an alternate TKI in the context of TKI-resistant or possible-TKI resistant BCR::ABL1 mutant CML may be based on mutantion profile.",
+        "description": "Dasatinib (Sprycel) is not recommended by the National Comprehensive Cancer Network\u00ae (NCCN\u00ae) as a treatment option for patients with CML in the context of secondary resistance variants. Selection of an alternate TKI in the context of TKI-resistant or possible-TKI resistant BCR::ABL1 mutant CML may be based on mutantion profile.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Chronic Myelogenous Leukemia V.2.2016. © National Comprehensive Cancer Network, Inc. 2016. All rights reserved. Accessed August 9 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Chronic Myelogenous Leukemia V.2.2016. \u00a9 National Comprehensive Cancer Network, Inc. 2016. All rights reserved. Accessed August 9 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/cml_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2016-01-01",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 83,
+        "feature_id": 83,
+        "source_id": 47,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -2473,16 +2805,20 @@
         "therapy_resistance": 1,
         "favorable_prognosis": "",
         "predictive_implication": "Guideline",
-        "description": "Dasatinib (Sprycel) is not recommended by the National Comprehensive Cancer Network® (NCCN®) as a treatment option for patients with CML in the context of secondary resistance variants. Selection of an alternate TKI in the context of TKI-resistant or possible-TKI resistant BCR::ABL1 mutant CML may be based on mutantion profile.",
+        "description": "Dasatinib (Sprycel) is not recommended by the National Comprehensive Cancer Network\u00ae (NCCN\u00ae) as a treatment option for patients with CML in the context of secondary resistance variants. Selection of an alternate TKI in the context of TKI-resistant or possible-TKI resistant BCR::ABL1 mutant CML may be based on mutantion profile.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Chronic Myelogenous Leukemia V.2.2016. © National Comprehensive Cancer Network, Inc. 2016. All rights reserved. Accessed August 9 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Chronic Myelogenous Leukemia V.2.2016. \u00a9 National Comprehensive Cancer Network, Inc. 2016. All rights reserved. Accessed August 9 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/cml_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2016-01-01",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 84,
+        "feature_id": 84,
+        "source_id": 47,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -2508,16 +2844,20 @@
         "therapy_resistance": 1,
         "favorable_prognosis": "",
         "predictive_implication": "Guideline",
-        "description": "Dasatinib (Sprycel) is not recommended by the National Comprehensive Cancer Network® (NCCN®) as a treatment option for patients with CML in the context of secondary resistance variants. Selection of an alternate TKI in the context of TKI-resistant or possible-TKI resistant BCR::ABL1 mutant CML may be based on mutantion profile.",
+        "description": "Dasatinib (Sprycel) is not recommended by the National Comprehensive Cancer Network\u00ae (NCCN\u00ae) as a treatment option for patients with CML in the context of secondary resistance variants. Selection of an alternate TKI in the context of TKI-resistant or possible-TKI resistant BCR::ABL1 mutant CML may be based on mutantion profile.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Chronic Myelogenous Leukemia V.2.2016. © National Comprehensive Cancer Network, Inc. 2016. All rights reserved. Accessed August 9 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Chronic Myelogenous Leukemia V.2.2016. \u00a9 National Comprehensive Cancer Network, Inc. 2016. All rights reserved. Accessed August 9 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/cml_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2016-01-01",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 85,
+        "feature_id": 85,
+        "source_id": 47,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -2543,16 +2883,20 @@
         "therapy_resistance": 1,
         "favorable_prognosis": "",
         "predictive_implication": "Guideline",
-        "description": "Dasatinib (Sprycel) is not recommended by the National Comprehensive Cancer Network® (NCCN®) as a treatment option for patients with CML in the context of secondary resistance variants. Selection of an alternate TKI in the context of TKI-resistant or possible-TKI resistant BCR::ABL1 mutant CML may be based on mutantion profile.",
+        "description": "Dasatinib (Sprycel) is not recommended by the National Comprehensive Cancer Network\u00ae (NCCN\u00ae) as a treatment option for patients with CML in the context of secondary resistance variants. Selection of an alternate TKI in the context of TKI-resistant or possible-TKI resistant BCR::ABL1 mutant CML may be based on mutantion profile.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Chronic Myelogenous Leukemia V.2.2016. © National Comprehensive Cancer Network, Inc. 2016. All rights reserved. Accessed August 9 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Chronic Myelogenous Leukemia V.2.2016. \u00a9 National Comprehensive Cancer Network, Inc. 2016. All rights reserved. Accessed August 9 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/cml_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2016-01-01",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 86,
+        "feature_id": 86,
+        "source_id": 47,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -2578,16 +2922,20 @@
         "therapy_resistance": 1,
         "favorable_prognosis": "",
         "predictive_implication": "Guideline",
-        "description": "Nilotinib (Tasigna) is not recommended by the National Comprehensive Cancer Network® (NCCN®) as a treatment option for patients with CML in the context of secondary resistance variants. Selection of an alternate TKI in the context of TKI-resistant or possible-TKI resistant BCR::ABL1 mutant CML may be based on mutantion profile.",
+        "description": "Nilotinib (Tasigna) is not recommended by the National Comprehensive Cancer Network\u00ae (NCCN\u00ae) as a treatment option for patients with CML in the context of secondary resistance variants. Selection of an alternate TKI in the context of TKI-resistant or possible-TKI resistant BCR::ABL1 mutant CML may be based on mutantion profile.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Chronic Myelogenous Leukemia V.2.2016. © National Comprehensive Cancer Network, Inc. 2016. All rights reserved. Accessed August 9 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Chronic Myelogenous Leukemia V.2.2016. \u00a9 National Comprehensive Cancer Network, Inc. 2016. All rights reserved. Accessed August 9 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/cml_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2016-01-01",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 87,
+        "feature_id": 87,
+        "source_id": 47,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -2613,16 +2961,20 @@
         "therapy_resistance": 1,
         "favorable_prognosis": "",
         "predictive_implication": "Guideline",
-        "description": "Nilotinib (Tasigna) is not recommended by the National Comprehensive Cancer Network® (NCCN®) as a treatment option for patients with CML in the context of secondary resistance variants. Selection of an alternate TKI in the context of TKI-resistant or possible-TKI resistant BCR::ABL1 mutant CML may be based on mutantion profile.",
+        "description": "Nilotinib (Tasigna) is not recommended by the National Comprehensive Cancer Network\u00ae (NCCN\u00ae) as a treatment option for patients with CML in the context of secondary resistance variants. Selection of an alternate TKI in the context of TKI-resistant or possible-TKI resistant BCR::ABL1 mutant CML may be based on mutantion profile.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Chronic Myelogenous Leukemia V.2.2016. © National Comprehensive Cancer Network, Inc. 2016. All rights reserved. Accessed August 9 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Chronic Myelogenous Leukemia V.2.2016. \u00a9 National Comprehensive Cancer Network, Inc. 2016. All rights reserved. Accessed August 9 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/cml_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2016-01-01",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 88,
+        "feature_id": 88,
+        "source_id": 47,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -2648,16 +3000,20 @@
         "therapy_resistance": 1,
         "favorable_prognosis": "",
         "predictive_implication": "Guideline",
-        "description": "Nilotinib (Tasigna) is not recommended by the National Comprehensive Cancer Network® (NCCN®) as a treatment option for patients with CML in the context of secondary resistance variants. Selection of an alternate TKI in the context of TKI-resistant or possible-TKI resistant BCR::ABL1 mutant CML may be based on mutantion profile.",
+        "description": "Nilotinib (Tasigna) is not recommended by the National Comprehensive Cancer Network\u00ae (NCCN\u00ae) as a treatment option for patients with CML in the context of secondary resistance variants. Selection of an alternate TKI in the context of TKI-resistant or possible-TKI resistant BCR::ABL1 mutant CML may be based on mutantion profile.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Chronic Myelogenous Leukemia V.2.2016. © National Comprehensive Cancer Network, Inc. 2016. All rights reserved. Accessed August 9 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Chronic Myelogenous Leukemia V.2.2016. \u00a9 National Comprehensive Cancer Network, Inc. 2016. All rights reserved. Accessed August 9 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/cml_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2016-01-01",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 89,
+        "feature_id": 89,
+        "source_id": 47,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -2683,16 +3039,20 @@
         "therapy_resistance": 1,
         "favorable_prognosis": "",
         "predictive_implication": "Guideline",
-        "description": "Nilotinib (Tasigna) is not recommended by the National Comprehensive Cancer Network® (NCCN®) as a treatment option for patients with CML in the context of secondary resistance variants. Selection of an alternate TKI in the context of TKI-resistant or possible-TKI resistant BCR::ABL1 mutant CML may be based on mutantion profile.",
+        "description": "Nilotinib (Tasigna) is not recommended by the National Comprehensive Cancer Network\u00ae (NCCN\u00ae) as a treatment option for patients with CML in the context of secondary resistance variants. Selection of an alternate TKI in the context of TKI-resistant or possible-TKI resistant BCR::ABL1 mutant CML may be based on mutantion profile.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Chronic Myelogenous Leukemia V.2.2016. © National Comprehensive Cancer Network, Inc. 2016. All rights reserved. Accessed August 9 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Chronic Myelogenous Leukemia V.2.2016. \u00a9 National Comprehensive Cancer Network, Inc. 2016. All rights reserved. Accessed August 9 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/cml_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2016-01-01",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 90,
+        "feature_id": 90,
+        "source_id": 47,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -2718,16 +3078,20 @@
         "therapy_resistance": 1,
         "favorable_prognosis": "",
         "predictive_implication": "Guideline",
-        "description": "Nilotinib (Tasigna) is not recommended by the National Comprehensive Cancer Network® (NCCN®) as a treatment option for patients with CML in the context of secondary resistance variants. Selection of an alternate TKI in the context of TKI-resistant or possible-TKI resistant BCR::ABL1 mutant CML may be based on mutantion profile.",
+        "description": "Nilotinib (Tasigna) is not recommended by the National Comprehensive Cancer Network\u00ae (NCCN\u00ae) as a treatment option for patients with CML in the context of secondary resistance variants. Selection of an alternate TKI in the context of TKI-resistant or possible-TKI resistant BCR::ABL1 mutant CML may be based on mutantion profile.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Chronic Myelogenous Leukemia V.2.2016. © National Comprehensive Cancer Network, Inc. 2016. All rights reserved. Accessed August 9 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Chronic Myelogenous Leukemia V.2.2016. \u00a9 National Comprehensive Cancer Network, Inc. 2016. All rights reserved. Accessed August 9 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/cml_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2016-01-01",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 91,
+        "feature_id": 91,
+        "source_id": 47,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -2753,16 +3117,20 @@
         "therapy_resistance": 1,
         "favorable_prognosis": "",
         "predictive_implication": "Guideline",
-        "description": "Nilotinib (Tasigna) is not recommended by the National Comprehensive Cancer Network® (NCCN®) as a treatment option for patients with CML in the context of secondary resistance variants. Selection of an alternate TKI in the context of TKI-resistant or possible-TKI resistant BCR::ABL1 mutant CML may be based on mutantion profile.",
+        "description": "Nilotinib (Tasigna) is not recommended by the National Comprehensive Cancer Network\u00ae (NCCN\u00ae) as a treatment option for patients with CML in the context of secondary resistance variants. Selection of an alternate TKI in the context of TKI-resistant or possible-TKI resistant BCR::ABL1 mutant CML may be based on mutantion profile.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Chronic Myelogenous Leukemia V.2.2016. © National Comprehensive Cancer Network, Inc. 2016. All rights reserved. Accessed August 9 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Chronic Myelogenous Leukemia V.2.2016. \u00a9 National Comprehensive Cancer Network, Inc. 2016. All rights reserved. Accessed August 9 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/cml_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2016-01-01",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 92,
+        "feature_id": 92,
+        "source_id": 47,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -2788,16 +3156,20 @@
         "therapy_resistance": 1,
         "favorable_prognosis": "",
         "predictive_implication": "Guideline",
-        "description": "Bosutinib (Bosulif) is not recommended by the National Comprehensive Cancer Network® (NCCN®) as a treatment option for patients with CML in the context of secondary resistance variants. Selection of an alternate TKI in the context of TKI-resistant or possible-TKI resistant BCR::ABL1 mutant CML may be based on mutantion profile.",
+        "description": "Bosutinib (Bosulif) is not recommended by the National Comprehensive Cancer Network\u00ae (NCCN\u00ae) as a treatment option for patients with CML in the context of secondary resistance variants. Selection of an alternate TKI in the context of TKI-resistant or possible-TKI resistant BCR::ABL1 mutant CML may be based on mutantion profile.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Chronic Myelogenous Leukemia V.2.2016. © National Comprehensive Cancer Network, Inc. 2016. All rights reserved. Accessed August 9 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Chronic Myelogenous Leukemia V.2.2016. \u00a9 National Comprehensive Cancer Network, Inc. 2016. All rights reserved. Accessed August 9 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/cml_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2016-01-01",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 93,
+        "feature_id": 93,
+        "source_id": 47,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -2823,16 +3195,20 @@
         "therapy_resistance": 1,
         "favorable_prognosis": "",
         "predictive_implication": "Guideline",
-        "description": "Bosutinib (Bosulif) is not recommended by the National Comprehensive Cancer Network® (NCCN®) as a treatment option for patients with CML in the context of secondary resistance variants. Selection of an alternate TKI in the context of TKI-resistant or possible-TKI resistant BCR::ABL1 mutant CML may be based on mutantion profile.",
+        "description": "Bosutinib (Bosulif) is not recommended by the National Comprehensive Cancer Network\u00ae (NCCN\u00ae) as a treatment option for patients with CML in the context of secondary resistance variants. Selection of an alternate TKI in the context of TKI-resistant or possible-TKI resistant BCR::ABL1 mutant CML may be based on mutantion profile.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Chronic Myelogenous Leukemia V.2.2016. © National Comprehensive Cancer Network, Inc. 2016. All rights reserved. Accessed August 9 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Chronic Myelogenous Leukemia V.2.2016. \u00a9 National Comprehensive Cancer Network, Inc. 2016. All rights reserved. Accessed August 9 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/cml_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2016-01-01",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 94,
+        "feature_id": 94,
+        "source_id": 47,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -2858,16 +3234,20 @@
         "therapy_resistance": 1,
         "favorable_prognosis": "",
         "predictive_implication": "Guideline",
-        "description": "Bosutinib (Bosulif) is not recommended by the National Comprehensive Cancer Network® (NCCN®) as a treatment option for patients with CML in the context of secondary resistance variants. Selection of an alternate TKI in the context of TKI-resistant or possible-TKI resistant BCR::ABL1 mutant CML may be based on mutantion profile.",
+        "description": "Bosutinib (Bosulif) is not recommended by the National Comprehensive Cancer Network\u00ae (NCCN\u00ae) as a treatment option for patients with CML in the context of secondary resistance variants. Selection of an alternate TKI in the context of TKI-resistant or possible-TKI resistant BCR::ABL1 mutant CML may be based on mutantion profile.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Chronic Myelogenous Leukemia V.2.2016. © National Comprehensive Cancer Network, Inc. 2016. All rights reserved. Accessed August 9 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Chronic Myelogenous Leukemia V.2.2016. \u00a9 National Comprehensive Cancer Network, Inc. 2016. All rights reserved. Accessed August 9 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/cml_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2016-01-01",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 95,
+        "feature_id": 95,
+        "source_id": 47,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -2893,16 +3273,20 @@
         "therapy_resistance": 1,
         "favorable_prognosis": "",
         "predictive_implication": "Guideline",
-        "description": "Bosutinib (Bosulif) is not recommended by the National Comprehensive Cancer Network® (NCCN®) as a treatment option for patients with CML in the context of secondary resistance variants. Selection of an alternate TKI in the context of TKI-resistant or possible-TKI resistant BCR::ABL1 mutant CML may be based on mutantion profile.",
+        "description": "Bosutinib (Bosulif) is not recommended by the National Comprehensive Cancer Network\u00ae (NCCN\u00ae) as a treatment option for patients with CML in the context of secondary resistance variants. Selection of an alternate TKI in the context of TKI-resistant or possible-TKI resistant BCR::ABL1 mutant CML may be based on mutantion profile.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Chronic Myelogenous Leukemia V.2.2016. © National Comprehensive Cancer Network, Inc. 2016. All rights reserved. Accessed August 9 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Chronic Myelogenous Leukemia V.2.2016. \u00a9 National Comprehensive Cancer Network, Inc. 2016. All rights reserved. Accessed August 9 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/cml_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2016-01-01",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 96,
+        "feature_id": 96,
+        "source_id": 47,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -2928,16 +3312,20 @@
         "therapy_resistance": 1,
         "favorable_prognosis": "",
         "predictive_implication": "Guideline",
-        "description": "Bosutinib (Bosulif) is not recommended by the National Comprehensive Cancer Network® (NCCN®) as a treatment option for patients with CML in the context of secondary resistance variants. Selection of an alternate TKI in the context of TKI-resistant or possible-TKI resistant BCR::ABL1 mutant CML may be based on mutantion profile.",
+        "description": "Bosutinib (Bosulif) is not recommended by the National Comprehensive Cancer Network\u00ae (NCCN\u00ae) as a treatment option for patients with CML in the context of secondary resistance variants. Selection of an alternate TKI in the context of TKI-resistant or possible-TKI resistant BCR::ABL1 mutant CML may be based on mutantion profile.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Chronic Myelogenous Leukemia V.2.2016. © National Comprehensive Cancer Network, Inc. 2016. All rights reserved. Accessed August 9 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Chronic Myelogenous Leukemia V.2.2016. \u00a9 National Comprehensive Cancer Network, Inc. 2016. All rights reserved. Accessed August 9 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/cml_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2016-01-01",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 97,
+        "feature_id": 97,
+        "source_id": 47,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -2963,16 +3351,20 @@
         "therapy_resistance": 1,
         "favorable_prognosis": "",
         "predictive_implication": "Guideline",
-        "description": "Bosutinib (Bosulif) is not recommended by the National Comprehensive Cancer Network® (NCCN®) as a treatment option for patients with CML in the context of secondary resistance variants. Selection of an alternate TKI in the context of TKI-resistant or possible-TKI resistant BCR::ABL1 mutant CML may be based on mutantion profile.",
+        "description": "Bosutinib (Bosulif) is not recommended by the National Comprehensive Cancer Network\u00ae (NCCN\u00ae) as a treatment option for patients with CML in the context of secondary resistance variants. Selection of an alternate TKI in the context of TKI-resistant or possible-TKI resistant BCR::ABL1 mutant CML may be based on mutantion profile.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Chronic Myelogenous Leukemia V.2.2016. © National Comprehensive Cancer Network, Inc. 2016. All rights reserved. Accessed August 9 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Chronic Myelogenous Leukemia V.2.2016. \u00a9 National Comprehensive Cancer Network, Inc. 2016. All rights reserved. Accessed August 9 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/cml_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2016-01-01",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 98,
+        "feature_id": 98,
+        "source_id": 47,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -2998,16 +3390,20 @@
         "therapy_resistance": 1,
         "favorable_prognosis": "",
         "predictive_implication": "Guideline",
-        "description": "Bosutinib (Bosulif) is not recommended by the National Comprehensive Cancer Network® (NCCN®) as a treatment option for patients with CML in the context of secondary resistance variants. Selection of an alternate TKI in the context of TKI-resistant or possible-TKI resistant BCR::ABL1 mutant CML may be based on mutantion profile.",
+        "description": "Bosutinib (Bosulif) is not recommended by the National Comprehensive Cancer Network\u00ae (NCCN\u00ae) as a treatment option for patients with CML in the context of secondary resistance variants. Selection of an alternate TKI in the context of TKI-resistant or possible-TKI resistant BCR::ABL1 mutant CML may be based on mutantion profile.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Chronic Myelogenous Leukemia V.2.2016. © National Comprehensive Cancer Network, Inc. 2016. All rights reserved. Accessed August 9 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Chronic Myelogenous Leukemia V.2.2016. \u00a9 National Comprehensive Cancer Network, Inc. 2016. All rights reserved. Accessed August 9 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/cml_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2016-01-01",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 99,
+        "feature_id": 99,
+        "source_id": 47,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -3033,16 +3429,20 @@
         "therapy_resistance": 1,
         "favorable_prognosis": "",
         "predictive_implication": "Guideline",
-        "description": "Bosutinib (Bosulif) is not recommended by the National Comprehensive Cancer Network® (NCCN®) as a treatment option for patients with CML in the context of secondary resistance variants. Selection of an alternate TKI in the context of TKI-resistant or possible-TKI resistant BCR::ABL1 mutant CML may be based on mutantion profile.",
+        "description": "Bosutinib (Bosulif) is not recommended by the National Comprehensive Cancer Network\u00ae (NCCN\u00ae) as a treatment option for patients with CML in the context of secondary resistance variants. Selection of an alternate TKI in the context of TKI-resistant or possible-TKI resistant BCR::ABL1 mutant CML may be based on mutantion profile.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Chronic Myelogenous Leukemia V.2.2016. © National Comprehensive Cancer Network, Inc. 2016. All rights reserved. Accessed August 9 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Chronic Myelogenous Leukemia V.2.2016. \u00a9 National Comprehensive Cancer Network, Inc. 2016. All rights reserved. Accessed August 9 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/cml_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2016-01-01",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 100,
+        "feature_id": 100,
+        "source_id": 47,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -3068,16 +3468,20 @@
         "therapy_resistance": 1,
         "favorable_prognosis": "",
         "predictive_implication": "Guideline",
-        "description": "Bosutinib (Bosulif) is not recommended by the National Comprehensive Cancer Network® (NCCN®) as a treatment option for patients with CML in the context of secondary resistance variants. Selection of an alternate TKI in the context of TKI-resistant or possible-TKI resistant BCR::ABL1 mutant CML may be based on mutantion profile.",
+        "description": "Bosutinib (Bosulif) is not recommended by the National Comprehensive Cancer Network\u00ae (NCCN\u00ae) as a treatment option for patients with CML in the context of secondary resistance variants. Selection of an alternate TKI in the context of TKI-resistant or possible-TKI resistant BCR::ABL1 mutant CML may be based on mutantion profile.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Chronic Myelogenous Leukemia V.2.2016. © National Comprehensive Cancer Network, Inc. 2016. All rights reserved. Accessed August 9 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Chronic Myelogenous Leukemia V.2.2016. \u00a9 National Comprehensive Cancer Network, Inc. 2016. All rights reserved. Accessed August 9 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/cml_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2016-01-01",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 101,
+        "feature_id": 101,
+        "source_id": 47,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -3103,16 +3507,20 @@
         "therapy_resistance": 1,
         "favorable_prognosis": "",
         "predictive_implication": "Guideline",
-        "description": "Bosutinib (Bosulif) is not recommended by the National Comprehensive Cancer Network® (NCCN®) as a treatment option for patients with CML in the context of secondary resistance variants. Selection of an alternate TKI in the context of TKI-resistant or possible-TKI resistant BCR::ABL1 mutant CML may be based on mutantion profile.",
+        "description": "Bosutinib (Bosulif) is not recommended by the National Comprehensive Cancer Network\u00ae (NCCN\u00ae) as a treatment option for patients with CML in the context of secondary resistance variants. Selection of an alternate TKI in the context of TKI-resistant or possible-TKI resistant BCR::ABL1 mutant CML may be based on mutantion profile.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Chronic Myelogenous Leukemia V.2.2016. © National Comprehensive Cancer Network, Inc. 2016. All rights reserved. Accessed August 9 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Chronic Myelogenous Leukemia V.2.2016. \u00a9 National Comprehensive Cancer Network, Inc. 2016. All rights reserved. Accessed August 9 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/cml_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2016-01-01",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 102,
+        "feature_id": 102,
+        "source_id": 47,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -3138,16 +3546,20 @@
         "therapy_resistance": 1,
         "favorable_prognosis": "",
         "predictive_implication": "Guideline",
-        "description": "Ponatinib (Iclusig) is not recommended by the National Comprehensive Cancer Network® (NCCN®) as a treatment option for patients with CML in the context of secondary resistance variants. Selection of an alternate TKI in the context of TKI-resistant or possible-TKI resistant BCR::ABL1 mutant CML may be based on mutantion profile.",
+        "description": "Ponatinib (Iclusig) is not recommended by the National Comprehensive Cancer Network\u00ae (NCCN\u00ae) as a treatment option for patients with CML in the context of secondary resistance variants. Selection of an alternate TKI in the context of TKI-resistant or possible-TKI resistant BCR::ABL1 mutant CML may be based on mutantion profile.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Chronic Myelogenous Leukemia V.2.2016. © National Comprehensive Cancer Network, Inc. 2016. All rights reserved. Accessed August 9 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Chronic Myelogenous Leukemia V.2.2016. \u00a9 National Comprehensive Cancer Network, Inc. 2016. All rights reserved. Accessed August 9 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/cml_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2016-01-01",
         "last_updated": "2023-11-30",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 103,
+        "feature_id": 103,
+        "source_id": 47,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -3173,16 +3585,20 @@
         "therapy_resistance": 1,
         "favorable_prognosis": "",
         "predictive_implication": "Guideline",
-        "description": "Omacetaxine is not recommended by the National Comprehensive Cancer Network® (NCCN®) as a treatment option for patients with CML in the context of secondary resistance variants. Selection of an alternate TKI in the context of TKI-resistant or possible-TKI resistant BCR::ABL1 mutant CML may be based on mutantion profile.",
+        "description": "Omacetaxine is not recommended by the National Comprehensive Cancer Network\u00ae (NCCN\u00ae) as a treatment option for patients with CML in the context of secondary resistance variants. Selection of an alternate TKI in the context of TKI-resistant or possible-TKI resistant BCR::ABL1 mutant CML may be based on mutantion profile.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Chronic Myelogenous Leukemia V.2.2016. © National Comprehensive Cancer Network, Inc. 2016. All rights reserved. Accessed August 9 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Chronic Myelogenous Leukemia V.2.2016. \u00a9 National Comprehensive Cancer Network, Inc. 2016. All rights reserved. Accessed August 9 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/cml_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2016-01-01",
         "last_updated": "2023-11-30",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 104,
+        "feature_id": 104,
+        "source_id": 47,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -3208,16 +3624,20 @@
         "therapy_resistance": 1,
         "favorable_prognosis": "",
         "predictive_implication": "Guideline",
-        "description": "Dasatinib (Sprycel) is not recommended by the National Comprehensive Cancer Network® (NCCN®) as a treatment option for patients with CML in the context of secondary resistance variants. Selection of an alternate TKI in the context of TKI-resistant or possible-TKI resistant BCR::ABL1 mutant CML may be based on mutantion profile.",
+        "description": "Dasatinib (Sprycel) is not recommended by the National Comprehensive Cancer Network\u00ae (NCCN\u00ae) as a treatment option for patients with CML in the context of secondary resistance variants. Selection of an alternate TKI in the context of TKI-resistant or possible-TKI resistant BCR::ABL1 mutant CML may be based on mutantion profile.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Chronic Myelogenous Leukemia V.2.2016. © National Comprehensive Cancer Network, Inc. 2016. All rights reserved. Accessed August 9 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Chronic Myelogenous Leukemia V.2.2016. \u00a9 National Comprehensive Cancer Network, Inc. 2016. All rights reserved. Accessed August 9 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/cml_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2016-01-01",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 105,
+        "feature_id": 105,
+        "source_id": 47,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -3252,7 +3672,11 @@
         "nct": "",
         "publication_date": "2015-11-03",
         "last_updated": "2023-10-05",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 106,
+        "feature_id": 106,
+        "source_id": 48,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -3287,7 +3711,11 @@
         "nct": "",
         "publication_date": "2015-11-03",
         "last_updated": "2023-10-05",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 107,
+        "feature_id": 107,
+        "source_id": 48,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -3322,7 +3750,11 @@
         "nct": "",
         "publication_date": "2015-11-03",
         "last_updated": "2017-03-16",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 108,
+        "feature_id": 108,
+        "source_id": 49,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -3357,7 +3789,11 @@
         "nct": "",
         "publication_date": "2015-11-03",
         "last_updated": "2017-03-16",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 109,
+        "feature_id": 109,
+        "source_id": 49,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -3392,7 +3828,11 @@
         "nct": "",
         "publication_date": "2014-06-01",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 110,
+        "feature_id": 110,
+        "source_id": 50,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -3427,7 +3867,11 @@
         "nct": "",
         "publication_date": "2014-06-01",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 111,
+        "feature_id": 111,
+        "source_id": 50,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -3462,7 +3906,11 @@
         "nct": "",
         "publication_date": "2014-06-01",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 112,
+        "feature_id": 112,
+        "source_id": 50,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -3497,7 +3945,11 @@
         "nct": "",
         "publication_date": "2014-06-01",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 113,
+        "feature_id": 113,
+        "source_id": 50,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -3532,7 +3984,11 @@
         "nct": "",
         "publication_date": "2014-06-01",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 114,
+        "feature_id": 114,
+        "source_id": 50,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -3567,7 +4023,11 @@
         "nct": "",
         "publication_date": "2015-03-12",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 115,
+        "feature_id": 115,
+        "source_id": 51,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -3602,7 +4062,11 @@
         "nct": "",
         "publication_date": "2015-03-12",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 116,
+        "feature_id": 116,
+        "source_id": 51,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -3637,7 +4101,11 @@
         "nct": "",
         "publication_date": "2014-02-24",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 117,
+        "feature_id": 117,
+        "source_id": 52,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -3672,7 +4140,11 @@
         "nct": "",
         "publication_date": "2018-05-07",
         "last_updated": "2019-02-04",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 118,
+        "feature_id": 118,
+        "source_id": 53,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -3707,7 +4179,11 @@
         "nct": "",
         "publication_date": "2018-05-07",
         "last_updated": "2019-02-04",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 119,
+        "feature_id": 119,
+        "source_id": 53,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -3742,7 +4218,11 @@
         "nct": "",
         "publication_date": "2015-04-09",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 120,
+        "feature_id": 120,
+        "source_id": 54,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -3768,16 +4248,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": 0,
         "predictive_implication": "Guideline",
-        "description": "The National Comprehensive Cancer Network® (NCCN®) highlights ASXL1 frameshift and nonsense variants as associated with poor prognosis in myelodysplastic syndromes, and is mutated most frequently in chronic myelomonocytic leukemia (CMML).",
+        "description": "The National Comprehensive Cancer Network\u00ae (NCCN\u00ae) highlights ASXL1 frameshift and nonsense variants as associated with poor prognosis in myelodysplastic syndromes, and is mutated most frequently in chronic myelomonocytic leukemia (CMML).",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Myelodysplastic Syndromes V.2.2023. © National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Myelodysplastic Syndromes V.2.2023. \u00a9 National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/mds_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2023-10-17",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 121,
+        "feature_id": 121,
+        "source_id": 33,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -3803,16 +4287,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": 0,
         "predictive_implication": "Guideline",
-        "description": "The National Comprehensive Cancer Network® (NCCN®) highlights ASXL1 frameshift and nonsense variants as associated with poor prognosis in myelodysplastic syndromes, and is mutated most frequently in chronic myelomonocytic leukemia (CMML).",
+        "description": "The National Comprehensive Cancer Network\u00ae (NCCN\u00ae) highlights ASXL1 frameshift and nonsense variants as associated with poor prognosis in myelodysplastic syndromes, and is mutated most frequently in chronic myelomonocytic leukemia (CMML).",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Myelodysplastic Syndromes V.2.2023. © National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Myelodysplastic Syndromes V.2.2023. \u00a9 National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/mds_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2023-10-17",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 122,
+        "feature_id": 122,
+        "source_id": 33,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -3847,7 +4335,11 @@
         "nct": "",
         "publication_date": "2021-01-06",
         "last_updated": "2025-01-08",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 123,
+        "feature_id": 123,
+        "source_id": 55,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -3882,7 +4374,11 @@
         "nct": "",
         "publication_date": "2021-01-06",
         "last_updated": "2025-01-08",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 124,
+        "feature_id": 124,
+        "source_id": 55,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -3917,7 +4413,11 @@
         "nct": "",
         "publication_date": "2021-01-06",
         "last_updated": "2025-01-08",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 125,
+        "feature_id": 125,
+        "source_id": 55,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -3952,7 +4452,11 @@
         "nct": "",
         "publication_date": "2016-12-31",
         "last_updated": "2019-08-08",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 126,
+        "feature_id": 126,
+        "source_id": 56,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -3987,7 +4491,11 @@
         "nct": "",
         "publication_date": "2016-12-31",
         "last_updated": "2019-08-08",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 127,
+        "feature_id": 127,
+        "source_id": 56,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -4022,7 +4530,11 @@
         "nct": "",
         "publication_date": "2016-12-31",
         "last_updated": "2019-08-08",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 128,
+        "feature_id": 128,
+        "source_id": 56,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -4057,7 +4569,11 @@
         "nct": "",
         "publication_date": "2017-04-01",
         "last_updated": "2019-08-15",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 129,
+        "feature_id": 129,
+        "source_id": 57,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -4092,7 +4608,11 @@
         "nct": "",
         "publication_date": "2020-05-01",
         "last_updated": "2020-10-22",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 130,
+        "feature_id": 130,
+        "source_id": 58,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -4127,7 +4647,11 @@
         "nct": "",
         "publication_date": "2014-02-02",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 131,
+        "feature_id": 131,
+        "source_id": 59,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -4162,7 +4686,11 @@
         "nct": "",
         "publication_date": "2014-02-02",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 132,
+        "feature_id": 132,
+        "source_id": 59,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -4197,7 +4725,11 @@
         "nct": "",
         "publication_date": "2014-02-02",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 133,
+        "feature_id": 133,
+        "source_id": 59,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -4232,7 +4764,11 @@
         "nct": "",
         "publication_date": "2014-02-02",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 134,
+        "feature_id": 134,
+        "source_id": 59,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -4267,7 +4803,11 @@
         "nct": "",
         "publication_date": "2014-02-02",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 135,
+        "feature_id": 135,
+        "source_id": 59,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -4302,7 +4842,11 @@
         "nct": "",
         "publication_date": "2014-02-02",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 136,
+        "feature_id": 136,
+        "source_id": 59,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -4337,7 +4881,11 @@
         "nct": "",
         "publication_date": "2020-05-01",
         "last_updated": "2020-10-22",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 137,
+        "feature_id": 137,
+        "source_id": 58,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -4363,16 +4911,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": 0,
         "predictive_implication": "Guideline",
-        "description": "The National Comprehensive Cancer Network® (NCCN®) highlights BCOR frameshift, splice site, and nonsense variants as associated with poor prognosis in myelodysplastic syndromes, and is mutated most frequently in chronic myelomonocytic leukemia (CMML).",
+        "description": "The National Comprehensive Cancer Network\u00ae (NCCN\u00ae) highlights BCOR frameshift, splice site, and nonsense variants as associated with poor prognosis in myelodysplastic syndromes, and is mutated most frequently in chronic myelomonocytic leukemia (CMML).",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Myelodysplastic Syndromes V.2.2023. © National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Myelodysplastic Syndromes V.2.2023. \u00a9 National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/mds_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2023-10-17",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 138,
+        "feature_id": 138,
+        "source_id": 33,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -4398,16 +4950,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": 0,
         "predictive_implication": "Guideline",
-        "description": "The National Comprehensive Cancer Network® (NCCN®) highlights BCOR frameshift, splice site, and nonsense variants as associated with poor prognosis in myelodysplastic syndromes, and is mutated most frequently in chronic myelomonocytic leukemia (CMML).",
+        "description": "The National Comprehensive Cancer Network\u00ae (NCCN\u00ae) highlights BCOR frameshift, splice site, and nonsense variants as associated with poor prognosis in myelodysplastic syndromes, and is mutated most frequently in chronic myelomonocytic leukemia (CMML).",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Myelodysplastic Syndromes V.2.2023. © National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Myelodysplastic Syndromes V.2.2023. \u00a9 National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/mds_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2023-10-17",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 139,
+        "feature_id": 139,
+        "source_id": 33,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -4433,16 +4989,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": 0,
         "predictive_implication": "Guideline",
-        "description": "The National Comprehensive Cancer Network® (NCCN®) highlights BCOR frameshift, splice site, and nonsense variants as associated with poor prognosis in myelodysplastic syndromes, and is mutated most frequently in chronic myelomonocytic leukemia (CMML).",
+        "description": "The National Comprehensive Cancer Network\u00ae (NCCN\u00ae) highlights BCOR frameshift, splice site, and nonsense variants as associated with poor prognosis in myelodysplastic syndromes, and is mutated most frequently in chronic myelomonocytic leukemia (CMML).",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Myelodysplastic Syndromes V.2.2023. © National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Myelodysplastic Syndromes V.2.2023. \u00a9 National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/mds_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2023-10-17",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 140,
+        "feature_id": 140,
+        "source_id": 33,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -4477,7 +5037,11 @@
         "nct": "",
         "publication_date": "2010-07-14",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 141,
+        "feature_id": 141,
+        "source_id": 60,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -4512,7 +5076,11 @@
         "nct": "",
         "publication_date": "2011-08-04",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 142,
+        "feature_id": 142,
+        "source_id": 46,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -4547,7 +5115,11 @@
         "nct": "",
         "publication_date": "2015-09-11",
         "last_updated": "2019-04-30",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 143,
+        "feature_id": 143,
+        "source_id": 61,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -4582,7 +5154,11 @@
         "nct": "",
         "publication_date": "2020-04-01",
         "last_updated": "2020-11-12",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 144,
+        "feature_id": 144,
+        "source_id": 62,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -4617,7 +5193,11 @@
         "nct": "",
         "publication_date": "2020-04-01",
         "last_updated": "2020-11-12",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 145,
+        "feature_id": 145,
+        "source_id": 62,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -4652,7 +5232,11 @@
         "nct": "",
         "publication_date": "2020-04-01",
         "last_updated": "2020-11-12",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 146,
+        "feature_id": 146,
+        "source_id": 62,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -4687,7 +5271,11 @@
         "nct": "",
         "publication_date": "2020-04-01",
         "last_updated": "2020-11-12",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 147,
+        "feature_id": 147,
+        "source_id": 62,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -4722,7 +5310,11 @@
         "nct": "",
         "publication_date": "2020-04-01",
         "last_updated": "2020-11-12",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 148,
+        "feature_id": 148,
+        "source_id": 62,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -4757,7 +5349,11 @@
         "nct": "",
         "publication_date": "2020-04-01",
         "last_updated": "2020-11-12",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 149,
+        "feature_id": 149,
+        "source_id": 62,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -4792,7 +5388,11 @@
         "nct": "",
         "publication_date": "2020-06-01",
         "last_updated": "2020-11-12",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 150,
+        "feature_id": 150,
+        "source_id": 63,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -4827,7 +5427,11 @@
         "nct": "",
         "publication_date": "2020-06-01",
         "last_updated": "2020-11-12",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 151,
+        "feature_id": 151,
+        "source_id": 63,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -4862,7 +5466,11 @@
         "nct": "",
         "publication_date": "2020-04-01",
         "last_updated": "2021-09-16",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 152,
+        "feature_id": 152,
+        "source_id": 64,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -4897,7 +5505,11 @@
         "nct": "",
         "publication_date": "2020-04-01",
         "last_updated": "2021-09-16",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 153,
+        "feature_id": 153,
+        "source_id": 64,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -4932,7 +5544,11 @@
         "nct": "",
         "publication_date": "2020-04-01",
         "last_updated": "2020-10-15",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 154,
+        "feature_id": 154,
+        "source_id": 64,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -4967,7 +5583,11 @@
         "nct": "",
         "publication_date": "2020-05-01",
         "last_updated": "2020-11-12",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 155,
+        "feature_id": 155,
+        "source_id": 65,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -4993,16 +5613,20 @@
         "therapy_resistance": 1,
         "favorable_prognosis": "",
         "predictive_implication": "Guideline",
-        "description": "Panitumumab (Vectibix) is not recommended by the National Comprehensive Cancer Network® (NCCN®) as a treatment option for patients with metastatic colorectal cancer, BRAF V600E makes response to panitumumab or cetuximab highly unlikely unless given with a BRAF inhibitor. ",
+        "description": "Panitumumab (Vectibix) is not recommended by the National Comprehensive Cancer Network\u00ae (NCCN\u00ae) as a treatment option for patients with metastatic colorectal cancer, BRAF V600E makes response to panitumumab or cetuximab highly unlikely unless given with a BRAF inhibitor. ",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Colon Cancer V.4.2018. © National Comprehensive Cancer Network, Inc. 2018. All rights reserved. Accessed March 20 2019. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Colon Cancer V.4.2018. \u00a9 National Comprehensive Cancer Network, Inc. 2018. All rights reserved. Accessed March 20 2019. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/colon_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2018-01-01",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 156,
+        "feature_id": 156,
+        "source_id": 66,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -5030,14 +5654,18 @@
         "predictive_implication": "Guideline",
         "description": "BRAF V600E alterations are associated with an unfavorable prognosis in MSI-low and microsatellite-stable patients.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Colon Cancer V.2.2016. © National Comprehensive Cancer Network, Inc. 2016. All rights reserved. Accessed March 20 2019. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Colon Cancer V.2.2016. \u00a9 National Comprehensive Cancer Network, Inc. 2016. All rights reserved. Accessed March 20 2019. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/colon_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2016-01-01",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 157,
+        "feature_id": 157,
+        "source_id": 67,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -5063,16 +5691,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": "",
         "predictive_implication": "Guideline",
-        "description": "Vemurafenib (Zelboraf) is recommended by the National Comprehensive Cancer Network® (NCCN®) as a treatment option for patients with BRAF p.V600E mutant melanoma. Activating BRAF mutations are associated with an increased sensitivity to BRAF inhibitors. Co-administration with a MEK inhibitor may potentiate the effects of BRAF inhibitors.",
+        "description": "Vemurafenib (Zelboraf) is recommended by the National Comprehensive Cancer Network\u00ae (NCCN\u00ae) as a treatment option for patients with BRAF p.V600E mutant melanoma. Activating BRAF mutations are associated with an increased sensitivity to BRAF inhibitors. Co-administration with a MEK inhibitor may potentiate the effects of BRAF inhibitors.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Melanoma V.3.2016. © National Comprehensive Cancer Network, Inc. 2016. All rights reserved. Accessed November 5 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Melanoma V.3.2016. \u00a9 National Comprehensive Cancer Network, Inc. 2016. All rights reserved. Accessed November 5 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/melanoma_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2016-01-01",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 158,
+        "feature_id": 158,
+        "source_id": 68,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -5098,16 +5730,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": "",
         "predictive_implication": "Guideline",
-        "description": "Dabrafenib (Tafinlar) is recommended by the National Comprehensive Cancer Network® (NCCN®) as a treatment option for patients with BRAF p.V600E mutant melanoma. Activating BRAF mutations are associated with an increased sensitivity to BRAF inhibitors. Co-administration with a MEK inhibitor may potentiate the effects of BRAF inhibitors.",
+        "description": "Dabrafenib (Tafinlar) is recommended by the National Comprehensive Cancer Network\u00ae (NCCN\u00ae) as a treatment option for patients with BRAF p.V600E mutant melanoma. Activating BRAF mutations are associated with an increased sensitivity to BRAF inhibitors. Co-administration with a MEK inhibitor may potentiate the effects of BRAF inhibitors.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Melanoma V.3.2016. © National Comprehensive Cancer Network, Inc. 2016. All rights reserved. Accessed November 5 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Melanoma V.3.2016. \u00a9 National Comprehensive Cancer Network, Inc. 2016. All rights reserved. Accessed November 5 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/melanoma_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2016-01-01",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 159,
+        "feature_id": 159,
+        "source_id": 68,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -5133,16 +5769,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": "",
         "predictive_implication": "Guideline",
-        "description": "Vemurafenib (Zelboraf) in combination with Cobimetinib (Coltellic) is recommended by the National Comprehensive Cancer Network® (NCCN®) as a treatment option for patients with BRAF p.V600E mutant melanoma. Activating BRAF mutations are associated with an increased sensitivity to BRAF inhibitors. Co-administration with a MEK inhibitor may potentiate the effects of BRAF inhibitors.",
+        "description": "Vemurafenib (Zelboraf) in combination with Cobimetinib (Coltellic) is recommended by the National Comprehensive Cancer Network\u00ae (NCCN\u00ae) as a treatment option for patients with BRAF p.V600E mutant melanoma. Activating BRAF mutations are associated with an increased sensitivity to BRAF inhibitors. Co-administration with a MEK inhibitor may potentiate the effects of BRAF inhibitors.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Melanoma V.3.2016. © National Comprehensive Cancer Network, Inc. 2016. All rights reserved. Accessed November 5 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Melanoma V.3.2016. \u00a9 National Comprehensive Cancer Network, Inc. 2016. All rights reserved. Accessed November 5 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/melanoma_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2016-01-01",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 160,
+        "feature_id": 160,
+        "source_id": 68,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -5168,16 +5808,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": "",
         "predictive_implication": "Guideline",
-        "description": "Dabrafenib (Tafinlar) in combination with Trametinib (Mekinist) is recommended by the National Comprehensive Cancer Network® (NCCN®) as a treatment option for patients with BRAF p.V600E mutant melanoma. Activating BRAF mutations are associated with an increased sensitivity to BRAF inhibitors. Co-administration with a MEK inhibitor may potentiate the effects of BRAF inhibitors.",
+        "description": "Dabrafenib (Tafinlar) in combination with Trametinib (Mekinist) is recommended by the National Comprehensive Cancer Network\u00ae (NCCN\u00ae) as a treatment option for patients with BRAF p.V600E mutant melanoma. Activating BRAF mutations are associated with an increased sensitivity to BRAF inhibitors. Co-administration with a MEK inhibitor may potentiate the effects of BRAF inhibitors.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Melanoma V.3.2016. © National Comprehensive Cancer Network, Inc. 2016. All rights reserved. Accessed November 5 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Melanoma V.3.2016. \u00a9 National Comprehensive Cancer Network, Inc. 2016. All rights reserved. Accessed November 5 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/melanoma_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2016-01-01",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 161,
+        "feature_id": 161,
+        "source_id": 68,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -5212,7 +5856,11 @@
         "nct": "NCT01673854",
         "publication_date": "2016-08-16",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 162,
+        "feature_id": 162,
+        "source_id": 69,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -5247,7 +5895,11 @@
         "nct": "NCT01673854",
         "publication_date": "2016-08-16",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 163,
+        "feature_id": 163,
+        "source_id": 69,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -5282,7 +5934,11 @@
         "nct": "",
         "publication_date": "2016-06-30",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 164,
+        "feature_id": 164,
+        "source_id": 70,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -5317,7 +5973,11 @@
         "nct": "",
         "publication_date": "2016-06-30",
         "last_updated": "2023-10-31",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 165,
+        "feature_id": 165,
+        "source_id": 70,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -5352,7 +6012,11 @@
         "nct": "",
         "publication_date": "2009-12-1",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 166,
+        "feature_id": 166,
+        "source_id": 71,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -5387,7 +6051,11 @@
         "nct": "",
         "publication_date": "2016-10-01",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 167,
+        "feature_id": 167,
+        "source_id": 72,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -5422,7 +6090,11 @@
         "nct": "",
         "publication_date": "2017-02-22",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 168,
+        "feature_id": 168,
+        "source_id": 73,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -5457,7 +6129,11 @@
         "nct": "NCT01524978",
         "publication_date": "2015-08-20",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 169,
+        "feature_id": 169,
+        "source_id": 74,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -5492,7 +6168,11 @@
         "nct": "NCT01524978",
         "publication_date": "2015-08-20",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 170,
+        "feature_id": 170,
+        "source_id": 74,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -5527,7 +6207,11 @@
         "nct": "NCT01524978",
         "publication_date": "2015-08-20",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 171,
+        "feature_id": 171,
+        "source_id": 74,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -5562,7 +6246,11 @@
         "nct": "",
         "publication_date": "2016-09-28",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 172,
+        "feature_id": 172,
+        "source_id": 75,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -5597,7 +6285,11 @@
         "nct": "",
         "publication_date": "2016-06-02",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 173,
+        "feature_id": 173,
+        "source_id": 76,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -5632,7 +6324,11 @@
         "nct": "",
         "publication_date": "2016-06-02",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 174,
+        "feature_id": 174,
+        "source_id": 76,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -5667,7 +6363,11 @@
         "nct": "",
         "publication_date": "2016-10-21",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 175,
+        "feature_id": 175,
+        "source_id": 77,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -5702,7 +6402,11 @@
         "nct": "",
         "publication_date": "2014-01-07",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 176,
+        "feature_id": 176,
+        "source_id": 78,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -5737,7 +6441,11 @@
         "nct": "",
         "publication_date": "2014-01-07",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 177,
+        "feature_id": 177,
+        "source_id": 78,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -5772,7 +6480,11 @@
         "nct": "",
         "publication_date": "2014-01-07",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 178,
+        "feature_id": 178,
+        "source_id": 78,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -5807,7 +6519,11 @@
         "nct": "",
         "publication_date": "2014-01-07",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 179,
+        "feature_id": 179,
+        "source_id": 78,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -5842,7 +6558,11 @@
         "nct": "",
         "publication_date": "2015-04-09",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 180,
+        "feature_id": 180,
+        "source_id": 54,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -5877,7 +6597,11 @@
         "nct": "",
         "publication_date": "2015-05-22",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 181,
+        "feature_id": 181,
+        "source_id": 79,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -5903,16 +6627,20 @@
         "therapy_resistance": 1,
         "favorable_prognosis": "",
         "predictive_implication": "Guideline",
-        "description": "Cetuximab (Erbitux) is not recommended by the National Comprehensive Cancer Network® (NCCN®) as a treatment option for patients with metastatic colorectal cancer, BRAF V600E makes response to panitumumab or cetuximab highly unlikely unless given with a BRAF inhibitor. ",
+        "description": "Cetuximab (Erbitux) is not recommended by the National Comprehensive Cancer Network\u00ae (NCCN\u00ae) as a treatment option for patients with metastatic colorectal cancer, BRAF V600E makes response to panitumumab or cetuximab highly unlikely unless given with a BRAF inhibitor. ",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Colon Cancer V.4.2018. © National Comprehensive Cancer Network, Inc. 2018. All rights reserved. Accessed March 20 2019. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Colon Cancer V.4.2018. \u00a9 National Comprehensive Cancer Network, Inc. 2018. All rights reserved. Accessed March 20 2019. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/colon_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2018-01-01",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 182,
+        "feature_id": 182,
+        "source_id": 66,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -5940,14 +6668,18 @@
         "predictive_implication": "Guideline",
         "description": "BRAF V600E alterations are associated with an unfavorable prognosis in MSI-low and microsatellite-stable patients.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Colon Cancer V.2.2016. © National Comprehensive Cancer Network, Inc. 2016. All rights reserved. Accessed November 5 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Colon Cancer V.2.2016. \u00a9 National Comprehensive Cancer Network, Inc. 2016. All rights reserved. Accessed November 5 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/colon_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2016-01-01",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 183,
+        "feature_id": 183,
+        "source_id": 80,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -5982,7 +6714,11 @@
         "nct": "NCT01524978",
         "publication_date": "2015-08-20",
         "last_updated": "2019-10-04",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 184,
+        "feature_id": 184,
+        "source_id": 74,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -6017,7 +6753,11 @@
         "nct": "NCT01844986",
         "publication_date": "2020-11-01",
         "last_updated": "2020-11-12",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 185,
+        "feature_id": 185,
+        "source_id": 81,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -6052,7 +6792,11 @@
         "nct": "NCT01844986",
         "publication_date": "2020-11-01",
         "last_updated": "2020-11-12",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 186,
+        "feature_id": 186,
+        "source_id": 81,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -6087,7 +6831,11 @@
         "nct": "NCT01844986",
         "publication_date": "2020-11-01",
         "last_updated": "2020-11-12",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 187,
+        "feature_id": 187,
+        "source_id": 81,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -6122,7 +6870,11 @@
         "nct": "",
         "publication_date": "2020-10-01",
         "last_updated": "2020-11-12",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 188,
+        "feature_id": 188,
+        "source_id": 82,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -6157,7 +6909,11 @@
         "nct": "",
         "publication_date": "2020-10-01",
         "last_updated": "2020-11-12",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 189,
+        "feature_id": 189,
+        "source_id": 82,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -6192,7 +6948,11 @@
         "nct": "",
         "publication_date": "2020-10-01",
         "last_updated": "2020-11-12",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 190,
+        "feature_id": 190,
+        "source_id": 82,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -6227,7 +6987,11 @@
         "nct": "",
         "publication_date": "2010-04-20",
         "last_updated": "2019-03-20",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 191,
+        "feature_id": 191,
+        "source_id": 83,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -6262,7 +7026,11 @@
         "nct": "",
         "publication_date": "2017-02-21",
         "last_updated": "2019-03-20",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 192,
+        "feature_id": 192,
+        "source_id": 84,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -6297,7 +7065,11 @@
         "nct": "",
         "publication_date": "2015-02-25",
         "last_updated": "2019-03-07",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 193,
+        "feature_id": 193,
+        "source_id": 85,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -6332,7 +7104,11 @@
         "nct": "",
         "publication_date": "2020-04-01",
         "last_updated": "2020-10-15",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 194,
+        "feature_id": 194,
+        "source_id": 86,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -6367,7 +7143,11 @@
         "nct": "",
         "publication_date": "2020-04-01",
         "last_updated": "2020-10-15",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 195,
+        "feature_id": 195,
+        "source_id": 86,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -6402,7 +7182,11 @@
         "nct": "",
         "publication_date": "2020-04-01",
         "last_updated": "2020-10-15",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 196,
+        "feature_id": 196,
+        "source_id": 86,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -6437,7 +7221,11 @@
         "nct": "",
         "publication_date": "2020-05-01",
         "last_updated": "2020-10-22",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 197,
+        "feature_id": 197,
+        "source_id": 58,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -6472,7 +7260,11 @@
         "nct": "",
         "publication_date": "2020-11-01",
         "last_updated": "2020-11-12",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 198,
+        "feature_id": 198,
+        "source_id": 87,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -6507,7 +7299,11 @@
         "nct": "",
         "publication_date": "2020-11-01",
         "last_updated": "2020-11-12",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 199,
+        "feature_id": 199,
+        "source_id": 87,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -6542,7 +7338,11 @@
         "nct": "",
         "publication_date": "2020-11-01",
         "last_updated": "2020-11-12",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 200,
+        "feature_id": 200,
+        "source_id": 87,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -6577,7 +7377,11 @@
         "nct": "",
         "publication_date": "2020-04-01",
         "last_updated": "2020-10-15",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 201,
+        "feature_id": 201,
+        "source_id": 86,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -6612,7 +7416,11 @@
         "nct": "",
         "publication_date": "2020-04-01",
         "last_updated": "2020-10-15",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 202,
+        "feature_id": 202,
+        "source_id": 86,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -6647,7 +7455,11 @@
         "nct": "",
         "publication_date": "2020-04-01",
         "last_updated": "2020-10-15",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 203,
+        "feature_id": 203,
+        "source_id": 86,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -6682,7 +7494,11 @@
         "nct": "NCT01844986",
         "publication_date": "2020-11-01",
         "last_updated": "2020-11-12",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 204,
+        "feature_id": 204,
+        "source_id": 81,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -6717,7 +7533,11 @@
         "nct": "NCT01844986",
         "publication_date": "2020-11-01",
         "last_updated": "2020-11-12",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 205,
+        "feature_id": 205,
+        "source_id": 81,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -6752,7 +7572,11 @@
         "nct": "NCT01844986",
         "publication_date": "2020-11-01",
         "last_updated": "2020-11-12",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 206,
+        "feature_id": 206,
+        "source_id": 81,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -6787,7 +7611,11 @@
         "nct": "",
         "publication_date": "2020-10-01",
         "last_updated": "2020-11-12",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 207,
+        "feature_id": 207,
+        "source_id": 82,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -6822,7 +7650,11 @@
         "nct": "",
         "publication_date": "2020-10-01",
         "last_updated": "2020-11-12",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 208,
+        "feature_id": 208,
+        "source_id": 82,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -6857,7 +7689,11 @@
         "nct": "",
         "publication_date": "2020-10-01",
         "last_updated": "2020-11-12",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 209,
+        "feature_id": 209,
+        "source_id": 82,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -6892,7 +7728,11 @@
         "nct": "",
         "publication_date": "2010-04-20",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 210,
+        "feature_id": 210,
+        "source_id": 83,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -6927,7 +7767,11 @@
         "nct": "",
         "publication_date": "2017-02-21",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 211,
+        "feature_id": 211,
+        "source_id": 84,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -6962,7 +7806,11 @@
         "nct": "NCT01682772",
         "publication_date": "2015-10-29",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 212,
+        "feature_id": 212,
+        "source_id": 88,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -6997,7 +7845,11 @@
         "nct": "",
         "publication_date": "2015-02-25",
         "last_updated": "2019-03-07",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 213,
+        "feature_id": 213,
+        "source_id": 85,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -7032,7 +7884,11 @@
         "nct": "",
         "publication_date": "2016-03-24",
         "last_updated": "2019-04-16",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 214,
+        "feature_id": 214,
+        "source_id": 89,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -7067,7 +7923,11 @@
         "nct": "",
         "publication_date": "2020-05-01",
         "last_updated": "2020-10-22",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 215,
+        "feature_id": 215,
+        "source_id": 58,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -7102,7 +7962,11 @@
         "nct": "",
         "publication_date": "2020-11-01",
         "last_updated": "2020-11-12",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 216,
+        "feature_id": 216,
+        "source_id": 87,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -7137,7 +8001,11 @@
         "nct": "",
         "publication_date": "2020-11-01",
         "last_updated": "2020-11-12",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 217,
+        "feature_id": 217,
+        "source_id": 87,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -7172,7 +8040,11 @@
         "nct": "",
         "publication_date": "2020-11-01",
         "last_updated": "2020-11-12",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 218,
+        "feature_id": 218,
+        "source_id": 87,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -7207,7 +8079,11 @@
         "nct": "",
         "publication_date": "2014-02-02",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 219,
+        "feature_id": 219,
+        "source_id": 59,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -7242,7 +8118,11 @@
         "nct": "",
         "publication_date": "2014-02-02",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 220,
+        "feature_id": 220,
+        "source_id": 59,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -7277,7 +8157,11 @@
         "nct": "",
         "publication_date": "2014-02-02",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 221,
+        "feature_id": 221,
+        "source_id": 59,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -7312,7 +8196,11 @@
         "nct": "",
         "publication_date": "2014-02-02",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 222,
+        "feature_id": 222,
+        "source_id": 59,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -7347,7 +8235,11 @@
         "nct": "",
         "publication_date": "2014-02-02",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 223,
+        "feature_id": 223,
+        "source_id": 59,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -7382,7 +8274,11 @@
         "nct": "",
         "publication_date": "2014-02-02",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 224,
+        "feature_id": 224,
+        "source_id": 59,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -7417,7 +8313,11 @@
         "nct": "",
         "publication_date": "2020-05-01",
         "last_updated": "2020-10-22",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 225,
+        "feature_id": 225,
+        "source_id": 58,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -7452,7 +8352,11 @@
         "nct": "",
         "publication_date": "2020-05-01",
         "last_updated": "2020-10-22",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 226,
+        "feature_id": 226,
+        "source_id": 58,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -7487,7 +8391,11 @@
         "nct": "",
         "publication_date": "2014-02-02",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 227,
+        "feature_id": 227,
+        "source_id": 59,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -7522,7 +8430,11 @@
         "nct": "",
         "publication_date": "2014-02-02",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 228,
+        "feature_id": 228,
+        "source_id": 59,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -7557,7 +8469,11 @@
         "nct": "",
         "publication_date": "2014-02-02",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 229,
+        "feature_id": 229,
+        "source_id": 59,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -7592,7 +8508,11 @@
         "nct": "",
         "publication_date": "2014-02-02",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 230,
+        "feature_id": 230,
+        "source_id": 59,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -7627,7 +8547,11 @@
         "nct": "",
         "publication_date": "2014-02-02",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 231,
+        "feature_id": 231,
+        "source_id": 59,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -7662,7 +8586,11 @@
         "nct": "",
         "publication_date": "2014-02-02",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 232,
+        "feature_id": 232,
+        "source_id": 59,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -7697,7 +8625,11 @@
         "nct": "",
         "publication_date": "2020-05-01",
         "last_updated": "2020-10-22",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 233,
+        "feature_id": 233,
+        "source_id": 58,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -7732,7 +8664,11 @@
         "nct": "",
         "publication_date": "2014-02-02",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 234,
+        "feature_id": 234,
+        "source_id": 59,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -7767,7 +8703,11 @@
         "nct": "",
         "publication_date": "2014-02-02",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 235,
+        "feature_id": 235,
+        "source_id": 59,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -7802,7 +8742,11 @@
         "nct": "",
         "publication_date": "2014-02-02",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 236,
+        "feature_id": 236,
+        "source_id": 59,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -7837,7 +8781,11 @@
         "nct": "",
         "publication_date": "2014-02-02",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 237,
+        "feature_id": 237,
+        "source_id": 59,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -7872,7 +8820,11 @@
         "nct": "",
         "publication_date": "2014-02-02",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 238,
+        "feature_id": 238,
+        "source_id": 59,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -7907,7 +8859,11 @@
         "nct": "",
         "publication_date": "2014-02-02",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 239,
+        "feature_id": 239,
+        "source_id": 59,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -7942,7 +8898,11 @@
         "nct": "",
         "publication_date": "2020-05-01",
         "last_updated": "2020-10-22",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 240,
+        "feature_id": 240,
+        "source_id": 58,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -7977,7 +8937,11 @@
         "nct": "",
         "publication_date": "2010-09-07",
         "last_updated": "2019-09-12",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 241,
+        "feature_id": 241,
+        "source_id": 90,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -8012,7 +8976,11 @@
         "nct": "",
         "publication_date": "2017-03-30",
         "last_updated": "2024-10-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 242,
+        "feature_id": 242,
+        "source_id": 91,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -8038,16 +9006,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": "",
         "predictive_implication": "Guideline",
-        "description": "Erlotinib (Tarceva) is recommended by the National Comprehensive Cancer Network® (NCCN®) as a treatment option for patients with EGFR mutant metastatic non-small cell lung cancer. Mutant EGFR may suggest sensitivity to Erlotinib as a first or subsequent line of therapy.",
+        "description": "Erlotinib (Tarceva) is recommended by the National Comprehensive Cancer Network\u00ae (NCCN\u00ae) as a treatment option for patients with EGFR mutant metastatic non-small cell lung cancer. Mutant EGFR may suggest sensitivity to Erlotinib as a first or subsequent line of therapy.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Non-Small Lung Cancer V.1.2017. © National Comprehensive Cancer Network, Inc. 2017. All rights reserved. Accessed November 5, 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Non-Small Lung Cancer V.1.2017. \u00a9 National Comprehensive Cancer Network, Inc. 2017. All rights reserved. Accessed November 5, 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/nscl_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2017-01-01",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 243,
+        "feature_id": 243,
+        "source_id": 20,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -8073,16 +9045,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": "",
         "predictive_implication": "Guideline",
-        "description": "Gefitinib (Iressa) is recommended by the National Comprehensive Cancer Network® (NCCN®) as a treatment option for patients with EGFR mutant metastatic non-small cell lung cancer as a first or subsequent line of therapy.",
+        "description": "Gefitinib (Iressa) is recommended by the National Comprehensive Cancer Network\u00ae (NCCN\u00ae) as a treatment option for patients with EGFR mutant metastatic non-small cell lung cancer as a first or subsequent line of therapy.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Non-Small Lung Cancer V.1.2017. © National Comprehensive Cancer Network, Inc. 2017. All rights reserved. Accessed November 5, 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Non-Small Lung Cancer V.1.2017. \u00a9 National Comprehensive Cancer Network, Inc. 2017. All rights reserved. Accessed November 5, 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/nscl_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2017-01-01",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 244,
+        "feature_id": 244,
+        "source_id": 20,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -8108,16 +9084,20 @@
         "therapy_resistance": 1,
         "favorable_prognosis": "",
         "predictive_implication": "Guideline",
-        "description": "Gefitinib (Iressa) is not recommended by the National Comprehensive Cancer Network® (NCCN®) as a treatment option for patients with second-site mutations within the EGFR kinase domain, such as p.T790M, as they are associated with acquired resistance to EGFR TKIs.",
+        "description": "Gefitinib (Iressa) is not recommended by the National Comprehensive Cancer Network\u00ae (NCCN\u00ae) as a treatment option for patients with second-site mutations within the EGFR kinase domain, such as p.T790M, as they are associated with acquired resistance to EGFR TKIs.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Non-Small Lung Cancer V.1.2017. © National Comprehensive Cancer Network, Inc. 2017. All rights reserved. Accessed November 5, 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Non-Small Lung Cancer V.1.2017. \u00a9 National Comprehensive Cancer Network, Inc. 2017. All rights reserved. Accessed November 5, 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/nscl_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2017-01-01",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 245,
+        "feature_id": 245,
+        "source_id": 20,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -8143,16 +9123,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": "",
         "predictive_implication": "Guideline",
-        "description": "Afatinib (Gilotrif) is recommended by the National Comprehensive Cancer Network® (NCCN®) as a treatment option for patients with EGFR mutant metastatic non-small cell lung cancer as a first or subsequent line of therapy.",
+        "description": "Afatinib (Gilotrif) is recommended by the National Comprehensive Cancer Network\u00ae (NCCN\u00ae) as a treatment option for patients with EGFR mutant metastatic non-small cell lung cancer as a first or subsequent line of therapy.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Non-Small Lung Cancer V.1.2017. © National Comprehensive Cancer Network, Inc. 2017. All rights reserved. Accessed November 5, 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Non-Small Lung Cancer V.1.2017. \u00a9 National Comprehensive Cancer Network, Inc. 2017. All rights reserved. Accessed November 5, 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/nscl_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2017-01-01",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 246,
+        "feature_id": 246,
+        "source_id": 20,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -8178,16 +9162,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": "",
         "predictive_implication": "Guideline",
-        "description": "Gefitinib (Iressa) is recommended by the National Comprehensive Cancer Network® (NCCN®) as a treatment option for patients with EGFR mutant non-small cell lung cancer. There is significant association between EGFR mutants and sensitivity to EGFR TKIs.",
+        "description": "Gefitinib (Iressa) is recommended by the National Comprehensive Cancer Network\u00ae (NCCN\u00ae) as a treatment option for patients with EGFR mutant non-small cell lung cancer. There is significant association between EGFR mutants and sensitivity to EGFR TKIs.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Non-Small Lung Cancer V.1.2017. © National Comprehensive Cancer Network, Inc. 2017. All rights reserved. Accessed November 5, 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Non-Small Lung Cancer V.1.2017. \u00a9 National Comprehensive Cancer Network, Inc. 2017. All rights reserved. Accessed November 5, 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/nscl_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2017-01-01",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 247,
+        "feature_id": 247,
+        "source_id": 20,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -8213,16 +9201,20 @@
         "therapy_resistance": 1,
         "favorable_prognosis": "",
         "predictive_implication": "Guideline",
-        "description": "Gefitinib (Iressa) is not recommended by the National Comprehensive Cancer Network® (NCCN®) as a treatment option for patients with non-small cell lung cancer whose tumors harbor EGFR exon 20 insertion variants, as these mutations may predict resistance to TKIs.",
+        "description": "Gefitinib (Iressa) is not recommended by the National Comprehensive Cancer Network\u00ae (NCCN\u00ae) as a treatment option for patients with non-small cell lung cancer whose tumors harbor EGFR exon 20 insertion variants, as these mutations may predict resistance to TKIs.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Non-Small Lung Cancer V.1.2017. © National Comprehensive Cancer Network, Inc. 2017. All rights reserved. Accessed November 5, 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Non-Small Lung Cancer V.1.2017. \u00a9 National Comprehensive Cancer Network, Inc. 2017. All rights reserved. Accessed November 5, 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/nscl_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2017-01-01",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 248,
+        "feature_id": 248,
+        "source_id": 20,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -8257,7 +9249,11 @@
         "nct": "NCT02143466",
         "publication_date": "2016-04-15",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 249,
+        "feature_id": 249,
+        "source_id": 92,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -8292,7 +9288,11 @@
         "nct": "NCT01588145",
         "publication_date": "2016-04-15",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 250,
+        "feature_id": 250,
+        "source_id": 93,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -8327,7 +9327,11 @@
         "nct": "NCT01708954",
         "publication_date": "2016-10-04",
         "last_updated": "2019-01-29",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 251,
+        "feature_id": 251,
+        "source_id": 94,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -8362,7 +9366,11 @@
         "nct": "NCT01708954",
         "publication_date": "2016-10-04",
         "last_updated": "2019-01-29",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 252,
+        "feature_id": 252,
+        "source_id": 94,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -8397,7 +9405,11 @@
         "nct": "NCT01708954",
         "publication_date": "2016-10-04",
         "last_updated": "2019-01-29",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 253,
+        "feature_id": 253,
+        "source_id": 94,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -8432,7 +9444,11 @@
         "nct": "NCT01708954",
         "publication_date": "2016-10-04",
         "last_updated": "2023-11-30",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 254,
+        "feature_id": 254,
+        "source_id": 94,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -8467,7 +9483,11 @@
         "nct": "NCT01708954",
         "publication_date": "2016-10-04",
         "last_updated": "2019-01-29",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 255,
+        "feature_id": 255,
+        "source_id": 94,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -8502,7 +9522,11 @@
         "nct": "NCT01708954",
         "publication_date": "2016-10-04",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 256,
+        "feature_id": 256,
+        "source_id": 94,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -8537,7 +9561,11 @@
         "nct": "NCT01526928",
         "publication_date": "2015-04-30",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 257,
+        "feature_id": 257,
+        "source_id": 95,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -8572,7 +9600,11 @@
         "nct": "",
         "publication_date": "2005-10-01",
         "last_updated": "2025-01-08",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 258,
+        "feature_id": 258,
+        "source_id": 96,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -8607,7 +9639,11 @@
         "nct": "",
         "publication_date": "2016-04-12",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 259,
+        "feature_id": 259,
+        "source_id": 97,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -8642,7 +9678,11 @@
         "nct": "",
         "publication_date": "2016-04-12",
         "last_updated": "2023-11-30",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 260,
+        "feature_id": 260,
+        "source_id": 97,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -8677,7 +9717,11 @@
         "nct": "",
         "publication_date": "2016-04-12",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 261,
+        "feature_id": 261,
+        "source_id": 97,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -8712,7 +9756,11 @@
         "nct": "",
         "publication_date": "2016-04-12",
         "last_updated": "2023-11-30",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 262,
+        "feature_id": 262,
+        "source_id": 97,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -8747,7 +9795,11 @@
         "nct": "",
         "publication_date": "2016-04-12",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 263,
+        "feature_id": 263,
+        "source_id": 97,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -8782,7 +9834,11 @@
         "nct": "",
         "publication_date": "2014-02-01",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 264,
+        "feature_id": 264,
+        "source_id": 98,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -8817,7 +9873,11 @@
         "nct": "",
         "publication_date": "2014-02-01",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 265,
+        "feature_id": 265,
+        "source_id": 98,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -8852,7 +9912,11 @@
         "nct": "",
         "publication_date": "2019-10-01",
         "last_updated": "2020-11-12",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 266,
+        "feature_id": 266,
+        "source_id": 99,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -8887,7 +9951,11 @@
         "nct": "",
         "publication_date": "2019-10-01",
         "last_updated": "2020-11-12",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 267,
+        "feature_id": 267,
+        "source_id": 99,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -8922,7 +9990,11 @@
         "nct": "",
         "publication_date": "2019-10-01",
         "last_updated": "2023-11-30",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 268,
+        "feature_id": 268,
+        "source_id": 99,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -8957,7 +10029,11 @@
         "nct": "",
         "publication_date": "2013-10-01",
         "last_updated": "2019-08-09",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 269,
+        "feature_id": 269,
+        "source_id": 19,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -8992,7 +10068,11 @@
         "nct": "",
         "publication_date": "2018-01-11",
         "last_updated": "2019-08-15",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 270,
+        "feature_id": 270,
+        "source_id": 100,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -9027,7 +10107,11 @@
         "nct": "",
         "publication_date": "2018-01-11",
         "last_updated": "2023-11-30",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 271,
+        "feature_id": 271,
+        "source_id": 100,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -9062,7 +10146,11 @@
         "nct": "",
         "publication_date": "2020-12-11",
         "last_updated": "2024-03-04",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 272,
+        "feature_id": 272,
+        "source_id": 101,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -9097,7 +10185,11 @@
         "nct": "",
         "publication_date": "2020-12-11",
         "last_updated": "2024-03-04",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 273,
+        "feature_id": 273,
+        "source_id": 101,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -9132,7 +10224,11 @@
         "nct": "",
         "publication_date": "2021-05-21",
         "last_updated": "2024-03-04",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 274,
+        "feature_id": 274,
+        "source_id": 102,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -9167,7 +10263,11 @@
         "nct": "",
         "publication_date": "2021-09-01",
         "last_updated": "2021-09-16",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 275,
+        "feature_id": 275,
+        "source_id": 103,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -9202,7 +10302,11 @@
         "nct": "",
         "publication_date": "2018-01-31",
         "last_updated": "2018-09-10",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 276,
+        "feature_id": 276,
+        "source_id": 104,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -9228,16 +10332,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": "",
         "predictive_implication": "Guideline",
-        "description": "Ado-trasuzumab emtansine (Kadcyla) is recommended by the National Comprehensive Cancer Network® (NCCN®) as a treatment option for patients with non-small cell lung cancer whose tumors harbor variants in ERBB2.",
+        "description": "Ado-trasuzumab emtansine (Kadcyla) is recommended by the National Comprehensive Cancer Network\u00ae (NCCN\u00ae) as a treatment option for patients with non-small cell lung cancer whose tumors harbor variants in ERBB2.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Non-Small Lung Cancer V.5.2019. © National Comprehensive Cancer Network, Inc. 2019. All rights reserved. Accessed August 12, 2019. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Non-Small Lung Cancer V.5.2019. \u00a9 National Comprehensive Cancer Network, Inc. 2019. All rights reserved. Accessed August 12, 2019. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/nscl_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2019-01-01",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 277,
+        "feature_id": 277,
+        "source_id": 11,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -9272,7 +10380,11 @@
         "nct": "",
         "publication_date": "2018-01-31",
         "last_updated": "2018-09-10",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 278,
+        "feature_id": 278,
+        "source_id": 104,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -9307,7 +10419,11 @@
         "nct": "",
         "publication_date": "2016-06-16",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 279,
+        "feature_id": 279,
+        "source_id": 105,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -9342,7 +10458,11 @@
         "nct": "",
         "publication_date": "2014-09-30",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 280,
+        "feature_id": 280,
+        "source_id": 106,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -9377,7 +10497,11 @@
         "nct": "",
         "publication_date": "2014-02-13",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 281,
+        "feature_id": 281,
+        "source_id": 23,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -9412,7 +10536,11 @@
         "nct": "",
         "publication_date": "2013-11-03",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 282,
+        "feature_id": 282,
+        "source_id": 107,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -9438,16 +10566,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": 0,
         "predictive_implication": "Guideline",
-        "description": "The National Comprehensive Cancer Network® (NCCN®) highlights nonsense and frameshift variants in ETV6 as being associated with poor prognosis in patients with myelodysplastic syndromes.",
+        "description": "The National Comprehensive Cancer Network\u00ae (NCCN\u00ae) highlights nonsense and frameshift variants in ETV6 as being associated with poor prognosis in patients with myelodysplastic syndromes.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Myelodysplastic Syndromes V.2.2023. © National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Myelodysplastic Syndromes V.2.2023. \u00a9 National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/mds_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2023-10-17",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 283,
+        "feature_id": 283,
+        "source_id": 33,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -9473,16 +10605,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": 0,
         "predictive_implication": "Guideline",
-        "description": "The National Comprehensive Cancer Network® (NCCN®) highlights nonsense and frameshift variants in ETV6 as being associated with poor prognosis in patients with myelodysplastic syndromes.",
+        "description": "The National Comprehensive Cancer Network\u00ae (NCCN\u00ae) highlights nonsense and frameshift variants in ETV6 as being associated with poor prognosis in patients with myelodysplastic syndromes.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Myelodysplastic Syndromes V.2.2023. © National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Myelodysplastic Syndromes V.2.2023. \u00a9 National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/mds_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2023-10-17",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 284,
+        "feature_id": 284,
+        "source_id": 33,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -9508,16 +10644,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": 0,
         "predictive_implication": "Guideline",
-        "description": "The National Comprehensive Cancer Network® (NCCN®) highlights nonsense and frameshift variants in EZH2 as being associated with poor prognosis in patients with myelodysplastic syndromes.",
+        "description": "The National Comprehensive Cancer Network\u00ae (NCCN\u00ae) highlights nonsense and frameshift variants in EZH2 as being associated with poor prognosis in patients with myelodysplastic syndromes.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Myelodysplastic Syndromes V.2.2023. © National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Myelodysplastic Syndromes V.2.2023. \u00a9 National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/mds_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2023-10-17",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 285,
+        "feature_id": 285,
+        "source_id": 33,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -9543,16 +10683,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": 0,
         "predictive_implication": "Guideline",
-        "description": "The National Comprehensive Cancer Network® (NCCN®) highlights nonsense and frameshift variants in EZH2 as being associated with poor prognosis in patients with myelodysplastic syndromes.",
+        "description": "The National Comprehensive Cancer Network\u00ae (NCCN\u00ae) highlights nonsense and frameshift variants in EZH2 as being associated with poor prognosis in patients with myelodysplastic syndromes.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Myelodysplastic Syndromes V.2.2023. © National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Myelodysplastic Syndromes V.2.2023. \u00a9 National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/mds_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2023-10-17",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 286,
+        "feature_id": 286,
+        "source_id": 33,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -9587,7 +10731,11 @@
         "nct": "",
         "publication_date": "2020-06-01",
         "last_updated": "2020-11-10",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 287,
+        "feature_id": 287,
+        "source_id": 108,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -9622,7 +10770,11 @@
         "nct": "",
         "publication_date": "2020-06-01",
         "last_updated": "2020-11-10",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 288,
+        "feature_id": 288,
+        "source_id": 108,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -9657,7 +10809,11 @@
         "nct": "",
         "publication_date": "2020-06-01",
         "last_updated": "2020-11-10",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 289,
+        "feature_id": 289,
+        "source_id": 108,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -9692,7 +10848,11 @@
         "nct": "",
         "publication_date": "2020-06-01",
         "last_updated": "2020-11-10",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 290,
+        "feature_id": 290,
+        "source_id": 108,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -9727,7 +10887,11 @@
         "nct": "",
         "publication_date": "2020-06-01",
         "last_updated": "2020-11-10",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 291,
+        "feature_id": 291,
+        "source_id": 108,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -9762,7 +10926,11 @@
         "nct": "",
         "publication_date": "2020-05-01",
         "last_updated": "2020-10-22",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 292,
+        "feature_id": 292,
+        "source_id": 58,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -9797,7 +10965,11 @@
         "nct": "",
         "publication_date": "2008-09-12",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 293,
+        "feature_id": 293,
+        "source_id": 109,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -9832,7 +11004,11 @@
         "nct": "",
         "publication_date": "2024-01-19",
         "last_updated": "2024-01-25",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 294,
+        "feature_id": 294,
+        "source_id": 26,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -9867,7 +11043,11 @@
         "nct": "",
         "publication_date": "2024-01-19",
         "last_updated": "2024-01-25",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 295,
+        "feature_id": 295,
+        "source_id": 26,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -9902,7 +11082,11 @@
         "nct": "",
         "publication_date": "2024-01-19",
         "last_updated": "2024-01-25",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 296,
+        "feature_id": 296,
+        "source_id": 26,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -9937,7 +11121,11 @@
         "nct": "",
         "publication_date": "2024-01-19",
         "last_updated": "2024-01-25",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 297,
+        "feature_id": 297,
+        "source_id": 26,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -9972,7 +11160,11 @@
         "nct": "",
         "publication_date": "2012-08-23",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 298,
+        "feature_id": 298,
+        "source_id": 110,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -10007,7 +11199,11 @@
         "nct": "",
         "publication_date": "2012-08-23",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 299,
+        "feature_id": 299,
+        "source_id": 110,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -10042,7 +11238,11 @@
         "nct": "",
         "publication_date": "2014-10-09",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 300,
+        "feature_id": 300,
+        "source_id": 111,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -10077,7 +11277,11 @@
         "nct": "",
         "publication_date": "2014-10-09",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 301,
+        "feature_id": 301,
+        "source_id": 111,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -10112,7 +11316,11 @@
         "nct": "",
         "publication_date": "2014-10-09",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 302,
+        "feature_id": 302,
+        "source_id": 111,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -10147,7 +11355,11 @@
         "nct": "",
         "publication_date": "2014-10-09",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 303,
+        "feature_id": 303,
+        "source_id": 111,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -10182,7 +11394,11 @@
         "nct": "",
         "publication_date": "2013-01-16",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 304,
+        "feature_id": 304,
+        "source_id": 112,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -10217,7 +11433,11 @@
         "nct": "",
         "publication_date": "2006-09-14",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 305,
+        "feature_id": 305,
+        "source_id": 113,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -10252,7 +11472,11 @@
         "nct": "",
         "publication_date": "2012-06-10",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 306,
+        "feature_id": 306,
+        "source_id": 114,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -10287,7 +11511,11 @@
         "nct": "NCT02074839",
         "publication_date": "2018-07-20",
         "last_updated": "2020-11-12",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 307,
+        "feature_id": 307,
+        "source_id": 115,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -10313,16 +11541,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": "",
         "predictive_implication": "Guideline",
-        "description": "Alkylating chemotherapy is recommended by the National Comprehensive Cancer Network® (NCCN®) as a treatment option for patients with glioma harboring mutation of IDH1, as mutation of IDH1 is associated with a survival benefit in patients treated with alkylating chemotherapy, but not untreated patients.",
+        "description": "Alkylating chemotherapy is recommended by the National Comprehensive Cancer Network\u00ae (NCCN\u00ae) as a treatment option for patients with glioma harboring mutation of IDH1, as mutation of IDH1 is associated with a survival benefit in patients treated with alkylating chemotherapy, but not untreated patients.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Glioma V.1.2016. © National Comprehensive Cancer Network, Inc. 2016. All rights reserved. Accessed November 5 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Glioma V.1.2016. \u00a9 National Comprehensive Cancer Network, Inc. 2016. All rights reserved. Accessed November 5 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/cns_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2016-01-01",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 308,
+        "feature_id": 308,
+        "source_id": 116,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -10350,14 +11582,18 @@
         "predictive_implication": "Guideline",
         "description": "Mutation of IDH1 is associated with a survival benefit in patients treated with alkylating chemotherapy (but not untreated patients).",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Glioma V.1.2016. © National Comprehensive Cancer Network, Inc. 2016. All rights reserved. Accessed November 5 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Glioma V.1.2016. \u00a9 National Comprehensive Cancer Network, Inc. 2016. All rights reserved. Accessed November 5 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/cns_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2016-01-01",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 309,
+        "feature_id": 309,
+        "source_id": 116,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -10392,7 +11628,11 @@
         "nct": "",
         "publication_date": "2020-08-01",
         "last_updated": "2021-09-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 310,
+        "feature_id": 310,
+        "source_id": 117,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -10427,7 +11667,11 @@
         "nct": "",
         "publication_date": "2020-08-01",
         "last_updated": "2021-09-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 311,
+        "feature_id": 311,
+        "source_id": 117,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -10462,7 +11706,11 @@
         "nct": "",
         "publication_date": "2020-08-01",
         "last_updated": "2021-09-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 312,
+        "feature_id": 312,
+        "source_id": 117,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -10497,7 +11745,11 @@
         "nct": "",
         "publication_date": "2020-08-01",
         "last_updated": "2021-09-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 313,
+        "feature_id": 313,
+        "source_id": 117,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -10532,7 +11784,11 @@
         "nct": "",
         "publication_date": "2020-08-01",
         "last_updated": "2021-09-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 314,
+        "feature_id": 314,
+        "source_id": 117,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -10567,7 +11823,11 @@
         "nct": "",
         "publication_date": "2020-08-01",
         "last_updated": "2021-09-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 315,
+        "feature_id": 315,
+        "source_id": 117,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -10602,7 +11862,11 @@
         "nct": "NCT01915498",
         "publication_date": "2019-09-01",
         "last_updated": "2020-11-12",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 316,
+        "feature_id": 316,
+        "source_id": 118,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -10637,7 +11901,11 @@
         "nct": "NCT01915498",
         "publication_date": "2019-09-01",
         "last_updated": "2020-11-12",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 317,
+        "feature_id": 317,
+        "source_id": 118,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -10672,7 +11940,11 @@
         "nct": "NCT01915498",
         "publication_date": "2019-09-01",
         "last_updated": "2020-11-12",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 318,
+        "feature_id": 318,
+        "source_id": 118,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -10698,16 +11970,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": "",
         "predictive_implication": "Guideline",
-        "description": "Alkylating chemotherapy is recommended by the National Comprehensive Cancer Network® (NCCN®) as a treatment option for patients with glioma harboring mutation of IDH2, as mutation of IDH2 is associated with a survival benefit in patients treated with alkylating chemotherapy, but not untreated patients.",
+        "description": "Alkylating chemotherapy is recommended by the National Comprehensive Cancer Network\u00ae (NCCN\u00ae) as a treatment option for patients with glioma harboring mutation of IDH2, as mutation of IDH2 is associated with a survival benefit in patients treated with alkylating chemotherapy, but not untreated patients.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Glioma V.1.2016. © National Comprehensive Cancer Network, Inc. 2016. All rights reserved. Accessed November 5 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Glioma V.1.2016. \u00a9 National Comprehensive Cancer Network, Inc. 2016. All rights reserved. Accessed November 5 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/cns_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2016-01-01",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 319,
+        "feature_id": 319,
+        "source_id": 116,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -10735,14 +12011,18 @@
         "predictive_implication": "Guideline",
         "description": "Mutation of IDH2 is associated with a survival benefit in patients treated with alkylating chemotherapy, but not untreated patients.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Glioma V.1.2016. © National Comprehensive Cancer Network, Inc. 2016. All rights reserved. Accessed November 5 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Glioma V.1.2016. \u00a9 National Comprehensive Cancer Network, Inc. 2016. All rights reserved. Accessed November 5 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/cns_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2016-01-01",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 320,
+        "feature_id": 320,
+        "source_id": 116,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -10768,16 +12048,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": 0,
         "predictive_implication": "Guideline",
-        "description": "The National Comprehensive Cancer Network® (NCCN®) highlights IDH2 p.R140Q and p.R172 variants as being associated with poor prognosis in patients with myelodysplastic syndromes.",
+        "description": "The National Comprehensive Cancer Network\u00ae (NCCN\u00ae) highlights IDH2 p.R140Q and p.R172 variants as being associated with poor prognosis in patients with myelodysplastic syndromes.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Myelodysplastic Syndromes V.2.2023. © National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Myelodysplastic Syndromes V.2.2023. \u00a9 National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/mds_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2023-10-17",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 321,
+        "feature_id": 321,
+        "source_id": 33,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -10803,16 +12087,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": 0,
         "predictive_implication": "Guideline",
-        "description": "The National Comprehensive Cancer Network® (NCCN®) highlights IDH2 p.R140Q and p.R172 variants as being associated with poor prognosis in patients with myelodysplastic syndromes.",
+        "description": "The National Comprehensive Cancer Network\u00ae (NCCN\u00ae) highlights IDH2 p.R140Q and p.R172 variants as being associated with poor prognosis in patients with myelodysplastic syndromes.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Myelodysplastic Syndromes V.2.2023. © National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Myelodysplastic Syndromes V.2.2023. \u00a9 National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/mds_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2023-10-17",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 322,
+        "feature_id": 322,
+        "source_id": 33,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -10838,16 +12126,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": 0,
         "predictive_implication": "Guideline",
-        "description": "The National Comprehensive Cancer Network® (NCCN®) highlights IDH2 p.R140Q and p.R172 variants as being associated with poor prognosis in patients with myelodysplastic syndromes.",
+        "description": "The National Comprehensive Cancer Network\u00ae (NCCN\u00ae) highlights IDH2 p.R140Q and p.R172 variants as being associated with poor prognosis in patients with myelodysplastic syndromes.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Myelodysplastic Syndromes V.2.2023. © National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Myelodysplastic Syndromes V.2.2023. \u00a9 National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/mds_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2023-10-17",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 323,
+        "feature_id": 323,
+        "source_id": 33,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -10882,7 +12174,11 @@
         "nct": "",
         "publication_date": "2017-02-28",
         "last_updated": "2019-04-30",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 324,
+        "feature_id": 324,
+        "source_id": 119,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -10917,7 +12213,11 @@
         "nct": "",
         "publication_date": "2015-11-26",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 325,
+        "feature_id": 325,
+        "source_id": 120,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -10952,7 +12252,11 @@
         "nct": "",
         "publication_date": "2015-11-26",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 326,
+        "feature_id": 326,
+        "source_id": 120,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -10987,7 +12291,11 @@
         "nct": "",
         "publication_date": "2017-02-28",
         "last_updated": "2019-04-30",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 327,
+        "feature_id": 327,
+        "source_id": 119,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -11022,7 +12330,11 @@
         "nct": "",
         "publication_date": "2005-04-28",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 328,
+        "feature_id": 328,
+        "source_id": 121,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -11057,7 +12369,11 @@
         "nct": "",
         "publication_date": "2014-11-13",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 329,
+        "feature_id": 329,
+        "source_id": 122,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -11092,7 +12408,11 @@
         "nct": "",
         "publication_date": "2014-11-13",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 330,
+        "feature_id": 330,
+        "source_id": 122,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -11127,7 +12447,11 @@
         "nct": "",
         "publication_date": "2014-11-13",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 331,
+        "feature_id": 331,
+        "source_id": 122,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -11162,7 +12486,11 @@
         "nct": "",
         "publication_date": "2014-11-13",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 332,
+        "feature_id": 332,
+        "source_id": 122,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -11197,7 +12525,11 @@
         "nct": "",
         "publication_date": "2014-11-13",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 333,
+        "feature_id": 333,
+        "source_id": 122,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -11232,7 +12564,11 @@
         "nct": "",
         "publication_date": "2014-11-13",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 334,
+        "feature_id": 334,
+        "source_id": 122,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -11267,7 +12603,11 @@
         "nct": "",
         "publication_date": "2020-08-01",
         "last_updated": "2020-11-12",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 335,
+        "feature_id": 335,
+        "source_id": 3,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -11302,7 +12642,11 @@
         "nct": "",
         "publication_date": "2020-08-01",
         "last_updated": "2020-11-12",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 336,
+        "feature_id": 336,
+        "source_id": 3,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -11337,7 +12681,11 @@
         "nct": "",
         "publication_date": "2020-06-01",
         "last_updated": "2020-11-12",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 337,
+        "feature_id": 337,
+        "source_id": 123,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -11372,7 +12720,11 @@
         "nct": "",
         "publication_date": "2020-06-01",
         "last_updated": "2020-11-12",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 338,
+        "feature_id": 338,
+        "source_id": 123,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -11407,7 +12759,11 @@
         "nct": "",
         "publication_date": "2020-06-01",
         "last_updated": "2020-11-12",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 339,
+        "feature_id": 339,
+        "source_id": 123,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -11442,7 +12798,11 @@
         "nct": "",
         "publication_date": "2020-06-01",
         "last_updated": "2020-11-12",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 340,
+        "feature_id": 340,
+        "source_id": 123,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -11477,7 +12837,11 @@
         "nct": "",
         "publication_date": "2020-08-14",
         "last_updated": "2020-11-12",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 341,
+        "feature_id": 341,
+        "source_id": 124,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -11512,7 +12876,11 @@
         "nct": "",
         "publication_date": "2020-08-14",
         "last_updated": "2020-11-12",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 342,
+        "feature_id": 342,
+        "source_id": 124,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -11547,7 +12915,11 @@
         "nct": "",
         "publication_date": "2020-08-14",
         "last_updated": "2020-11-12",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 343,
+        "feature_id": 343,
+        "source_id": 124,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -11573,16 +12945,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": "",
         "predictive_implication": "Guideline",
-        "description": "Imatinib (Gleevec) is recommended by the National Comprehensive Cancer Network® (NCCN®) as a treatment option for patients with head and neck mucosal melanoma. Mucosal melanoma is a rare and highly aggressive neoplasm with poor prognosis. Patients with this disease and mutations with c-KIT mutations (KIT exon 11 or 13) may be sensitive to c-KIT inhibitors.",
+        "description": "Imatinib (Gleevec) is recommended by the National Comprehensive Cancer Network\u00ae (NCCN\u00ae) as a treatment option for patients with head and neck mucosal melanoma. Mucosal melanoma is a rare and highly aggressive neoplasm with poor prognosis. Patients with this disease and mutations with c-KIT mutations (KIT exon 11 or 13) may be sensitive to c-KIT inhibitors.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Head and Neck Cancers V.2.2016. © National Comprehensive Cancer Network, Inc. 2016. All rights reserved. Accessed November 5 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Head and Neck Cancers V.2.2016. \u00a9 National Comprehensive Cancer Network, Inc. 2016. All rights reserved. Accessed November 5 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/head-and-neck_blocks.pdf",
         "doi": "",
         "pmid": 20571149,
         "nct": "",
         "publication_date": "2016-01-01",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 344,
+        "feature_id": 344,
+        "source_id": 125,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -11608,16 +12984,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": "",
         "predictive_implication": "Guideline",
-        "description": "Imatinib (Gleevec) is recommended by the National Comprehensive Cancer Network® (NCCN®) as a treatment option for patients with melanoma and KIT exon 11 and 13 variants; p.W557, p.V559, p.L576P, and p.K642E appear to have high level of sensitivity to KIT inhibition.",
+        "description": "Imatinib (Gleevec) is recommended by the National Comprehensive Cancer Network\u00ae (NCCN\u00ae) as a treatment option for patients with melanoma and KIT exon 11 and 13 variants; p.W557, p.V559, p.L576P, and p.K642E appear to have high level of sensitivity to KIT inhibition.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Cutaneous Melanoma V.2.2019. © National Comprehensive Cancer Network, Inc. 2019. All rights reserved. Accessed August 12 2019. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Cutaneous Melanoma V.2.2019. \u00a9 National Comprehensive Cancer Network, Inc. 2019. All rights reserved. Accessed August 12 2019. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/cutaneous_melanoma_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2019-01-01",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 345,
+        "feature_id": 345,
+        "source_id": 126,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -11643,16 +13023,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": "",
         "predictive_implication": "Guideline",
-        "description": "Imatinib (Gleevec) is recommended by the National Comprehensive Cancer Network® (NCCN®) as a treatment option for patients with melanoma and KIT exon 11 and 13 variants; p.W557, p.V559, p.L576P, and p.K642E appear to have high level of sensitivity to KIT inhibition.",
+        "description": "Imatinib (Gleevec) is recommended by the National Comprehensive Cancer Network\u00ae (NCCN\u00ae) as a treatment option for patients with melanoma and KIT exon 11 and 13 variants; p.W557, p.V559, p.L576P, and p.K642E appear to have high level of sensitivity to KIT inhibition.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Cutaneous Melanoma V.2.2019. © National Comprehensive Cancer Network, Inc. 2019. All rights reserved. Accessed August 12 2019. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Cutaneous Melanoma V.2.2019. \u00a9 National Comprehensive Cancer Network, Inc. 2019. All rights reserved. Accessed August 12 2019. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/cutaneous_melanoma_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2019-01-01",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 346,
+        "feature_id": 346,
+        "source_id": 126,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -11678,16 +13062,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": "",
         "predictive_implication": "Guideline",
-        "description": "Imatinib (Gleevec) is recommended by the National Comprehensive Cancer Network® (NCCN®) as a treatment option for patients with melanoma and KIT exon 11 and 13 variants; p.W557, p.V559, p.L576P, and p.K642E appear to have high level of sensitivity to KIT inhibition.",
+        "description": "Imatinib (Gleevec) is recommended by the National Comprehensive Cancer Network\u00ae (NCCN\u00ae) as a treatment option for patients with melanoma and KIT exon 11 and 13 variants; p.W557, p.V559, p.L576P, and p.K642E appear to have high level of sensitivity to KIT inhibition.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Cutaneous Melanoma V.2.2019. © National Comprehensive Cancer Network, Inc. 2019. All rights reserved. Accessed August 12 2019. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Cutaneous Melanoma V.2.2019. \u00a9 National Comprehensive Cancer Network, Inc. 2019. All rights reserved. Accessed August 12 2019. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/cutaneous_melanoma_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2019-01-01",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 347,
+        "feature_id": 347,
+        "source_id": 126,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -11713,16 +13101,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": "",
         "predictive_implication": "Guideline",
-        "description": "Imatinib (Gleevec) is recommended by the National Comprehensive Cancer Network® (NCCN®) as a treatment option for patients with melanoma and KIT exon 11 and 13 variants; p.W557, p.V559, p.L576P, and p.K642E appear to have high level of sensitivity to KIT inhibition.",
+        "description": "Imatinib (Gleevec) is recommended by the National Comprehensive Cancer Network\u00ae (NCCN\u00ae) as a treatment option for patients with melanoma and KIT exon 11 and 13 variants; p.W557, p.V559, p.L576P, and p.K642E appear to have high level of sensitivity to KIT inhibition.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Cutaneous Melanoma V.2.2019. © National Comprehensive Cancer Network, Inc. 2019. All rights reserved. Accessed August 12 2019. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Cutaneous Melanoma V.2.2019. \u00a9 National Comprehensive Cancer Network, Inc. 2019. All rights reserved. Accessed August 12 2019. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/cutaneous_melanoma_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2019-01-01",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 348,
+        "feature_id": 348,
+        "source_id": 126,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -11748,16 +13140,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": "",
         "predictive_implication": "Guideline",
-        "description": "Imatinib (Gleevec) is recommended by the National Comprehensive Cancer Network® (NCCN®) as a treatment option for patients with melanoma and KIT exon 11 and 13 variants; p.W557, p.V559, p.L576P, and p.K642E appear to have high level of sensitivity to KIT inhibition.",
+        "description": "Imatinib (Gleevec) is recommended by the National Comprehensive Cancer Network\u00ae (NCCN\u00ae) as a treatment option for patients with melanoma and KIT exon 11 and 13 variants; p.W557, p.V559, p.L576P, and p.K642E appear to have high level of sensitivity to KIT inhibition.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Cutaneous Melanoma V.2.2019. © National Comprehensive Cancer Network, Inc. 2019. All rights reserved. Accessed August 12 2019. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Cutaneous Melanoma V.2.2019. \u00a9 National Comprehensive Cancer Network, Inc. 2019. All rights reserved. Accessed August 12 2019. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/cutaneous_melanoma_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2019-01-01",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 349,
+        "feature_id": 349,
+        "source_id": 126,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -11783,16 +13179,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": "",
         "predictive_implication": "Guideline",
-        "description": "Imatinib (Gleevec) is recommended by the National Comprehensive Cancer Network® (NCCN®) as a treatment option for patients with melanoma and KIT exon 11 and 13 variants; p.W557, p.V559, p.L576P, and p.K642E appear to have high level of sensitivity to KIT inhibition.",
+        "description": "Imatinib (Gleevec) is recommended by the National Comprehensive Cancer Network\u00ae (NCCN\u00ae) as a treatment option for patients with melanoma and KIT exon 11 and 13 variants; p.W557, p.V559, p.L576P, and p.K642E appear to have high level of sensitivity to KIT inhibition.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Cutaneous Melanoma V.2.2019. © National Comprehensive Cancer Network, Inc. 2019. All rights reserved. Accessed August 12 2019. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Cutaneous Melanoma V.2.2019. \u00a9 National Comprehensive Cancer Network, Inc. 2019. All rights reserved. Accessed August 12 2019. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/cutaneous_melanoma_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2019-01-01",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 350,
+        "feature_id": 350,
+        "source_id": 126,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -11818,16 +13218,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": "",
         "predictive_implication": "Guideline",
-        "description": "Imatinib (Gleevec) is recommended by the National Comprehensive Cancer Network® (NCCN®) as a treatment option for patients with melanoma and KIT exon 11 and 13 variants; p.W557, p.V559, p.L576P, and p.K642E appear to have high level of sensitivity to KIT inhibition.",
+        "description": "Imatinib (Gleevec) is recommended by the National Comprehensive Cancer Network\u00ae (NCCN\u00ae) as a treatment option for patients with melanoma and KIT exon 11 and 13 variants; p.W557, p.V559, p.L576P, and p.K642E appear to have high level of sensitivity to KIT inhibition.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Cutaneous Melanoma V.2.2019. © National Comprehensive Cancer Network, Inc. 2019. All rights reserved. Accessed August 12 2019. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Cutaneous Melanoma V.2.2019. \u00a9 National Comprehensive Cancer Network, Inc. 2019. All rights reserved. Accessed August 12 2019. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/cutaneous_melanoma_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2019-01-01",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 351,
+        "feature_id": 351,
+        "source_id": 126,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -11853,16 +13257,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": "",
         "predictive_implication": "Guideline",
-        "description": "Imatinib (Gleevec) is recommended by the National Comprehensive Cancer Network® (NCCN®) as a treatment option for patients with melanoma and KIT exon 11 and 13 variants; p.W557, p.V559, p.L576P, and p.K642E appear to have high level of sensitivity to KIT inhibition.",
+        "description": "Imatinib (Gleevec) is recommended by the National Comprehensive Cancer Network\u00ae (NCCN\u00ae) as a treatment option for patients with melanoma and KIT exon 11 and 13 variants; p.W557, p.V559, p.L576P, and p.K642E appear to have high level of sensitivity to KIT inhibition.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Cutaneous Melanoma V.2.2019. © National Comprehensive Cancer Network, Inc. 2019. All rights reserved. Accessed August 12 2019. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Cutaneous Melanoma V.2.2019. \u00a9 National Comprehensive Cancer Network, Inc. 2019. All rights reserved. Accessed August 12 2019. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/cutaneous_melanoma_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2019-01-01",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 352,
+        "feature_id": 352,
+        "source_id": 126,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -11888,16 +13296,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": "",
         "predictive_implication": "Guideline",
-        "description": "Imatinib (Gleevec) is recommended by the National Comprehensive Cancer Network® (NCCN®) as a treatment option for patients with melanoma and KIT exon 11 and 13 variants; p.W557, p.V559, p.L576P, and p.K642E appear to have high level of sensitivity to KIT inhibition.",
+        "description": "Imatinib (Gleevec) is recommended by the National Comprehensive Cancer Network\u00ae (NCCN\u00ae) as a treatment option for patients with melanoma and KIT exon 11 and 13 variants; p.W557, p.V559, p.L576P, and p.K642E appear to have high level of sensitivity to KIT inhibition.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Cutaneous Melanoma V.2.2019. © National Comprehensive Cancer Network, Inc. 2019. All rights reserved. Accessed August 12 2019. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Cutaneous Melanoma V.2.2019. \u00a9 National Comprehensive Cancer Network, Inc. 2019. All rights reserved. Accessed August 12 2019. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/cutaneous_melanoma_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2019-01-01",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 353,
+        "feature_id": 353,
+        "source_id": 126,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -11923,16 +13335,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": "",
         "predictive_implication": "Guideline",
-        "description": "Imatinib (Gleevec) is not recommended by the National Comprehensive Cancer Network® (NCCN®) as a treatment option for patients with melanoma and KIT exon 17 variants (p.D816H), these variants appear to have minimal or no sensitivity to KIT inhibitiors.",
+        "description": "Imatinib (Gleevec) is not recommended by the National Comprehensive Cancer Network\u00ae (NCCN\u00ae) as a treatment option for patients with melanoma and KIT exon 17 variants (p.D816H), these variants appear to have minimal or no sensitivity to KIT inhibitiors.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Cutaneous Melanoma V.2.2019. © National Comprehensive Cancer Network, Inc. 2019. All rights reserved. Accessed August 12 2019. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Cutaneous Melanoma V.2.2019. \u00a9 National Comprehensive Cancer Network, Inc. 2019. All rights reserved. Accessed August 12 2019. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/cutaneous_melanoma_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2019-01-01",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 354,
+        "feature_id": 354,
+        "source_id": 126,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -11958,16 +13374,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": "",
         "predictive_implication": "Guideline",
-        "description": "Imatinib (Gleevec) is not recommended by the National Comprehensive Cancer Network® (NCCN®) as a treatment option for patients with melanoma and KIT exon 17 variants (p.D816H), these variants appear to have minimal or no sensitivity to KIT inhibitiors.",
+        "description": "Imatinib (Gleevec) is not recommended by the National Comprehensive Cancer Network\u00ae (NCCN\u00ae) as a treatment option for patients with melanoma and KIT exon 17 variants (p.D816H), these variants appear to have minimal or no sensitivity to KIT inhibitiors.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Cutaneous Melanoma V.2.2019. © National Comprehensive Cancer Network, Inc. 2019. All rights reserved. Accessed August 12 2019. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Cutaneous Melanoma V.2.2019. \u00a9 National Comprehensive Cancer Network, Inc. 2019. All rights reserved. Accessed August 12 2019. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/cutaneous_melanoma_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2019-01-01",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 355,
+        "feature_id": 355,
+        "source_id": 126,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -11993,16 +13413,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": "",
         "predictive_implication": "Guideline",
-        "description": "Imatinib (Gleevec) is recommended by the National Comprehensive Cancer Network® (NCCN®) as a treatment option for patients with KIT mutant melanoma. Activating KIT mutations are associated with an increased sensitvity to imatinib.",
+        "description": "Imatinib (Gleevec) is recommended by the National Comprehensive Cancer Network\u00ae (NCCN\u00ae) as a treatment option for patients with KIT mutant melanoma. Activating KIT mutations are associated with an increased sensitvity to imatinib.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Melanoma V.3.2016. © National Comprehensive Cancer Network, Inc. 2016. All rights reserved. Accessed November 5 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Melanoma V.3.2016. \u00a9 National Comprehensive Cancer Network, Inc. 2016. All rights reserved. Accessed November 5 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/melanoma_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2016-01-01",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 356,
+        "feature_id": 356,
+        "source_id": 68,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -12028,16 +13452,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": "",
         "predictive_implication": "Guideline",
-        "description": "Imatinib (Gleevec) is recommended by the National Comprehensive Cancer Network® (NCCN®) as a treatment option for patients with gastrointestinal stromal tumors and mutations in KIT exon 11. Approximately 90% of patients have diseases that respond to imatinib when their tumors have a KIT exon 11 mutation.",
+        "description": "Imatinib (Gleevec) is recommended by the National Comprehensive Cancer Network\u00ae (NCCN\u00ae) as a treatment option for patients with gastrointestinal stromal tumors and mutations in KIT exon 11. Approximately 90% of patients have diseases that respond to imatinib when their tumors have a KIT exon 11 mutation.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Gastrointestinal Stromal Tumors V.2.2019. © National Comprehensive Cancer Network, Inc. 2019. All rights reserved. Accessed August 10 2019. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Gastrointestinal Stromal Tumors V.2.2019. \u00a9 National Comprehensive Cancer Network, Inc. 2019. All rights reserved. Accessed August 10 2019. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/gist_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2019-01-01",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 357,
+        "feature_id": 357,
+        "source_id": 127,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -12063,16 +13491,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": "",
         "predictive_implication": "Guideline",
-        "description": "Imatinib (Gleevec) is recommended by the National Comprehensive Cancer Network® (NCCN®) as a treatment option for patients with gastrointestinal stromal tumors and mutations in KIT exon 9. Approximately 50% of patients have diseases that respond to imatinib when their tumors have a KIT exon 9 mutation, and the likelihood of response improves with use of 800 mg dosage rather than the standard 400 mg.",
+        "description": "Imatinib (Gleevec) is recommended by the National Comprehensive Cancer Network\u00ae (NCCN\u00ae) as a treatment option for patients with gastrointestinal stromal tumors and mutations in KIT exon 9. Approximately 50% of patients have diseases that respond to imatinib when their tumors have a KIT exon 9 mutation, and the likelihood of response improves with use of 800 mg dosage rather than the standard 400 mg.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Gastrointestinal Stromal Tumors V.2.2019. © National Comprehensive Cancer Network, Inc. 2019. All rights reserved. Accessed August 10 2019. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Gastrointestinal Stromal Tumors V.2.2019. \u00a9 National Comprehensive Cancer Network, Inc. 2019. All rights reserved. Accessed August 10 2019. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/gist_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2019-01-01",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 358,
+        "feature_id": 358,
+        "source_id": 127,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -12098,16 +13530,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": "",
         "predictive_implication": "Guideline",
-        "description": "Sunitinib (Sutent) is recommended by the National Comprehensive Cancer Network® (NCCN®) as a treatment option for patients with thymic carcinomas and c-KIT mutations.",
+        "description": "Sunitinib (Sutent) is recommended by the National Comprehensive Cancer Network\u00ae (NCCN\u00ae) as a treatment option for patients with thymic carcinomas and c-KIT mutations.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Thymomas and Thymic Carcinomas V.1.2021. © National Comprehensive Cancer Network, Inc. 2021. All rights reserved. Accessed November 19 2020. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Thymomas and Thymic Carcinomas V.1.2021. \u00a9 National Comprehensive Cancer Network, Inc. 2021. All rights reserved. Accessed November 19 2020. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/thymic_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2020-01-01",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 359,
+        "feature_id": 359,
+        "source_id": 128,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -12142,7 +13578,11 @@
         "nct": "",
         "publication_date": "2023-06-01",
         "last_updated": "2021-09-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 360,
+        "feature_id": 360,
+        "source_id": 129,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -12177,7 +13617,11 @@
         "nct": "",
         "publication_date": "2023-06-01",
         "last_updated": "2021-09-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 361,
+        "feature_id": 361,
+        "source_id": 129,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -12212,7 +13656,11 @@
         "nct": "",
         "publication_date": "2023-06-01",
         "last_updated": "2021-09-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 362,
+        "feature_id": 362,
+        "source_id": 129,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -12247,7 +13695,11 @@
         "nct": "",
         "publication_date": "2023-06-01",
         "last_updated": "2021-09-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 363,
+        "feature_id": 363,
+        "source_id": 129,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -12282,7 +13734,11 @@
         "nct": "NCT02154490",
         "publication_date": "2016-01-03",
         "last_updated": "2018-09-14",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 364,
+        "feature_id": 364,
+        "source_id": 130,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -12317,7 +13773,11 @@
         "nct": "NCT01155453",
         "publication_date": "2015-02-16",
         "last_updated": "2019-01-29",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 365,
+        "feature_id": 365,
+        "source_id": 131,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -12343,16 +13803,20 @@
         "therapy_resistance": 1,
         "favorable_prognosis": "",
         "predictive_implication": "Guideline",
-        "description": "Cetuximab (Erbitux) is not recommended by the National Comprehensive Cancer Network® (NCCN®) as a treatment option for patients with primary or metastatic colorectal cancer and known KRAS mutations (exon 2, 3, and 4).",
+        "description": "Cetuximab (Erbitux) is not recommended by the National Comprehensive Cancer Network\u00ae (NCCN\u00ae) as a treatment option for patients with primary or metastatic colorectal cancer and known KRAS mutations (exon 2, 3, and 4).",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Colon Cancer V.4.2018. © National Comprehensive Cancer Network, Inc. 2018. All rights reserved. Accessed March 20 2019. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Colon Cancer V.4.2018. \u00a9 National Comprehensive Cancer Network, Inc. 2018. All rights reserved. Accessed March 20 2019. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/colon_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2018-01-01",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 366,
+        "feature_id": 366,
+        "source_id": 66,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -12378,16 +13842,20 @@
         "therapy_resistance": 1,
         "favorable_prognosis": "",
         "predictive_implication": "Guideline",
-        "description": "Panitumumab (Vectibix) is not recommended by the National Comprehensive Cancer Network® (NCCN®) as a treatment option for patients with primary or metastatic colorectal cancer and known KRAS mutations (exon 2, 3, and 4).",
+        "description": "Panitumumab (Vectibix) is not recommended by the National Comprehensive Cancer Network\u00ae (NCCN\u00ae) as a treatment option for patients with primary or metastatic colorectal cancer and known KRAS mutations (exon 2, 3, and 4).",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Colon Cancer V.4.2018. © National Comprehensive Cancer Network, Inc. 2018. All rights reserved. Accessed March 20 2019. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Colon Cancer V.4.2018. \u00a9 National Comprehensive Cancer Network, Inc. 2018. All rights reserved. Accessed March 20 2019. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/colon_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2018-01-01",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 367,
+        "feature_id": 367,
+        "source_id": 66,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -12413,16 +13881,20 @@
         "therapy_resistance": 1,
         "favorable_prognosis": "",
         "predictive_implication": "Guideline",
-        "description": "Cetuximab (Erbitux) is not recommended by the National Comprehensive Cancer Network® (NCCN®) as a treatment option for patients with primary or metastatic colorectal cancer and known KRAS mutations (exon 2, 3, and 4).",
+        "description": "Cetuximab (Erbitux) is not recommended by the National Comprehensive Cancer Network\u00ae (NCCN\u00ae) as a treatment option for patients with primary or metastatic colorectal cancer and known KRAS mutations (exon 2, 3, and 4).",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Colon Cancer V.4.2018. © National Comprehensive Cancer Network, Inc. 2018. All rights reserved. Accessed March 20 2019. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Colon Cancer V.4.2018. \u00a9 National Comprehensive Cancer Network, Inc. 2018. All rights reserved. Accessed March 20 2019. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/colon_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2018-01-01",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 368,
+        "feature_id": 368,
+        "source_id": 66,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -12448,16 +13920,20 @@
         "therapy_resistance": 1,
         "favorable_prognosis": "",
         "predictive_implication": "Guideline",
-        "description": "Panitumumab (Vectibix) is not recommended by the National Comprehensive Cancer Network® (NCCN®) as a treatment option for patients with primary or metastatic colorectal cancer and known KRAS mutations (exon 2, 3, and 4).",
+        "description": "Panitumumab (Vectibix) is not recommended by the National Comprehensive Cancer Network\u00ae (NCCN\u00ae) as a treatment option for patients with primary or metastatic colorectal cancer and known KRAS mutations (exon 2, 3, and 4).",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Colon Cancer V.4.2018. © National Comprehensive Cancer Network, Inc. 2018. All rights reserved. Accessed March 20 2019. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Colon Cancer V.4.2018. \u00a9 National Comprehensive Cancer Network, Inc. 2018. All rights reserved. Accessed March 20 2019. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/colon_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2018-01-01",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 369,
+        "feature_id": 369,
+        "source_id": 66,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -12483,16 +13959,20 @@
         "therapy_resistance": 1,
         "favorable_prognosis": "",
         "predictive_implication": "Guideline",
-        "description": "Cetuximab (Erbitux) is not recommended by the National Comprehensive Cancer Network® (NCCN®) as a treatment option for patients with primary or metastatic colorectal cancer and known KRAS mutations (exon 2, 3, and 4).",
+        "description": "Cetuximab (Erbitux) is not recommended by the National Comprehensive Cancer Network\u00ae (NCCN\u00ae) as a treatment option for patients with primary or metastatic colorectal cancer and known KRAS mutations (exon 2, 3, and 4).",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Colon Cancer V.4.2018. © National Comprehensive Cancer Network, Inc. 2018. All rights reserved. Accessed March 20 2019. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Colon Cancer V.4.2018. \u00a9 National Comprehensive Cancer Network, Inc. 2018. All rights reserved. Accessed March 20 2019. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/colon_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2018-01-01",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 370,
+        "feature_id": 370,
+        "source_id": 66,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -12518,16 +13998,20 @@
         "therapy_resistance": 1,
         "favorable_prognosis": "",
         "predictive_implication": "Guideline",
-        "description": "Panitumumab (Vectibix) is not recommended by the National Comprehensive Cancer Network® (NCCN®) as a treatment option for patients with primary or metastatic colorectal cancer and known KRAS mutations (exon 2, 3, and 4).",
+        "description": "Panitumumab (Vectibix) is not recommended by the National Comprehensive Cancer Network\u00ae (NCCN\u00ae) as a treatment option for patients with primary or metastatic colorectal cancer and known KRAS mutations (exon 2, 3, and 4).",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Colon Cancer V.4.2018. © National Comprehensive Cancer Network, Inc. 2018. All rights reserved. Accessed March 20 2019. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Colon Cancer V.4.2018. \u00a9 National Comprehensive Cancer Network, Inc. 2018. All rights reserved. Accessed March 20 2019. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/colon_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2018-01-01",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 371,
+        "feature_id": 371,
+        "source_id": 66,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -12562,7 +14046,11 @@
         "nct": "",
         "publication_date": "2021-05-01",
         "last_updated": "2023-11-30",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 372,
+        "feature_id": 372,
+        "source_id": 132,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -12588,16 +14076,20 @@
         "therapy_resistance": 1,
         "favorable_prognosis": "",
         "predictive_implication": "Guideline",
-        "description": "Gefitinib (Iressa) is not recommended by the National Comprehensive Cancer Network® (NCCN®) as a treatment option for patients with non-small cell lung cancer whose tumors harbor variants in KRAS, as these mutations are associated with intrinsic resistance to EGFR TKIs.",
+        "description": "Gefitinib (Iressa) is not recommended by the National Comprehensive Cancer Network\u00ae (NCCN\u00ae) as a treatment option for patients with non-small cell lung cancer whose tumors harbor variants in KRAS, as these mutations are associated with intrinsic resistance to EGFR TKIs.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Non-Small Lung Cancer V.1.2017. © National Comprehensive Cancer Network, Inc. 2017. All rights reserved. Accessed November 5, 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Non-Small Lung Cancer V.1.2017. \u00a9 National Comprehensive Cancer Network, Inc. 2017. All rights reserved. Accessed November 5, 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/nscl_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2017-01-01",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 373,
+        "feature_id": 373,
+        "source_id": 20,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -12632,7 +14124,11 @@
         "nct": "",
         "publication_date": "2016-03-24",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 374,
+        "feature_id": 374,
+        "source_id": 133,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -12667,7 +14163,11 @@
         "nct": "",
         "publication_date": "2017-05-25",
         "last_updated": "2019-04-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 375,
+        "feature_id": 375,
+        "source_id": 134,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -12702,7 +14202,11 @@
         "nct": "",
         "publication_date": "2017-05-25",
         "last_updated": "2019-04-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 376,
+        "feature_id": 376,
+        "source_id": 134,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -12737,7 +14241,11 @@
         "nct": "",
         "publication_date": "2017-05-25",
         "last_updated": "2019-04-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 377,
+        "feature_id": 377,
+        "source_id": 134,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -12772,7 +14280,11 @@
         "nct": "",
         "publication_date": "2016-06-22",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 378,
+        "feature_id": 378,
+        "source_id": 135,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -12807,7 +14319,11 @@
         "nct": "",
         "publication_date": "2016-06-22",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 379,
+        "feature_id": 379,
+        "source_id": 135,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -12842,7 +14358,11 @@
         "nct": "",
         "publication_date": "2015-03-12",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 380,
+        "feature_id": 380,
+        "source_id": 136,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -12877,7 +14397,11 @@
         "nct": "",
         "publication_date": "2015-04-09",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 381,
+        "feature_id": 381,
+        "source_id": 54,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -12912,7 +14436,11 @@
         "nct": "",
         "publication_date": "2014-04-03",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 382,
+        "feature_id": 382,
+        "source_id": 137,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -12947,7 +14475,11 @@
         "nct": "",
         "publication_date": "2014-04-03",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 383,
+        "feature_id": 383,
+        "source_id": 137,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -12982,7 +14514,11 @@
         "nct": "",
         "publication_date": "2019-09-13",
         "last_updated": "2019-08-08",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 384,
+        "feature_id": 384,
+        "source_id": 138,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -13017,7 +14553,11 @@
         "nct": "",
         "publication_date": "2015-05-11",
         "last_updated": "2019-08-08",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 385,
+        "feature_id": 385,
+        "source_id": 139,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -13052,7 +14592,11 @@
         "nct": "",
         "publication_date": "2009-12-1",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 386,
+        "feature_id": 386,
+        "source_id": 71,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -13087,7 +14631,11 @@
         "nct": "",
         "publication_date": "2009-12-1",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 387,
+        "feature_id": 387,
+        "source_id": 71,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -13122,7 +14670,11 @@
         "nct": "",
         "publication_date": "2009-12-1",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 388,
+        "feature_id": 388,
+        "source_id": 71,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -13157,7 +14709,11 @@
         "nct": "",
         "publication_date": "2015-07-15",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 389,
+        "feature_id": 389,
+        "source_id": 140,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -13192,7 +14748,11 @@
         "nct": "",
         "publication_date": "2013-04-08",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 390,
+        "feature_id": 390,
+        "source_id": 141,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -13227,7 +14787,11 @@
         "nct": "",
         "publication_date": "2013-04-08",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 391,
+        "feature_id": 391,
+        "source_id": 141,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -13262,7 +14826,11 @@
         "nct": "",
         "publication_date": "2011-03-07",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 392,
+        "feature_id": 392,
+        "source_id": 142,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -13297,7 +14865,11 @@
         "nct": "",
         "publication_date": "2011-03-07",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 393,
+        "feature_id": 393,
+        "source_id": 142,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -13332,7 +14904,11 @@
         "nct": "",
         "publication_date": "2014-01-07",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 394,
+        "feature_id": 394,
+        "source_id": 78,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -13367,7 +14943,11 @@
         "nct": "",
         "publication_date": "2015-03-05",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 395,
+        "feature_id": 395,
+        "source_id": 143,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -13402,7 +14982,11 @@
         "nct": "",
         "publication_date": "2016-08-19",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 396,
+        "feature_id": 396,
+        "source_id": 144,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -13437,7 +15021,11 @@
         "nct": "",
         "publication_date": "2009-03-17",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 397,
+        "feature_id": 397,
+        "source_id": 145,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -13463,16 +15051,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": "",
         "predictive_implication": "Guideline",
-        "description": "Crizotinib (Xalkori) is recommended by the National Comprehensive Cancer Network® (NCCN®) as a treatment option for patients with metastatic non-small cell lung cancer whose tumors harbor MET exon 14 skipping variants.",
+        "description": "Crizotinib (Xalkori) is recommended by the National Comprehensive Cancer Network\u00ae (NCCN\u00ae) as a treatment option for patients with metastatic non-small cell lung cancer whose tumors harbor MET exon 14 skipping variants.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Non-Small Lung Cancer V.5.2019. © National Comprehensive Cancer Network, Inc. 2019. All rights reserved. Accessed August 12, 2019. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Non-Small Lung Cancer V.5.2019. \u00a9 National Comprehensive Cancer Network, Inc. 2019. All rights reserved. Accessed August 12, 2019. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/nscl_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2019-01-01",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 398,
+        "feature_id": 398,
+        "source_id": 11,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -13498,16 +15090,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": "",
         "predictive_implication": "Guideline",
-        "description": "Crizotinib (Xalkori) is recommended by the National Comprehensive Cancer Network® (NCCN®) as a treatment option for patients with metastatic non-small cell lung cancer whose tumors harbor MET exon 14 skipping variants.",
+        "description": "Crizotinib (Xalkori) is recommended by the National Comprehensive Cancer Network\u00ae (NCCN\u00ae) as a treatment option for patients with metastatic non-small cell lung cancer whose tumors harbor MET exon 14 skipping variants.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Non-Small Lung Cancer V.5.2019. © National Comprehensive Cancer Network, Inc. 2019. All rights reserved. Accessed August 12, 2019. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Non-Small Lung Cancer V.5.2019. \u00a9 National Comprehensive Cancer Network, Inc. 2019. All rights reserved. Accessed August 12, 2019. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/nscl_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2019-01-01",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 399,
+        "feature_id": 399,
+        "source_id": 11,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -13542,7 +15138,11 @@
         "nct": "",
         "publication_date": "2022-08-10",
         "last_updated": "2024-03-04",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 400,
+        "feature_id": 400,
+        "source_id": 146,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -13577,7 +15177,11 @@
         "nct": "",
         "publication_date": "2022-08-10",
         "last_updated": "2024-03-04",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 401,
+        "feature_id": 401,
+        "source_id": 146,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -13612,7 +15216,11 @@
         "nct": "NCT01876511",
         "publication_date": "2015-06-25",
         "last_updated": "2023-10-31",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 402,
+        "feature_id": 402,
+        "source_id": 147,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -13647,7 +15255,11 @@
         "nct": "",
         "publication_date": "2011-10-18",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 403,
+        "feature_id": 403,
+        "source_id": 148,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -13682,7 +15294,11 @@
         "nct": "NCT01876511",
         "publication_date": "2015-06-25",
         "last_updated": "2023-10-31",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 404,
+        "feature_id": 404,
+        "source_id": 147,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -13717,7 +15333,11 @@
         "nct": "NCT01876511",
         "publication_date": "2015-06-25",
         "last_updated": "2023-10-31",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 405,
+        "feature_id": 405,
+        "source_id": 147,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -13752,7 +15372,11 @@
         "nct": "NCT00903175",
         "publication_date": "2019-01-15",
         "last_updated": "2019-08-12",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 406,
+        "feature_id": 406,
+        "source_id": 149,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -13787,7 +15411,11 @@
         "nct": "NCT01876511",
         "publication_date": "2015-06-25",
         "last_updated": "2023-10-31",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 407,
+        "feature_id": 407,
+        "source_id": 147,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -13822,7 +15450,11 @@
         "nct": "",
         "publication_date": "2013-10-14",
         "last_updated": "2019-03-25",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 408,
+        "feature_id": 408,
+        "source_id": 150,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -13848,16 +15480,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": "",
         "predictive_implication": "Guideline",
-        "description": "Cetuximab (Erbitux) is not recommended by the National Comprehensive Cancer Network® (NCCN®) as a treatment option for patients with primary or metastatic colorectal cancer and known KRAS mutations (exon 2, 3, and 4).",
+        "description": "Cetuximab (Erbitux) is not recommended by the National Comprehensive Cancer Network\u00ae (NCCN\u00ae) as a treatment option for patients with primary or metastatic colorectal cancer and known KRAS mutations (exon 2, 3, and 4).",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Colon Cancer V.4.2018. © National Comprehensive Cancer Network, Inc. 2018. All rights reserved. Accessed March 20 2019. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Colon Cancer V.4.2018. \u00a9 National Comprehensive Cancer Network, Inc. 2018. All rights reserved. Accessed March 20 2019. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/colon_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2018-01-01",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 409,
+        "feature_id": 409,
+        "source_id": 66,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -13883,16 +15519,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": "",
         "predictive_implication": "Guideline",
-        "description": "Panitumumab (Vectibix) is not recommended by the National Comprehensive Cancer Network® (NCCN®) as a treatment option for patients with primary or metastatic colorectal cancer and known KRAS mutations (exon 2, 3, and 4).",
+        "description": "Panitumumab (Vectibix) is not recommended by the National Comprehensive Cancer Network\u00ae (NCCN\u00ae) as a treatment option for patients with primary or metastatic colorectal cancer and known KRAS mutations (exon 2, 3, and 4).",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Colon Cancer V.4.2018. © National Comprehensive Cancer Network, Inc. 2018. All rights reserved. Accessed March 20 2019. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Colon Cancer V.4.2018. \u00a9 National Comprehensive Cancer Network, Inc. 2018. All rights reserved. Accessed March 20 2019. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/colon_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2018-01-01",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 410,
+        "feature_id": 410,
+        "source_id": 66,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -13918,16 +15558,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": 0,
         "predictive_implication": "Guideline",
-        "description": "The National Comprehensive Cancer Network® (NCCN®) highlights NRAS G12, G13, and Q61 variants as being associated with poor prognosis in patients with myelodysplastic syndromes, particularly in patients predicted to have lower-risk MDS.",
+        "description": "The National Comprehensive Cancer Network\u00ae (NCCN\u00ae) highlights NRAS G12, G13, and Q61 variants as being associated with poor prognosis in patients with myelodysplastic syndromes, particularly in patients predicted to have lower-risk MDS.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Myelodysplastic Syndromes V.2.2023. © National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Myelodysplastic Syndromes V.2.2023. \u00a9 National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/mds_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2023-10-17",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 411,
+        "feature_id": 411,
+        "source_id": 33,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -13953,16 +15597,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": 0,
         "predictive_implication": "Guideline",
-        "description": "The National Comprehensive Cancer Network® (NCCN®) highlights NRAS G12, G13, and Q61 variants as being associated with poor prognosis in patients with myelodysplastic syndromes, particularly in patients predicted to have lower-risk MDS.",
+        "description": "The National Comprehensive Cancer Network\u00ae (NCCN\u00ae) highlights NRAS G12, G13, and Q61 variants as being associated with poor prognosis in patients with myelodysplastic syndromes, particularly in patients predicted to have lower-risk MDS.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Myelodysplastic Syndromes V.2.2023. © National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Myelodysplastic Syndromes V.2.2023. \u00a9 National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/mds_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2023-10-17",
         "last_updated": "2023-11-30",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 412,
+        "feature_id": 412,
+        "source_id": 33,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -13988,16 +15636,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": 0,
         "predictive_implication": "Guideline",
-        "description": "The National Comprehensive Cancer Network® (NCCN®) highlights NRAS G12, G13, and Q61 variants as being associated with poor prognosis in patients with myelodysplastic syndromes, particularly in patients predicted to have lower-risk MDS.",
+        "description": "The National Comprehensive Cancer Network\u00ae (NCCN\u00ae) highlights NRAS G12, G13, and Q61 variants as being associated with poor prognosis in patients with myelodysplastic syndromes, particularly in patients predicted to have lower-risk MDS.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Myelodysplastic Syndromes V.2.2023. © National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Myelodysplastic Syndromes V.2.2023. \u00a9 National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/mds_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2023-10-17",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 413,
+        "feature_id": 413,
+        "source_id": 33,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -14023,16 +15675,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": 0,
         "predictive_implication": "Guideline",
-        "description": "The National Comprehensive Cancer Network® (NCCN®) highlights NRAS G12, G13, and Q61 variants as being associated with poor prognosis in patients with myelodysplastic syndromes, particularly in patients predicted to have lower-risk MDS.",
+        "description": "The National Comprehensive Cancer Network\u00ae (NCCN\u00ae) highlights NRAS G12, G13, and Q61 variants as being associated with poor prognosis in patients with myelodysplastic syndromes, particularly in patients predicted to have lower-risk MDS.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Myelodysplastic Syndromes V.2.2023. © National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Myelodysplastic Syndromes V.2.2023. \u00a9 National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/mds_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2023-10-17",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 414,
+        "feature_id": 414,
+        "source_id": 33,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -14058,16 +15714,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": 0,
         "predictive_implication": "Guideline",
-        "description": "The National Comprehensive Cancer Network® (NCCN®) highlights NRAS G12, G13, and Q61 variants as being associated with poor prognosis in patients with myelodysplastic syndromes, particularly in patients predicted to have lower-risk MDS.",
+        "description": "The National Comprehensive Cancer Network\u00ae (NCCN\u00ae) highlights NRAS G12, G13, and Q61 variants as being associated with poor prognosis in patients with myelodysplastic syndromes, particularly in patients predicted to have lower-risk MDS.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Myelodysplastic Syndromes V.2.2023. © National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Myelodysplastic Syndromes V.2.2023. \u00a9 National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/mds_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2023-10-17",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 415,
+        "feature_id": 415,
+        "source_id": 33,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -14093,16 +15753,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": 0,
         "predictive_implication": "Guideline",
-        "description": "The National Comprehensive Cancer Network® (NCCN®) highlights NRAS G12, G13, and Q61 variants as being associated with poor prognosis in patients with myelodysplastic syndromes, particularly in patients predicted to have lower-risk MDS.",
+        "description": "The National Comprehensive Cancer Network\u00ae (NCCN\u00ae) highlights NRAS G12, G13, and Q61 variants as being associated with poor prognosis in patients with myelodysplastic syndromes, particularly in patients predicted to have lower-risk MDS.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Myelodysplastic Syndromes V.2.2023. © National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Myelodysplastic Syndromes V.2.2023. \u00a9 National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/mds_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2023-10-17",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 416,
+        "feature_id": 416,
+        "source_id": 33,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -14128,16 +15792,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": 0,
         "predictive_implication": "Guideline",
-        "description": "The National Comprehensive Cancer Network® (NCCN®) highlights NRAS G12, G13, and Q61 variants as being associated with poor prognosis in patients with myelodysplastic syndromes, particularly in patients predicted to have lower-risk MDS.",
+        "description": "The National Comprehensive Cancer Network\u00ae (NCCN\u00ae) highlights NRAS G12, G13, and Q61 variants as being associated with poor prognosis in patients with myelodysplastic syndromes, particularly in patients predicted to have lower-risk MDS.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Myelodysplastic Syndromes V.2.2023. © National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Myelodysplastic Syndromes V.2.2023. \u00a9 National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/mds_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2023-10-17",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 417,
+        "feature_id": 417,
+        "source_id": 33,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -14163,16 +15831,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": 0,
         "predictive_implication": "Guideline",
-        "description": "The National Comprehensive Cancer Network® (NCCN®) highlights NRAS G12, G13, and Q61 variants as being associated with poor prognosis in patients with myelodysplastic syndromes, particularly in patients predicted to have lower-risk MDS.",
+        "description": "The National Comprehensive Cancer Network\u00ae (NCCN\u00ae) highlights NRAS G12, G13, and Q61 variants as being associated with poor prognosis in patients with myelodysplastic syndromes, particularly in patients predicted to have lower-risk MDS.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Myelodysplastic Syndromes V.2.2023. © National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Myelodysplastic Syndromes V.2.2023. \u00a9 National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/mds_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2023-10-17",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 418,
+        "feature_id": 418,
+        "source_id": 33,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -14198,16 +15870,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": 0,
         "predictive_implication": "Guideline",
-        "description": "The National Comprehensive Cancer Network® (NCCN®) highlights NRAS G12, G13, and Q61 variants as being associated with poor prognosis in patients with myelodysplastic syndromes, particularly in patients predicted to have lower-risk MDS.",
+        "description": "The National Comprehensive Cancer Network\u00ae (NCCN\u00ae) highlights NRAS G12, G13, and Q61 variants as being associated with poor prognosis in patients with myelodysplastic syndromes, particularly in patients predicted to have lower-risk MDS.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Myelodysplastic Syndromes V.2.2023. © National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Myelodysplastic Syndromes V.2.2023. \u00a9 National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/mds_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2023-10-17",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 419,
+        "feature_id": 419,
+        "source_id": 33,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -14233,16 +15909,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": 0,
         "predictive_implication": "Guideline",
-        "description": "The National Comprehensive Cancer Network® (NCCN®) highlights NRAS G12, G13, and Q61 variants as being associated with poor prognosis in patients with myelodysplastic syndromes, particularly in patients predicted to have lower-risk MDS.",
+        "description": "The National Comprehensive Cancer Network\u00ae (NCCN\u00ae) highlights NRAS G12, G13, and Q61 variants as being associated with poor prognosis in patients with myelodysplastic syndromes, particularly in patients predicted to have lower-risk MDS.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Myelodysplastic Syndromes V.2.2023. © National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Myelodysplastic Syndromes V.2.2023. \u00a9 National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/mds_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2023-10-17",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 420,
+        "feature_id": 420,
+        "source_id": 33,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -14268,16 +15948,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": 0,
         "predictive_implication": "Guideline",
-        "description": "The National Comprehensive Cancer Network® (NCCN®) highlights NRAS G12, G13, and Q61 variants as being associated with poor prognosis in patients with myelodysplastic syndromes, particularly in patients predicted to have lower-risk MDS.",
+        "description": "The National Comprehensive Cancer Network\u00ae (NCCN\u00ae) highlights NRAS G12, G13, and Q61 variants as being associated with poor prognosis in patients with myelodysplastic syndromes, particularly in patients predicted to have lower-risk MDS.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Myelodysplastic Syndromes V.2.2023. © National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Myelodysplastic Syndromes V.2.2023. \u00a9 National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/mds_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2023-10-17",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 421,
+        "feature_id": 421,
+        "source_id": 33,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -14303,16 +15987,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": 0,
         "predictive_implication": "Guideline",
-        "description": "The National Comprehensive Cancer Network® (NCCN®) highlights NRAS G12, G13, and Q61 variants as being associated with poor prognosis in patients with myelodysplastic syndromes, particularly in patients predicted to have lower-risk MDS.",
+        "description": "The National Comprehensive Cancer Network\u00ae (NCCN\u00ae) highlights NRAS G12, G13, and Q61 variants as being associated with poor prognosis in patients with myelodysplastic syndromes, particularly in patients predicted to have lower-risk MDS.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Myelodysplastic Syndromes V.2.2023. © National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Myelodysplastic Syndromes V.2.2023. \u00a9 National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/mds_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2023-10-17",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 422,
+        "feature_id": 422,
+        "source_id": 33,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -14338,16 +16026,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": 0,
         "predictive_implication": "Guideline",
-        "description": "The National Comprehensive Cancer Network® (NCCN®) highlights NRAS G12, G13, and Q61 variants as being associated with poor prognosis in patients with myelodysplastic syndromes, particularly in patients predicted to have lower-risk MDS.",
+        "description": "The National Comprehensive Cancer Network\u00ae (NCCN\u00ae) highlights NRAS G12, G13, and Q61 variants as being associated with poor prognosis in patients with myelodysplastic syndromes, particularly in patients predicted to have lower-risk MDS.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Myelodysplastic Syndromes V.2.2023. © National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Myelodysplastic Syndromes V.2.2023. \u00a9 National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/mds_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2023-10-17",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 423,
+        "feature_id": 423,
+        "source_id": 33,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -14373,16 +16065,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": 0,
         "predictive_implication": "Guideline",
-        "description": "The National Comprehensive Cancer Network® (NCCN®) highlights NRAS G12, G13, and Q61 variants as being associated with poor prognosis in patients with myelodysplastic syndromes, particularly in patients predicted to have lower-risk MDS.",
+        "description": "The National Comprehensive Cancer Network\u00ae (NCCN\u00ae) highlights NRAS G12, G13, and Q61 variants as being associated with poor prognosis in patients with myelodysplastic syndromes, particularly in patients predicted to have lower-risk MDS.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Myelodysplastic Syndromes V.2.2023. © National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Myelodysplastic Syndromes V.2.2023. \u00a9 National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/mds_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2023-10-17",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 424,
+        "feature_id": 424,
+        "source_id": 33,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -14417,7 +16113,11 @@
         "nct": "",
         "publication_date": "2016-09-21",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 425,
+        "feature_id": 425,
+        "source_id": 151,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -14452,7 +16152,11 @@
         "nct": "",
         "publication_date": "2016-09-21",
         "last_updated": "2023-11-30",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 426,
+        "feature_id": 426,
+        "source_id": 151,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -14487,7 +16191,11 @@
         "nct": "",
         "publication_date": "2016-09-21",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 427,
+        "feature_id": 427,
+        "source_id": 151,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -14522,7 +16230,11 @@
         "nct": "",
         "publication_date": "2016-09-21",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 428,
+        "feature_id": 428,
+        "source_id": 151,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -14557,7 +16269,11 @@
         "nct": "",
         "publication_date": "2016-09-21",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 429,
+        "feature_id": 429,
+        "source_id": 151,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -14592,7 +16308,11 @@
         "nct": "",
         "publication_date": "2016-09-21",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 430,
+        "feature_id": 430,
+        "source_id": 151,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -14627,7 +16347,11 @@
         "nct": "",
         "publication_date": "2016-09-21",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 431,
+        "feature_id": 431,
+        "source_id": 151,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -14662,7 +16386,11 @@
         "nct": "",
         "publication_date": "2016-09-21",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 432,
+        "feature_id": 432,
+        "source_id": 151,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -14697,7 +16425,11 @@
         "nct": "",
         "publication_date": "2016-09-21",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 433,
+        "feature_id": 433,
+        "source_id": 151,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -14732,7 +16464,11 @@
         "nct": "",
         "publication_date": "2016-09-21",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 434,
+        "feature_id": 434,
+        "source_id": 151,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -14767,7 +16503,11 @@
         "nct": "",
         "publication_date": "2016-09-21",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 435,
+        "feature_id": 435,
+        "source_id": 151,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -14802,7 +16542,11 @@
         "nct": "",
         "publication_date": "2016-09-21",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 436,
+        "feature_id": 436,
+        "source_id": 151,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -14837,7 +16581,11 @@
         "nct": "",
         "publication_date": "2016-09-21",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 437,
+        "feature_id": 437,
+        "source_id": 151,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -14872,7 +16620,11 @@
         "nct": "",
         "publication_date": "2016-09-21",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 438,
+        "feature_id": 438,
+        "source_id": 151,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -14907,7 +16659,11 @@
         "nct": "",
         "publication_date": "2016-09-21",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 439,
+        "feature_id": 439,
+        "source_id": 151,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -14942,7 +16698,11 @@
         "nct": "",
         "publication_date": "2011-12-16",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 440,
+        "feature_id": 440,
+        "source_id": 152,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -14977,7 +16737,11 @@
         "nct": "",
         "publication_date": "2014-02-02",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 441,
+        "feature_id": 441,
+        "source_id": 59,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -15012,7 +16776,11 @@
         "nct": "",
         "publication_date": "2014-02-02",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 442,
+        "feature_id": 442,
+        "source_id": 59,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -15047,7 +16815,11 @@
         "nct": "",
         "publication_date": "2014-02-02",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 443,
+        "feature_id": 443,
+        "source_id": 59,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -15082,7 +16854,11 @@
         "nct": "",
         "publication_date": "2014-02-02",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 444,
+        "feature_id": 444,
+        "source_id": 59,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -15117,7 +16893,11 @@
         "nct": "",
         "publication_date": "2014-02-02",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 445,
+        "feature_id": 445,
+        "source_id": 59,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -15152,7 +16932,11 @@
         "nct": "",
         "publication_date": "2014-02-02",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 446,
+        "feature_id": 446,
+        "source_id": 59,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -15187,7 +16971,11 @@
         "nct": "",
         "publication_date": "2015-02-25",
         "last_updated": "2019-03-07",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 447,
+        "feature_id": 447,
+        "source_id": 85,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -15222,7 +17010,11 @@
         "nct": "",
         "publication_date": "2020-05-01",
         "last_updated": "2020-10-22",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 448,
+        "feature_id": 448,
+        "source_id": 58,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -15257,7 +17049,11 @@
         "nct": "",
         "publication_date": "2018-01-04",
         "last_updated": "2018-09-11",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 449,
+        "feature_id": 449,
+        "source_id": 153,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -15283,16 +17079,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": "",
         "predictive_implication": "Guideline",
-        "description": "Imatinib (Gleevec) is recommended by the National Comprehensive Cancer Network® (NCCN®) as a treatment option for patients with gastrointestinal stromal tumors and mutations in PDGFRA. Mutations in PDGFRA are associated with response to imatinib, with the exception of p.D842V.",
+        "description": "Imatinib (Gleevec) is recommended by the National Comprehensive Cancer Network\u00ae (NCCN\u00ae) as a treatment option for patients with gastrointestinal stromal tumors and mutations in PDGFRA. Mutations in PDGFRA are associated with response to imatinib, with the exception of p.D842V.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Gastrointestinal Stromal Tumors V.2.2019. © National Comprehensive Cancer Network, Inc. 2019. All rights reserved. Accessed August 10 2019. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Gastrointestinal Stromal Tumors V.2.2019. \u00a9 National Comprehensive Cancer Network, Inc. 2019. All rights reserved. Accessed August 10 2019. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/gist_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2019-01-01",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 450,
+        "feature_id": 450,
+        "source_id": 127,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -15318,16 +17118,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": "",
         "predictive_implication": "Guideline",
-        "description": "Imatinib (Gleevec) is recommended by the National Comprehensive Cancer Network® (NCCN®) as a treatment option for patients with gastrointestinal stromal tumors and mutations in PDGFRA. Mutations in PDGFRA are associated with response to imatinib, with the exception of p.D842V.",
+        "description": "Imatinib (Gleevec) is recommended by the National Comprehensive Cancer Network\u00ae (NCCN\u00ae) as a treatment option for patients with gastrointestinal stromal tumors and mutations in PDGFRA. Mutations in PDGFRA are associated with response to imatinib, with the exception of p.D842V.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Gastrointestinal Stromal Tumors V.2.2019. © National Comprehensive Cancer Network, Inc. 2019. All rights reserved. Accessed August 10 2019. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Gastrointestinal Stromal Tumors V.2.2019. \u00a9 National Comprehensive Cancer Network, Inc. 2019. All rights reserved. Accessed August 10 2019. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/gist_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2019-01-01",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 451,
+        "feature_id": 451,
+        "source_id": 127,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -15362,7 +17166,11 @@
         "nct": "",
         "publication_date": "2023-06-01",
         "last_updated": "2021-09-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 452,
+        "feature_id": 452,
+        "source_id": 129,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -15397,7 +17205,11 @@
         "nct": "",
         "publication_date": "2023-06-01",
         "last_updated": "2021-09-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 453,
+        "feature_id": 453,
+        "source_id": 129,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -15432,7 +17244,11 @@
         "nct": "",
         "publication_date": "2023-06-01",
         "last_updated": "2021-09-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 454,
+        "feature_id": 454,
+        "source_id": 129,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -15467,7 +17283,11 @@
         "nct": "",
         "publication_date": "2018-01-04",
         "last_updated": "2018-09-11",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 455,
+        "feature_id": 455,
+        "source_id": 153,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -15502,7 +17322,11 @@
         "nct": "",
         "publication_date": "2020-09-01",
         "last_updated": "2020-11-12",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 456,
+        "feature_id": 456,
+        "source_id": 154,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -15537,7 +17361,11 @@
         "nct": "",
         "publication_date": "2013-10-01",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 457,
+        "feature_id": 457,
+        "source_id": 155,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -15572,7 +17400,11 @@
         "nct": "NCT01576172",
         "publication_date": "2017-12-20",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 458,
+        "feature_id": 458,
+        "source_id": 44,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -15607,7 +17439,11 @@
         "nct": "",
         "publication_date": "2010-07-14",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 459,
+        "feature_id": 459,
+        "source_id": 60,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -15642,7 +17478,11 @@
         "nct": "",
         "publication_date": "2010-07-14",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 460,
+        "feature_id": 460,
+        "source_id": 60,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -15677,7 +17517,11 @@
         "nct": "",
         "publication_date": "2010-07-14",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 461,
+        "feature_id": 461,
+        "source_id": 60,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -15712,7 +17556,11 @@
         "nct": "",
         "publication_date": "2010-07-14",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 462,
+        "feature_id": 462,
+        "source_id": 60,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -15747,7 +17595,11 @@
         "nct": "",
         "publication_date": "2010-07-14",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 463,
+        "feature_id": 463,
+        "source_id": 60,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -15782,7 +17634,11 @@
         "nct": "",
         "publication_date": "2010-07-14",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 464,
+        "feature_id": 464,
+        "source_id": 60,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -15817,7 +17673,11 @@
         "nct": "",
         "publication_date": "2010-07-14",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 465,
+        "feature_id": 465,
+        "source_id": 60,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -15852,7 +17712,11 @@
         "nct": "",
         "publication_date": "2010-07-14",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 466,
+        "feature_id": 466,
+        "source_id": 60,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -15887,7 +17751,11 @@
         "nct": "",
         "publication_date": "2010-07-14",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 467,
+        "feature_id": 467,
+        "source_id": 60,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -15922,7 +17790,11 @@
         "nct": "",
         "publication_date": "2010-07-14",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 468,
+        "feature_id": 468,
+        "source_id": 60,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -15957,7 +17829,11 @@
         "nct": "",
         "publication_date": "2010-07-14",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 469,
+        "feature_id": 469,
+        "source_id": 60,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -15992,7 +17868,11 @@
         "nct": "",
         "publication_date": "2010-07-14",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 470,
+        "feature_id": 470,
+        "source_id": 60,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -16027,7 +17907,11 @@
         "nct": "",
         "publication_date": "2010-07-14",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 471,
+        "feature_id": 471,
+        "source_id": 60,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -16062,7 +17946,11 @@
         "nct": "",
         "publication_date": "2010-07-14",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 472,
+        "feature_id": 472,
+        "source_id": 60,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -16097,7 +17985,11 @@
         "nct": "",
         "publication_date": "2010-07-14",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 473,
+        "feature_id": 473,
+        "source_id": 60,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -16132,7 +18024,11 @@
         "nct": "",
         "publication_date": "2010-07-14",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 474,
+        "feature_id": 474,
+        "source_id": 60,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -16167,7 +18063,11 @@
         "nct": "",
         "publication_date": "2010-07-14",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 475,
+        "feature_id": 475,
+        "source_id": 60,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -16202,7 +18102,11 @@
         "nct": "",
         "publication_date": "2010-07-14",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 476,
+        "feature_id": 476,
+        "source_id": 60,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -16237,7 +18141,11 @@
         "nct": "",
         "publication_date": "2010-07-14",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 477,
+        "feature_id": 477,
+        "source_id": 60,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -16272,7 +18180,11 @@
         "nct": "",
         "publication_date": "2010-07-14",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 478,
+        "feature_id": 478,
+        "source_id": 60,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -16307,7 +18219,11 @@
         "nct": "",
         "publication_date": "2015-07-02",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 479,
+        "feature_id": 479,
+        "source_id": 156,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -16342,7 +18258,11 @@
         "nct": "",
         "publication_date": "2015-07-02",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 480,
+        "feature_id": 480,
+        "source_id": 156,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -16377,7 +18297,11 @@
         "nct": "",
         "publication_date": "2015-07-02",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 481,
+        "feature_id": 481,
+        "source_id": 156,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -16412,7 +18336,11 @@
         "nct": "",
         "publication_date": "2015-07-02",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 482,
+        "feature_id": 482,
+        "source_id": 156,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -16447,7 +18375,11 @@
         "nct": "NCT01876511",
         "publication_date": "2015-06-25",
         "last_updated": "2023-10-31",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 483,
+        "feature_id": 483,
+        "source_id": 147,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -16482,7 +18414,11 @@
         "nct": "",
         "publication_date": "2017-07-05",
         "last_updated": "2023-10-05",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 484,
+        "feature_id": 484,
+        "source_id": 157,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -16517,7 +18453,11 @@
         "nct": "",
         "publication_date": "2017-07-05",
         "last_updated": "2023-10-05",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 485,
+        "feature_id": 485,
+        "source_id": 157,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -16552,7 +18492,11 @@
         "nct": "",
         "publication_date": "2015-07-02",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 486,
+        "feature_id": 486,
+        "source_id": 156,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -16587,7 +18531,11 @@
         "nct": "NCT01876511",
         "publication_date": "2015-06-25",
         "last_updated": "2023-10-31",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 487,
+        "feature_id": 487,
+        "source_id": 147,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -16622,7 +18570,11 @@
         "nct": "",
         "publication_date": "2017-07-05",
         "last_updated": "2023-10-05",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 488,
+        "feature_id": 488,
+        "source_id": 157,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -16657,7 +18609,11 @@
         "nct": "",
         "publication_date": "2017-07-05",
         "last_updated": "2023-10-05",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 489,
+        "feature_id": 489,
+        "source_id": 157,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -16692,7 +18648,11 @@
         "nct": "",
         "publication_date": "2014-12-16",
         "last_updated": "2023-10-05",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 490,
+        "feature_id": 490,
+        "source_id": 158,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -16727,7 +18687,11 @@
         "nct": "",
         "publication_date": "2014-12-16",
         "last_updated": "2023-10-05",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 491,
+        "feature_id": 491,
+        "source_id": 158,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -16762,7 +18726,11 @@
         "nct": "",
         "publication_date": "2014-12-16",
         "last_updated": "2023-10-05",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 492,
+        "feature_id": 492,
+        "source_id": 158,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -16797,7 +18765,11 @@
         "nct": "",
         "publication_date": "2017-02-21",
         "last_updated": "2019-03-07",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 493,
+        "feature_id": 493,
+        "source_id": 159,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -16832,7 +18804,11 @@
         "nct": "",
         "publication_date": "2017-02-21",
         "last_updated": "2019-03-07",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 494,
+        "feature_id": 494,
+        "source_id": 159,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -16867,7 +18843,11 @@
         "nct": "",
         "publication_date": "2017-02-21",
         "last_updated": "2019-03-07",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 495,
+        "feature_id": 495,
+        "source_id": 159,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -16902,7 +18882,11 @@
         "nct": "NCT01576172",
         "publication_date": "2017-12-20",
         "last_updated": "2019-01-29",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 496,
+        "feature_id": 496,
+        "source_id": 44,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -16937,7 +18921,11 @@
         "nct": "",
         "publication_date": "2016-02-04",
         "last_updated": "2018-09-14",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 497,
+        "feature_id": 497,
+        "source_id": 160,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -16972,7 +18960,11 @@
         "nct": "",
         "publication_date": "2016-02-04",
         "last_updated": "2018-09-14",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 498,
+        "feature_id": 498,
+        "source_id": 160,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -17007,7 +18999,11 @@
         "nct": "",
         "publication_date": "2016-02-04",
         "last_updated": "2018-09-14",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 499,
+        "feature_id": 499,
+        "source_id": 160,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -17042,7 +19038,11 @@
         "nct": "",
         "publication_date": "2016-02-04",
         "last_updated": "2018-09-14",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 500,
+        "feature_id": 500,
+        "source_id": 160,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -17068,16 +19068,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": 0,
         "predictive_implication": "Guideline",
-        "description": "The National Comprehensive Cancer Network® (NCCN®) highlights variants in PTPN11 as being associated with shorter overall survival in patients with myelodysplastic syndromes.",
+        "description": "The National Comprehensive Cancer Network\u00ae (NCCN\u00ae) highlights variants in PTPN11 as being associated with shorter overall survival in patients with myelodysplastic syndromes.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Myelodysplastic Syndromes V.2.2023. © National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Myelodysplastic Syndromes V.2.2023. \u00a9 National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/mds_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2023-10-17",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 501,
+        "feature_id": 501,
+        "source_id": 33,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -17112,7 +19116,11 @@
         "nct": "",
         "publication_date": "2020-05-01",
         "last_updated": "2020-10-22",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 502,
+        "feature_id": 502,
+        "source_id": 58,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -17147,7 +19155,11 @@
         "nct": "",
         "publication_date": "2014-02-02",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 503,
+        "feature_id": 503,
+        "source_id": 59,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -17182,7 +19194,11 @@
         "nct": "",
         "publication_date": "2014-02-02",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 504,
+        "feature_id": 504,
+        "source_id": 59,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -17217,7 +19233,11 @@
         "nct": "",
         "publication_date": "2014-02-02",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 505,
+        "feature_id": 505,
+        "source_id": 59,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -17252,7 +19272,11 @@
         "nct": "",
         "publication_date": "2014-02-02",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 506,
+        "feature_id": 506,
+        "source_id": 59,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -17287,7 +19311,11 @@
         "nct": "",
         "publication_date": "2014-02-02",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 507,
+        "feature_id": 507,
+        "source_id": 59,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -17322,7 +19350,11 @@
         "nct": "",
         "publication_date": "2014-02-02",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 508,
+        "feature_id": 508,
+        "source_id": 59,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -17357,7 +19389,11 @@
         "nct": "",
         "publication_date": "2020-05-01",
         "last_updated": "2020-10-22",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 509,
+        "feature_id": 509,
+        "source_id": 58,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -17392,7 +19428,11 @@
         "nct": "",
         "publication_date": "2014-02-02",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 510,
+        "feature_id": 510,
+        "source_id": 59,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -17427,7 +19467,11 @@
         "nct": "",
         "publication_date": "2014-02-02",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 511,
+        "feature_id": 511,
+        "source_id": 59,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -17462,7 +19506,11 @@
         "nct": "",
         "publication_date": "2014-02-02",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 512,
+        "feature_id": 512,
+        "source_id": 59,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -17497,7 +19545,11 @@
         "nct": "",
         "publication_date": "2014-02-02",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 513,
+        "feature_id": 513,
+        "source_id": 59,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -17532,7 +19584,11 @@
         "nct": "",
         "publication_date": "2014-02-02",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 514,
+        "feature_id": 514,
+        "source_id": 59,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -17567,7 +19623,11 @@
         "nct": "",
         "publication_date": "2014-02-02",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 515,
+        "feature_id": 515,
+        "source_id": 59,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -17602,7 +19662,11 @@
         "nct": "",
         "publication_date": "2020-05-01",
         "last_updated": "2020-10-22",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 516,
+        "feature_id": 516,
+        "source_id": 58,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -17637,7 +19701,11 @@
         "nct": "",
         "publication_date": "2020-05-01",
         "last_updated": "2020-10-22",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 517,
+        "feature_id": 517,
+        "source_id": 58,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -17672,7 +19740,11 @@
         "nct": "",
         "publication_date": "2015-04-09",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 518,
+        "feature_id": 518,
+        "source_id": 54,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -17707,7 +19779,11 @@
         "nct": "",
         "publication_date": "2018-08-01",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 519,
+        "feature_id": 519,
+        "source_id": 161,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -17742,7 +19818,11 @@
         "nct": "",
         "publication_date": "2018-08-01",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 520,
+        "feature_id": 520,
+        "source_id": 161,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -17777,7 +19857,11 @@
         "nct": "",
         "publication_date": "2024-09-27",
         "last_updated": "2024-10-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 521,
+        "feature_id": 521,
+        "source_id": 162,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -17803,16 +19887,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": 0,
         "predictive_implication": "Guideline",
-        "description": "The National Comprehensive Cancer Network® (NCCN®) highlights RUNX1 nonsense and frameshift variants as being associated with poor prognosis in patients with myelodysplastic syndromes.",
+        "description": "The National Comprehensive Cancer Network\u00ae (NCCN\u00ae) highlights RUNX1 nonsense and frameshift variants as being associated with poor prognosis in patients with myelodysplastic syndromes.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Myelodysplastic Syndromes V.2.2023. © National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Myelodysplastic Syndromes V.2.2023. \u00a9 National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/mds_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2023-10-17",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 522,
+        "feature_id": 522,
+        "source_id": 33,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -17838,16 +19926,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": 0,
         "predictive_implication": "Guideline",
-        "description": "The National Comprehensive Cancer Network® (NCCN®) highlights RUNX1 nonsense and frameshift variants as being associated with poor prognosis in patients with myelodysplastic syndromes.",
+        "description": "The National Comprehensive Cancer Network\u00ae (NCCN\u00ae) highlights RUNX1 nonsense and frameshift variants as being associated with poor prognosis in patients with myelodysplastic syndromes.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Myelodysplastic Syndromes V.2.2023. © National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Myelodysplastic Syndromes V.2.2023. \u00a9 National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/mds_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2023-10-17",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 523,
+        "feature_id": 523,
+        "source_id": 33,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -17873,16 +19965,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": 0,
         "predictive_implication": "Guideline",
-        "description": "The National Comprehensive Cancer Network® (NCCN®) highlights SETBP1 E858, T864, I865, D868, S869, and G870 missense variants as being associated with disease progression in patients with myelodysplastic syndromes.",
+        "description": "The National Comprehensive Cancer Network\u00ae (NCCN\u00ae) highlights SETBP1 E858, T864, I865, D868, S869, and G870 missense variants as being associated with disease progression in patients with myelodysplastic syndromes.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Myelodysplastic Syndromes V.2.2023. © National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Myelodysplastic Syndromes V.2.2023. \u00a9 National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/mds_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2023-10-17",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 524,
+        "feature_id": 524,
+        "source_id": 33,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -17908,16 +20004,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": 0,
         "predictive_implication": "Guideline",
-        "description": "The National Comprehensive Cancer Network® (NCCN®) highlights SETBP1 E858, T864, I865, D868, S869, and G870 missense variants as being associated with disease progression in patients with myelodysplastic syndromes.",
+        "description": "The National Comprehensive Cancer Network\u00ae (NCCN\u00ae) highlights SETBP1 E858, T864, I865, D868, S869, and G870 missense variants as being associated with disease progression in patients with myelodysplastic syndromes.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Myelodysplastic Syndromes V.2.2023. © National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Myelodysplastic Syndromes V.2.2023. \u00a9 National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/mds_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2023-10-17",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 525,
+        "feature_id": 525,
+        "source_id": 33,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -17943,16 +20043,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": 0,
         "predictive_implication": "Guideline",
-        "description": "The National Comprehensive Cancer Network® (NCCN®) highlights SETBP1 E858, T864, I865, D868, S869, and G870 missense variants as being associated with disease progression in patients with myelodysplastic syndromes.",
+        "description": "The National Comprehensive Cancer Network\u00ae (NCCN\u00ae) highlights SETBP1 E858, T864, I865, D868, S869, and G870 missense variants as being associated with disease progression in patients with myelodysplastic syndromes.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Myelodysplastic Syndromes V.2.2023. © National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Myelodysplastic Syndromes V.2.2023. \u00a9 National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/mds_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2023-10-17",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 526,
+        "feature_id": 526,
+        "source_id": 33,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -17978,16 +20082,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": 0,
         "predictive_implication": "Guideline",
-        "description": "The National Comprehensive Cancer Network® (NCCN®) highlights SETBP1 E858, T864, I865, D868, S869, and G870 missense variants as being associated with disease progression in patients with myelodysplastic syndromes.",
+        "description": "The National Comprehensive Cancer Network\u00ae (NCCN\u00ae) highlights SETBP1 E858, T864, I865, D868, S869, and G870 missense variants as being associated with disease progression in patients with myelodysplastic syndromes.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Myelodysplastic Syndromes V.2.2023. © National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Myelodysplastic Syndromes V.2.2023. \u00a9 National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/mds_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2023-10-17",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 527,
+        "feature_id": 527,
+        "source_id": 33,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -18013,16 +20121,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": 0,
         "predictive_implication": "Guideline",
-        "description": "The National Comprehensive Cancer Network® (NCCN®) highlights SETBP1 E858, T864, I865, D868, S869, and G870 missense variants as being associated with disease progression in patients with myelodysplastic syndromes.",
+        "description": "The National Comprehensive Cancer Network\u00ae (NCCN\u00ae) highlights SETBP1 E858, T864, I865, D868, S869, and G870 missense variants as being associated with disease progression in patients with myelodysplastic syndromes.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Myelodysplastic Syndromes V.2.2023. © National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Myelodysplastic Syndromes V.2.2023. \u00a9 National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/mds_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2023-10-17",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 528,
+        "feature_id": 528,
+        "source_id": 33,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -18048,16 +20160,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": 0,
         "predictive_implication": "Guideline",
-        "description": "The National Comprehensive Cancer Network® (NCCN®) highlights SETBP1 E858, T864, I865, D868, S869, and G870 missense variants as being associated with disease progression in patients with myelodysplastic syndromes.",
+        "description": "The National Comprehensive Cancer Network\u00ae (NCCN\u00ae) highlights SETBP1 E858, T864, I865, D868, S869, and G870 missense variants as being associated with disease progression in patients with myelodysplastic syndromes.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Myelodysplastic Syndromes V.2.2023. © National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Myelodysplastic Syndromes V.2.2023. \u00a9 National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/mds_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2023-10-17",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 529,
+        "feature_id": 529,
+        "source_id": 33,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -18083,16 +20199,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": 0,
         "predictive_implication": "Guideline",
-        "description": "The National Comprehensive Cancer Network® (NCCN®) highlights SETBP1 E858, T864, I865, D868, S869, and G870 missense variants as being associated with disease progression in patients with myelodysplastic syndromes.",
+        "description": "The National Comprehensive Cancer Network\u00ae (NCCN\u00ae) highlights SETBP1 E858, T864, I865, D868, S869, and G870 missense variants as being associated with disease progression in patients with myelodysplastic syndromes.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Myelodysplastic Syndromes V.2.2023. © National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Myelodysplastic Syndromes V.2.2023. \u00a9 National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/mds_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2023-10-17",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 530,
+        "feature_id": 530,
+        "source_id": 33,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -18118,16 +20238,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": 1,
         "predictive_implication": "Guideline",
-        "description": "The National Comprehensive Cancer Network® (NCCN®) highlights SF3B1 E622, Y623, R625, N626, H662, T663, K666, K700E, I704, G740, G742, and D781 missense variants as being associated with a favorable prognosis in patients with myelodysplastic syndromes.",
+        "description": "The National Comprehensive Cancer Network\u00ae (NCCN\u00ae) highlights SF3B1 E622, Y623, R625, N626, H662, T663, K666, K700E, I704, G740, G742, and D781 missense variants as being associated with a favorable prognosis in patients with myelodysplastic syndromes.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Myelodysplastic Syndromes V.2.2023. © National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Myelodysplastic Syndromes V.2.2023. \u00a9 National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/mds_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2023-10-17",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 531,
+        "feature_id": 531,
+        "source_id": 33,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -18153,16 +20277,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": 1,
         "predictive_implication": "Guideline",
-        "description": "The National Comprehensive Cancer Network® (NCCN®) highlights SF3B1 E622, Y623, R625, N626, H662, T663, K666, K700E, I704, G740, G742, and D781 missense variants as being associated with a favorable prognosis in patients with myelodysplastic syndromes.",
+        "description": "The National Comprehensive Cancer Network\u00ae (NCCN\u00ae) highlights SF3B1 E622, Y623, R625, N626, H662, T663, K666, K700E, I704, G740, G742, and D781 missense variants as being associated with a favorable prognosis in patients with myelodysplastic syndromes.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Myelodysplastic Syndromes V.2.2023. © National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Myelodysplastic Syndromes V.2.2023. \u00a9 National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/mds_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2023-10-17",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 532,
+        "feature_id": 532,
+        "source_id": 33,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -18188,16 +20316,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": 1,
         "predictive_implication": "Guideline",
-        "description": "The National Comprehensive Cancer Network® (NCCN®) highlights SF3B1 E622, Y623, R625, N626, H662, T663, K666, K700E, I704, G740, G742, and D781 missense variants as being associated with a favorable prognosis in patients with myelodysplastic syndromes.",
+        "description": "The National Comprehensive Cancer Network\u00ae (NCCN\u00ae) highlights SF3B1 E622, Y623, R625, N626, H662, T663, K666, K700E, I704, G740, G742, and D781 missense variants as being associated with a favorable prognosis in patients with myelodysplastic syndromes.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Myelodysplastic Syndromes V.2.2023. © National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Myelodysplastic Syndromes V.2.2023. \u00a9 National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/mds_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2023-10-17",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 533,
+        "feature_id": 533,
+        "source_id": 33,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -18223,16 +20355,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": 1,
         "predictive_implication": "Guideline",
-        "description": "The National Comprehensive Cancer Network® (NCCN®) highlights SF3B1 E622, Y623, R625, N626, H662, T663, K666, K700E, I704, G740, G742, and D781 missense variants as being associated with a favorable prognosis in patients with myelodysplastic syndromes.",
+        "description": "The National Comprehensive Cancer Network\u00ae (NCCN\u00ae) highlights SF3B1 E622, Y623, R625, N626, H662, T663, K666, K700E, I704, G740, G742, and D781 missense variants as being associated with a favorable prognosis in patients with myelodysplastic syndromes.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Myelodysplastic Syndromes V.2.2023. © National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Myelodysplastic Syndromes V.2.2023. \u00a9 National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/mds_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2023-10-17",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 534,
+        "feature_id": 534,
+        "source_id": 33,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -18258,16 +20394,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": 1,
         "predictive_implication": "Guideline",
-        "description": "The National Comprehensive Cancer Network® (NCCN®) highlights SF3B1 E622, Y623, R625, N626, H662, T663, K666, K700E, I704, G740, G742, and D781 missense variants as being associated with a favorable prognosis in patients with myelodysplastic syndromes.",
+        "description": "The National Comprehensive Cancer Network\u00ae (NCCN\u00ae) highlights SF3B1 E622, Y623, R625, N626, H662, T663, K666, K700E, I704, G740, G742, and D781 missense variants as being associated with a favorable prognosis in patients with myelodysplastic syndromes.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Myelodysplastic Syndromes V.2.2023. © National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Myelodysplastic Syndromes V.2.2023. \u00a9 National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/mds_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2023-10-17",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 535,
+        "feature_id": 535,
+        "source_id": 33,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -18293,16 +20433,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": 1,
         "predictive_implication": "Guideline",
-        "description": "The National Comprehensive Cancer Network® (NCCN®) highlights SF3B1 E622, Y623, R625, N626, H662, T663, K666, K700E, I704, G740, G742, and D781 missense variants as being associated with a favorable prognosis in patients with myelodysplastic syndromes.",
+        "description": "The National Comprehensive Cancer Network\u00ae (NCCN\u00ae) highlights SF3B1 E622, Y623, R625, N626, H662, T663, K666, K700E, I704, G740, G742, and D781 missense variants as being associated with a favorable prognosis in patients with myelodysplastic syndromes.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Myelodysplastic Syndromes V.2.2023. © National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Myelodysplastic Syndromes V.2.2023. \u00a9 National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/mds_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2023-10-17",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 536,
+        "feature_id": 536,
+        "source_id": 33,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -18328,16 +20472,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": 1,
         "predictive_implication": "Guideline",
-        "description": "The National Comprehensive Cancer Network® (NCCN®) highlights SF3B1 E622, Y623, R625, N626, H662, T663, K666, K700E, I704, G740, G742, and D781 missense variants as being associated with a favorable prognosis in patients with myelodysplastic syndromes.",
+        "description": "The National Comprehensive Cancer Network\u00ae (NCCN\u00ae) highlights SF3B1 E622, Y623, R625, N626, H662, T663, K666, K700E, I704, G740, G742, and D781 missense variants as being associated with a favorable prognosis in patients with myelodysplastic syndromes.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Myelodysplastic Syndromes V.2.2023. © National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Myelodysplastic Syndromes V.2.2023. \u00a9 National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/mds_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2023-10-17",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 537,
+        "feature_id": 537,
+        "source_id": 33,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -18363,16 +20511,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": 1,
         "predictive_implication": "Guideline",
-        "description": "The National Comprehensive Cancer Network® (NCCN®) highlights SF3B1 E622, Y623, R625, N626, H662, T663, K666, K700E, I704, G740, G742, and D781 missense variants as being associated with a favorable prognosis in patients with myelodysplastic syndromes.",
+        "description": "The National Comprehensive Cancer Network\u00ae (NCCN\u00ae) highlights SF3B1 E622, Y623, R625, N626, H662, T663, K666, K700E, I704, G740, G742, and D781 missense variants as being associated with a favorable prognosis in patients with myelodysplastic syndromes.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Myelodysplastic Syndromes V.2.2023. © National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Myelodysplastic Syndromes V.2.2023. \u00a9 National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/mds_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2023-10-17",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 538,
+        "feature_id": 538,
+        "source_id": 33,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -18398,16 +20550,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": 1,
         "predictive_implication": "Guideline",
-        "description": "The National Comprehensive Cancer Network® (NCCN®) highlights SF3B1 E622, Y623, R625, N626, H662, T663, K666, K700E, I704, G740, G742, and D781 missense variants as being associated with a favorable prognosis in patients with myelodysplastic syndromes.",
+        "description": "The National Comprehensive Cancer Network\u00ae (NCCN\u00ae) highlights SF3B1 E622, Y623, R625, N626, H662, T663, K666, K700E, I704, G740, G742, and D781 missense variants as being associated with a favorable prognosis in patients with myelodysplastic syndromes.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Myelodysplastic Syndromes V.2.2023. © National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Myelodysplastic Syndromes V.2.2023. \u00a9 National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/mds_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2023-10-17",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 539,
+        "feature_id": 539,
+        "source_id": 33,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -18433,16 +20589,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": 1,
         "predictive_implication": "Guideline",
-        "description": "The National Comprehensive Cancer Network® (NCCN®) highlights SF3B1 E622, Y623, R625, N626, H662, T663, K666, K700E, I704, G740, G742, and D781 missense variants as being associated with a favorable prognosis in patients with myelodysplastic syndromes.",
+        "description": "The National Comprehensive Cancer Network\u00ae (NCCN\u00ae) highlights SF3B1 E622, Y623, R625, N626, H662, T663, K666, K700E, I704, G740, G742, and D781 missense variants as being associated with a favorable prognosis in patients with myelodysplastic syndromes.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Myelodysplastic Syndromes V.2.2023. © National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Myelodysplastic Syndromes V.2.2023. \u00a9 National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/mds_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2023-10-17",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 540,
+        "feature_id": 540,
+        "source_id": 33,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -18468,16 +20628,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": 1,
         "predictive_implication": "Guideline",
-        "description": "The National Comprehensive Cancer Network® (NCCN®) highlights SF3B1 E622, Y623, R625, N626, H662, T663, K666, K700E, I704, G740, G742, and D781 missense variants as being associated with a favorable prognosis in patients with myelodysplastic syndromes.",
+        "description": "The National Comprehensive Cancer Network\u00ae (NCCN\u00ae) highlights SF3B1 E622, Y623, R625, N626, H662, T663, K666, K700E, I704, G740, G742, and D781 missense variants as being associated with a favorable prognosis in patients with myelodysplastic syndromes.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Myelodysplastic Syndromes V.2.2023. © National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Myelodysplastic Syndromes V.2.2023. \u00a9 National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/mds_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2023-10-17",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 541,
+        "feature_id": 541,
+        "source_id": 33,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -18503,16 +20667,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": 1,
         "predictive_implication": "Guideline",
-        "description": "The National Comprehensive Cancer Network® (NCCN®) highlights SF3B1 E622, Y623, R625, N626, H662, T663, K666, K700E, I704, G740, G742, and D781 missense variants as being associated with a favorable prognosis in patients with myelodysplastic syndromes.",
+        "description": "The National Comprehensive Cancer Network\u00ae (NCCN\u00ae) highlights SF3B1 E622, Y623, R625, N626, H662, T663, K666, K700E, I704, G740, G742, and D781 missense variants as being associated with a favorable prognosis in patients with myelodysplastic syndromes.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Myelodysplastic Syndromes V.2.2023. © National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Myelodysplastic Syndromes V.2.2023. \u00a9 National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/mds_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2023-10-17",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 542,
+        "feature_id": 542,
+        "source_id": 33,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -18538,16 +20706,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": 1,
         "predictive_implication": "Guideline",
-        "description": "The National Comprehensive Cancer Network® (NCCN®) highlights SF3B1 E622, Y623, R625, N626, H662, T663, K666, K700E, I704, G740, G742, and D781 missense variants as being associated with a favorable prognosis in patients with myelodysplastic syndromes.",
+        "description": "The National Comprehensive Cancer Network\u00ae (NCCN\u00ae) highlights SF3B1 E622, Y623, R625, N626, H662, T663, K666, K700E, I704, G740, G742, and D781 missense variants as being associated with a favorable prognosis in patients with myelodysplastic syndromes.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Myelodysplastic Syndromes V.2.2023. © National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Myelodysplastic Syndromes V.2.2023. \u00a9 National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/mds_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2023-10-17",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 543,
+        "feature_id": 543,
+        "source_id": 33,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -18573,16 +20745,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": 1,
         "predictive_implication": "Guideline",
-        "description": "The National Comprehensive Cancer Network® (NCCN®) highlights SF3B1 E622, Y623, R625, N626, H662, T663, K666, K700E, I704, G740, G742, and D781 missense variants as being associated with a favorable prognosis in patients with myelodysplastic syndromes.",
+        "description": "The National Comprehensive Cancer Network\u00ae (NCCN\u00ae) highlights SF3B1 E622, Y623, R625, N626, H662, T663, K666, K700E, I704, G740, G742, and D781 missense variants as being associated with a favorable prognosis in patients with myelodysplastic syndromes.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Myelodysplastic Syndromes V.2.2023. © National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Myelodysplastic Syndromes V.2.2023. \u00a9 National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/mds_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2023-10-17",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 544,
+        "feature_id": 544,
+        "source_id": 33,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -18608,16 +20784,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": 1,
         "predictive_implication": "Guideline",
-        "description": "The National Comprehensive Cancer Network® (NCCN®) highlights SF3B1 E622, Y623, R625, N626, H662, T663, K666, K700E, I704, G740, G742, and D781 missense variants as being associated with a favorable prognosis in patients with myelodysplastic syndromes.",
+        "description": "The National Comprehensive Cancer Network\u00ae (NCCN\u00ae) highlights SF3B1 E622, Y623, R625, N626, H662, T663, K666, K700E, I704, G740, G742, and D781 missense variants as being associated with a favorable prognosis in patients with myelodysplastic syndromes.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Myelodysplastic Syndromes V.2.2023. © National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Myelodysplastic Syndromes V.2.2023. \u00a9 National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/mds_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2023-10-17",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 545,
+        "feature_id": 545,
+        "source_id": 33,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -18643,16 +20823,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": 1,
         "predictive_implication": "Guideline",
-        "description": "The National Comprehensive Cancer Network® (NCCN®) highlights SF3B1 E622, Y623, R625, N626, H662, T663, K666, K700E, I704, G740, G742, and D781 missense variants as being associated with a favorable prognosis in patients with myelodysplastic syndromes.",
+        "description": "The National Comprehensive Cancer Network\u00ae (NCCN\u00ae) highlights SF3B1 E622, Y623, R625, N626, H662, T663, K666, K700E, I704, G740, G742, and D781 missense variants as being associated with a favorable prognosis in patients with myelodysplastic syndromes.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Myelodysplastic Syndromes V.2.2023. © National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Myelodysplastic Syndromes V.2.2023. \u00a9 National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/mds_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2023-10-17",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 546,
+        "feature_id": 546,
+        "source_id": 33,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -18678,16 +20862,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": 1,
         "predictive_implication": "Guideline",
-        "description": "The National Comprehensive Cancer Network® (NCCN®) highlights SF3B1 E622, Y623, R625, N626, H662, T663, K666, K700E, I704, G740, G742, and D781 missense variants as being associated with a favorable prognosis in patients with myelodysplastic syndromes.",
+        "description": "The National Comprehensive Cancer Network\u00ae (NCCN\u00ae) highlights SF3B1 E622, Y623, R625, N626, H662, T663, K666, K700E, I704, G740, G742, and D781 missense variants as being associated with a favorable prognosis in patients with myelodysplastic syndromes.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Myelodysplastic Syndromes V.2.2023. © National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Myelodysplastic Syndromes V.2.2023. \u00a9 National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/mds_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2023-10-17",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 547,
+        "feature_id": 547,
+        "source_id": 33,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -18713,16 +20901,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": 1,
         "predictive_implication": "Guideline",
-        "description": "The National Comprehensive Cancer Network® (NCCN®) highlights SF3B1 E622, Y623, R625, N626, H662, T663, K666, K700E, I704, G740, G742, and D781 missense variants as being associated with a favorable prognosis in patients with myelodysplastic syndromes.",
+        "description": "The National Comprehensive Cancer Network\u00ae (NCCN\u00ae) highlights SF3B1 E622, Y623, R625, N626, H662, T663, K666, K700E, I704, G740, G742, and D781 missense variants as being associated with a favorable prognosis in patients with myelodysplastic syndromes.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Myelodysplastic Syndromes V.2.2023. © National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Myelodysplastic Syndromes V.2.2023. \u00a9 National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/mds_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2023-10-17",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 548,
+        "feature_id": 548,
+        "source_id": 33,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -18748,16 +20940,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": 1,
         "predictive_implication": "Guideline",
-        "description": "The National Comprehensive Cancer Network® (NCCN®) highlights SF3B1 E622, Y623, R625, N626, H662, T663, K666, K700E, I704, G740, G742, and D781 missense variants as being associated with a favorable prognosis in patients with myelodysplastic syndromes.",
+        "description": "The National Comprehensive Cancer Network\u00ae (NCCN\u00ae) highlights SF3B1 E622, Y623, R625, N626, H662, T663, K666, K700E, I704, G740, G742, and D781 missense variants as being associated with a favorable prognosis in patients with myelodysplastic syndromes.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Myelodysplastic Syndromes V.2.2023. © National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Myelodysplastic Syndromes V.2.2023. \u00a9 National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/mds_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2023-10-17",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 549,
+        "feature_id": 549,
+        "source_id": 33,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -18792,7 +20988,11 @@
         "nct": "",
         "publication_date": "2017-01-19",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 550,
+        "feature_id": 550,
+        "source_id": 163,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -18827,7 +21027,11 @@
         "nct": "",
         "publication_date": "2017-01-19",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 551,
+        "feature_id": 551,
+        "source_id": 163,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -18862,7 +21066,11 @@
         "nct": "",
         "publication_date": "2017-01-19",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 552,
+        "feature_id": 552,
+        "source_id": 163,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -18897,7 +21105,11 @@
         "nct": "",
         "publication_date": "2020-11-01",
         "last_updated": "2022-10-06",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 553,
+        "feature_id": 553,
+        "source_id": 164,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -18932,7 +21144,11 @@
         "nct": "",
         "publication_date": "2018-11-15",
         "last_updated": "2021-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 554,
+        "feature_id": 554,
+        "source_id": 165,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -18967,7 +21183,11 @@
         "nct": "",
         "publication_date": "2021-09-07",
         "last_updated": "2021-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 555,
+        "feature_id": 555,
+        "source_id": 166,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -18993,16 +21213,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": 0,
         "predictive_implication": "Guideline",
-        "description": "The National Comprehensive Cancer Network® (NCCN®) highlights STAG2 nonsense, frameshift, and splice site variants as being associated with a poor prognosis in patients with myelodysplastic syndromes.",
+        "description": "The National Comprehensive Cancer Network\u00ae (NCCN\u00ae) highlights STAG2 nonsense, frameshift, and splice site variants as being associated with a poor prognosis in patients with myelodysplastic syndromes.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Myelodysplastic Syndromes V.2.2023. © National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Myelodysplastic Syndromes V.2.2023. \u00a9 National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/mds_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2023-10-17",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 556,
+        "feature_id": 556,
+        "source_id": 33,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -19028,16 +21252,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": 0,
         "predictive_implication": "Guideline",
-        "description": "The National Comprehensive Cancer Network® (NCCN®) highlights STAG2 nonsense, frameshift, and splice site variants as being associated with a poor prognosis in patients with myelodysplastic syndromes.",
+        "description": "The National Comprehensive Cancer Network\u00ae (NCCN\u00ae) highlights STAG2 nonsense, frameshift, and splice site variants as being associated with a poor prognosis in patients with myelodysplastic syndromes.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Myelodysplastic Syndromes V.2.2023. © National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Myelodysplastic Syndromes V.2.2023. \u00a9 National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/mds_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2023-10-17",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 557,
+        "feature_id": 557,
+        "source_id": 33,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -19063,16 +21291,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": 0,
         "predictive_implication": "Guideline",
-        "description": "The National Comprehensive Cancer Network® (NCCN®) highlights STAG2 nonsense, frameshift, and splice site variants as being associated with a poor prognosis in patients with myelodysplastic syndromes.",
+        "description": "The National Comprehensive Cancer Network\u00ae (NCCN\u00ae) highlights STAG2 nonsense, frameshift, and splice site variants as being associated with a poor prognosis in patients with myelodysplastic syndromes.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Myelodysplastic Syndromes V.2.2023. © National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Myelodysplastic Syndromes V.2.2023. \u00a9 National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/mds_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2023-10-17",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 558,
+        "feature_id": 558,
+        "source_id": 33,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -19107,7 +21339,11 @@
         "nct": "",
         "publication_date": "2011-04-15",
         "last_updated": "2023-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 559,
+        "feature_id": 559,
+        "source_id": 167,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -19133,16 +21369,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": 0,
         "predictive_implication": "Guideline",
-        "description": "The National Comprehensive Cancer Network® (NCCN®) highlights TP53 nonsense, frameshift, splice site, and missense variants except for P47S and P72R as being associated with a poor prognosis in patients with myelodysplastic syndromes.",
+        "description": "The National Comprehensive Cancer Network\u00ae (NCCN\u00ae) highlights TP53 nonsense, frameshift, splice site, and missense variants except for P47S and P72R as being associated with a poor prognosis in patients with myelodysplastic syndromes.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Myelodysplastic Syndromes V.2.2023. © National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Myelodysplastic Syndromes V.2.2023. \u00a9 National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/mds_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2023-10-17",
         "last_updated": "2023-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 560,
+        "feature_id": 560,
+        "source_id": 33,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -19168,16 +21408,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": 0,
         "predictive_implication": "Guideline",
-        "description": "The National Comprehensive Cancer Network® (NCCN®) highlights TP53 nonsense, frameshift, splice site, and missense variants except for P47S and P72R as being associated with a poor prognosis in patients with myelodysplastic syndromes.",
+        "description": "The National Comprehensive Cancer Network\u00ae (NCCN\u00ae) highlights TP53 nonsense, frameshift, splice site, and missense variants except for P47S and P72R as being associated with a poor prognosis in patients with myelodysplastic syndromes.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Myelodysplastic Syndromes V.2.2023. © National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Myelodysplastic Syndromes V.2.2023. \u00a9 National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/mds_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2023-10-17",
         "last_updated": "2023-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 561,
+        "feature_id": 561,
+        "source_id": 33,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -19203,16 +21447,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": 0,
         "predictive_implication": "Guideline",
-        "description": "The National Comprehensive Cancer Network® (NCCN®) highlights TP53 nonsense, frameshift, splice site, and missense variants except for P47S and P72R as being associated with a poor prognosis in patients with myelodysplastic syndromes.",
+        "description": "The National Comprehensive Cancer Network\u00ae (NCCN\u00ae) highlights TP53 nonsense, frameshift, splice site, and missense variants except for P47S and P72R as being associated with a poor prognosis in patients with myelodysplastic syndromes.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Myelodysplastic Syndromes V.2.2023. © National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Myelodysplastic Syndromes V.2.2023. \u00a9 National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/mds_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2023-10-17",
         "last_updated": "2023-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 562,
+        "feature_id": 562,
+        "source_id": 33,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -19238,16 +21486,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": 0,
         "predictive_implication": "Guideline",
-        "description": "The National Comprehensive Cancer Network® (NCCN®) highlights TP53 nonsense, frameshift, splice site, and missense variants except for P47S and P72R as being associated with a poor prognosis in patients with myelodysplastic syndromes.",
+        "description": "The National Comprehensive Cancer Network\u00ae (NCCN\u00ae) highlights TP53 nonsense, frameshift, splice site, and missense variants except for P47S and P72R as being associated with a poor prognosis in patients with myelodysplastic syndromes.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Myelodysplastic Syndromes V.2.2023. © National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Myelodysplastic Syndromes V.2.2023. \u00a9 National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/mds_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2023-10-17",
         "last_updated": "2023-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 563,
+        "feature_id": 563,
+        "source_id": 33,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -19273,16 +21525,20 @@
         "therapy_resistance": 1,
         "favorable_prognosis": "",
         "predictive_implication": "Guideline",
-        "description": "Lenalidomide (Revlimid) is not recommended by the National Comprehensive Cancer Network® (NCCN®) as a treatment option for patients with myelodysplastic syndromes and nonsense, frameshift, splice site, or missense variants in TP53 except for P47S and P72R. These mutations may predict resistance or relapse to lenalidomide.",
+        "description": "Lenalidomide (Revlimid) is not recommended by the National Comprehensive Cancer Network\u00ae (NCCN\u00ae) as a treatment option for patients with myelodysplastic syndromes and nonsense, frameshift, splice site, or missense variants in TP53 except for P47S and P72R. These mutations may predict resistance or relapse to lenalidomide.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Myelodysplastic Syndromes V.2.2023. © National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Myelodysplastic Syndromes V.2.2023. \u00a9 National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/mds_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2023-10-17",
         "last_updated": "2023-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 564,
+        "feature_id": 564,
+        "source_id": 33,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -19308,16 +21564,20 @@
         "therapy_resistance": 1,
         "favorable_prognosis": "",
         "predictive_implication": "Guideline",
-        "description": "Lenalidomide (Revlimid) is not recommended by the National Comprehensive Cancer Network® (NCCN®) as a treatment option for patients with myelodysplastic syndromes and nonsense, frameshift, splice site, or missense variants in TP53 except for P47S and P72R. These mutations may predict resistance or relapse to lenalidomide.",
+        "description": "Lenalidomide (Revlimid) is not recommended by the National Comprehensive Cancer Network\u00ae (NCCN\u00ae) as a treatment option for patients with myelodysplastic syndromes and nonsense, frameshift, splice site, or missense variants in TP53 except for P47S and P72R. These mutations may predict resistance or relapse to lenalidomide.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Myelodysplastic Syndromes V.2.2023. © National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Myelodysplastic Syndromes V.2.2023. \u00a9 National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/mds_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2023-10-17",
         "last_updated": "2023-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 565,
+        "feature_id": 565,
+        "source_id": 33,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -19343,16 +21603,20 @@
         "therapy_resistance": 1,
         "favorable_prognosis": "",
         "predictive_implication": "Guideline",
-        "description": "Lenalidomide (Revlimid) is not recommended by the National Comprehensive Cancer Network® (NCCN®) as a treatment option for patients with myelodysplastic syndromes and nonsense, frameshift, splice site, or missense variants in TP53 except for P47S and P72R. These mutations may predict resistance or relapse to lenalidomide.",
+        "description": "Lenalidomide (Revlimid) is not recommended by the National Comprehensive Cancer Network\u00ae (NCCN\u00ae) as a treatment option for patients with myelodysplastic syndromes and nonsense, frameshift, splice site, or missense variants in TP53 except for P47S and P72R. These mutations may predict resistance or relapse to lenalidomide.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Myelodysplastic Syndromes V.2.2023. © National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Myelodysplastic Syndromes V.2.2023. \u00a9 National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/mds_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2023-10-17",
         "last_updated": "2023-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 566,
+        "feature_id": 566,
+        "source_id": 33,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -19378,16 +21642,20 @@
         "therapy_resistance": 1,
         "favorable_prognosis": "",
         "predictive_implication": "Guideline",
-        "description": "Lenalidomide (Revlimid) is not recommended by the National Comprehensive Cancer Network® (NCCN®) as a treatment option for patients with myelodysplastic syndromes and nonsense, frameshift, splice site, or missense variants in TP53 except for P47S and P72R. These mutations may predict resistance or relapse to lenalidomide.",
+        "description": "Lenalidomide (Revlimid) is not recommended by the National Comprehensive Cancer Network\u00ae (NCCN\u00ae) as a treatment option for patients with myelodysplastic syndromes and nonsense, frameshift, splice site, or missense variants in TP53 except for P47S and P72R. These mutations may predict resistance or relapse to lenalidomide.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Myelodysplastic Syndromes V.2.2023. © National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Myelodysplastic Syndromes V.2.2023. \u00a9 National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/mds_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2023-10-17",
         "last_updated": "2023-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 567,
+        "feature_id": 567,
+        "source_id": 33,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -19422,7 +21690,11 @@
         "nct": "",
         "publication_date": "2010-12-07",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 568,
+        "feature_id": 568,
+        "source_id": 168,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -19457,7 +21729,11 @@
         "nct": "NCT01576172",
         "publication_date": "2017-12-20",
         "last_updated": "2019-01-29",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 569,
+        "feature_id": 569,
+        "source_id": 44,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -19492,7 +21768,11 @@
         "nct": "",
         "publication_date": "2019-09-13",
         "last_updated": "2019-08-08",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 570,
+        "feature_id": 570,
+        "source_id": 138,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -19527,7 +21807,11 @@
         "nct": "",
         "publication_date": "2020-02-01",
         "last_updated": "2023-10-05",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 571,
+        "feature_id": 571,
+        "source_id": 169,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -19562,7 +21846,11 @@
         "nct": "",
         "publication_date": "2012-08-23",
         "last_updated": "2018-09-19",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 572,
+        "feature_id": 572,
+        "source_id": 110,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -19597,7 +21885,11 @@
         "nct": "",
         "publication_date": "2012-08-23",
         "last_updated": "2018-09-19",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 573,
+        "feature_id": 573,
+        "source_id": 110,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -19632,7 +21924,11 @@
         "nct": "",
         "publication_date": "2014-10-09",
         "last_updated": "2018-09-19",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 574,
+        "feature_id": 574,
+        "source_id": 111,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -19667,7 +21963,11 @@
         "nct": "",
         "publication_date": "2014-10-09",
         "last_updated": "2018-09-19",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 575,
+        "feature_id": 575,
+        "source_id": 111,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -19702,7 +22002,11 @@
         "nct": "NCT00903175",
         "publication_date": "2019-01-15",
         "last_updated": "2019-08-12",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 576,
+        "feature_id": 576,
+        "source_id": 149,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -19737,7 +22041,11 @@
         "nct": "NCT00903175",
         "publication_date": "2019-01-15",
         "last_updated": "2019-08-12",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 577,
+        "feature_id": 577,
+        "source_id": 149,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -19772,7 +22080,11 @@
         "nct": "",
         "publication_date": "2020-02-01",
         "last_updated": "2023-10-05",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 578,
+        "feature_id": 578,
+        "source_id": 169,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -19807,7 +22119,11 @@
         "nct": "",
         "publication_date": "2012-08-23",
         "last_updated": "2018-09-19",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 579,
+        "feature_id": 579,
+        "source_id": 110,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -19842,7 +22158,11 @@
         "nct": "",
         "publication_date": "2012-08-23",
         "last_updated": "2018-09-19",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 580,
+        "feature_id": 580,
+        "source_id": 110,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -19877,7 +22197,11 @@
         "nct": "",
         "publication_date": "2014-10-09",
         "last_updated": "2018-09-19",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 581,
+        "feature_id": 581,
+        "source_id": 111,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -19912,7 +22236,11 @@
         "nct": "",
         "publication_date": "2014-10-09",
         "last_updated": "2018-09-19",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 582,
+        "feature_id": 582,
+        "source_id": 111,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -19938,16 +22266,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": 0,
         "predictive_implication": "Guideline",
-        "description": "The National Comprehensive Cancer Network® (NCCN®) highlights ZRSR2 nonsense and frameshift variants as being associated with a poor prognosis in patients with myelodysplastic syndromes.",
+        "description": "The National Comprehensive Cancer Network\u00ae (NCCN\u00ae) highlights ZRSR2 nonsense and frameshift variants as being associated with a poor prognosis in patients with myelodysplastic syndromes.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Myelodysplastic Syndromes V.2.2023. © National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Myelodysplastic Syndromes V.2.2023. \u00a9 National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/mds_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2023-10-17",
         "last_updated": "2023-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 583,
+        "feature_id": 583,
+        "source_id": 33,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -19973,16 +22305,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": 0,
         "predictive_implication": "Guideline",
-        "description": "The National Comprehensive Cancer Network® (NCCN®) highlights ZRSR2 nonsense and frameshift variants as being associated with a poor prognosis in patients with myelodysplastic syndromes.",
+        "description": "The National Comprehensive Cancer Network\u00ae (NCCN\u00ae) highlights ZRSR2 nonsense and frameshift variants as being associated with a poor prognosis in patients with myelodysplastic syndromes.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Myelodysplastic Syndromes V.2.2023. © National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Myelodysplastic Syndromes V.2.2023. \u00a9 National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/mds_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2023-10-17",
         "last_updated": "2023-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 584,
+        "feature_id": 584,
+        "source_id": 33,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Germline Variant",
@@ -20019,7 +22355,11 @@
         "nct": "",
         "publication_date": "2009-08-01",
         "last_updated": "2019-09-12",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 585,
+        "feature_id": 585,
+        "source_id": 170,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Germline Variant",
@@ -20056,7 +22396,11 @@
         "nct": "",
         "publication_date": "2018-02-22",
         "last_updated": "2019-04-16",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 586,
+        "feature_id": 586,
+        "source_id": 171,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Germline Variant",
@@ -20093,7 +22437,11 @@
         "nct": "",
         "publication_date": "2017-04-01",
         "last_updated": "2019-08-15",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 587,
+        "feature_id": 587,
+        "source_id": 57,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Germline Variant",
@@ -20130,7 +22478,11 @@
         "nct": "",
         "publication_date": "2014-02-02",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 588,
+        "feature_id": 588,
+        "source_id": 59,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Germline Variant",
@@ -20167,7 +22519,11 @@
         "nct": "",
         "publication_date": "2014-02-02",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 589,
+        "feature_id": 589,
+        "source_id": 59,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Germline Variant",
@@ -20204,7 +22560,11 @@
         "nct": "",
         "publication_date": "2014-02-02",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 590,
+        "feature_id": 590,
+        "source_id": 59,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Germline Variant",
@@ -20241,7 +22601,11 @@
         "nct": "",
         "publication_date": "2014-02-02",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 591,
+        "feature_id": 591,
+        "source_id": 59,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Germline Variant",
@@ -20278,7 +22642,11 @@
         "nct": "",
         "publication_date": "2014-02-02",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 592,
+        "feature_id": 592,
+        "source_id": 59,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Germline Variant",
@@ -20315,7 +22683,11 @@
         "nct": "",
         "publication_date": "2014-02-02",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 593,
+        "feature_id": 593,
+        "source_id": 59,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Germline Variant",
@@ -20352,7 +22724,11 @@
         "nct": "",
         "publication_date": "2020-04-01",
         "last_updated": "2020-10-15",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 594,
+        "feature_id": 594,
+        "source_id": 86,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Germline Variant",
@@ -20389,7 +22765,11 @@
         "nct": "",
         "publication_date": "2020-04-01",
         "last_updated": "2020-10-15",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 595,
+        "feature_id": 595,
+        "source_id": 86,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Germline Variant",
@@ -20426,7 +22806,11 @@
         "nct": "",
         "publication_date": "2020-04-01",
         "last_updated": "2020-10-15",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 596,
+        "feature_id": 596,
+        "source_id": 86,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Germline Variant",
@@ -20463,7 +22847,11 @@
         "nct": "",
         "publication_date": "2023-03-11",
         "last_updated": "2023-07-06",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 597,
+        "feature_id": 597,
+        "source_id": 172,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Germline Variant",
@@ -20500,7 +22888,11 @@
         "nct": "NCT01844986",
         "publication_date": "2020-11-01",
         "last_updated": "2020-11-12",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 598,
+        "feature_id": 598,
+        "source_id": 81,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Germline Variant",
@@ -20537,7 +22929,11 @@
         "nct": "NCT01844986",
         "publication_date": "2020-11-01",
         "last_updated": "2020-11-12",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 599,
+        "feature_id": 599,
+        "source_id": 81,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Germline Variant",
@@ -20574,7 +22970,11 @@
         "nct": "NCT01844986",
         "publication_date": "2020-11-01",
         "last_updated": "2020-11-12",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 600,
+        "feature_id": 600,
+        "source_id": 81,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Germline Variant",
@@ -20602,16 +23002,20 @@
         "favorable_prognosis": "",
         "adverse_event_risk": "",
         "predictive_implication": "Guideline",
-        "description": "Olaparib (Lynparza) is recommended by the National Comprehensive Cancer Network® (NCCN®) as a treatment option for patients with chemotherapy-refractory ovarian cancer. These patients have higher response rates to PARP inhibitor therapy in the presence of BRCA1 and BRCA2 mutations, particularly concomittant with platinum-sensitive disease. Platinum-resistant disease partially abrogates olaparib sensitvity in the setting of BRCA1 and BRCA2 mutations.",
+        "description": "Olaparib (Lynparza) is recommended by the National Comprehensive Cancer Network\u00ae (NCCN\u00ae) as a treatment option for patients with chemotherapy-refractory ovarian cancer. These patients have higher response rates to PARP inhibitor therapy in the presence of BRCA1 and BRCA2 mutations, particularly concomittant with platinum-sensitive disease. Platinum-resistant disease partially abrogates olaparib sensitvity in the setting of BRCA1 and BRCA2 mutations.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Ovarian Cancer V.1.2016. © National Comprehensive Cancer Network, Inc. 2016. All rights reserved. Accessed November 5 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Ovarian Cancer V.1.2016. \u00a9 National Comprehensive Cancer Network, Inc. 2016. All rights reserved. Accessed November 5 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/ovarian_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2016-01-01",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 601,
+        "feature_id": 601,
+        "source_id": 173,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Germline Variant",
@@ -20648,7 +23052,11 @@
         "nct": "",
         "publication_date": "2015-02-25",
         "last_updated": "2019-03-07",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 602,
+        "feature_id": 602,
+        "source_id": 85,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Germline Variant",
@@ -20676,16 +23084,20 @@
         "favorable_prognosis": "",
         "adverse_event_risk": "",
         "predictive_implication": "Guideline",
-        "description": "Olaparib (Lynparza) is recommended by the National Comprehensive Cancer Network® (NCCN®) as a treatment option for patients with recurrent or stage IV disease with HER2-negative tumors with germline BRCA1/2 variants.",
+        "description": "Olaparib (Lynparza) is recommended by the National Comprehensive Cancer Network\u00ae (NCCN\u00ae) as a treatment option for patients with recurrent or stage IV disease with HER2-negative tumors with germline BRCA1/2 variants.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Invasive Breast Cancer NCCN Evidence Blocks V.2.2019. © National Comprehensive Cancer Network, Inc. 2019. All rights reserved. Accessed August 10 2019]. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Invasive Breast Cancer NCCN Evidence Blocks V.2.2019. \u00a9 National Comprehensive Cancer Network, Inc. 2019. All rights reserved. Accessed August 10 2019]. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/breast_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2019-07-02",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 603,
+        "feature_id": 603,
+        "source_id": 174,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Germline Variant",
@@ -20713,16 +23125,20 @@
         "favorable_prognosis": "",
         "adverse_event_risk": "",
         "predictive_implication": "Guideline",
-        "description": "Olaparib (Lynparza) is recommended by the National Comprehensive Cancer Network® (NCCN®) as a treatment option for patients with recurrent or stage IV disease with HER2-negative tumors with germline BRCA1/2 variants",
+        "description": "Olaparib (Lynparza) is recommended by the National Comprehensive Cancer Network\u00ae (NCCN\u00ae) as a treatment option for patients with recurrent or stage IV disease with HER2-negative tumors with germline BRCA1/2 variants",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Invasive Breast Cancer NCCN Evidence Blocks V.2.2019. © National Comprehensive Cancer Network, Inc. 2019. All rights reserved. Accessed August 10 2019]. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Invasive Breast Cancer NCCN Evidence Blocks V.2.2019. \u00a9 National Comprehensive Cancer Network, Inc. 2019. All rights reserved. Accessed August 10 2019]. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/breast_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2019-07-02",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 604,
+        "feature_id": 604,
+        "source_id": 174,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Germline Variant",
@@ -20750,16 +23166,20 @@
         "favorable_prognosis": "",
         "adverse_event_risk": "",
         "predictive_implication": "Guideline",
-        "description": "Carboplatin is recommended by the National Comprehensive Cancer Network® (NCCN®) as a treatment option for patients with recurrent or stage IV disease with triple-negative tumors and germline BRCA 1/2 variants.",
+        "description": "Carboplatin is recommended by the National Comprehensive Cancer Network\u00ae (NCCN\u00ae) as a treatment option for patients with recurrent or stage IV disease with triple-negative tumors and germline BRCA 1/2 variants.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Invasive Breast Cancer NCCN Evidence Blocks V.2.2019. © National Comprehensive Cancer Network, Inc. 2019. All rights reserved. Accessed August 10 2019]. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Invasive Breast Cancer NCCN Evidence Blocks V.2.2019. \u00a9 National Comprehensive Cancer Network, Inc. 2019. All rights reserved. Accessed August 10 2019]. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/breast_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2019-07-02",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 605,
+        "feature_id": 605,
+        "source_id": 174,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Germline Variant",
@@ -20787,16 +23207,20 @@
         "favorable_prognosis": "",
         "adverse_event_risk": "",
         "predictive_implication": "Guideline",
-        "description": "Cisplatin is recommended by the National Comprehensive Cancer Network® (NCCN®) as a treatment option for patients with recurrent or stage IV disease with triple-negative tumors and germline BRCA 1/2 variants.",
+        "description": "Cisplatin is recommended by the National Comprehensive Cancer Network\u00ae (NCCN\u00ae) as a treatment option for patients with recurrent or stage IV disease with triple-negative tumors and germline BRCA 1/2 variants.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Invasive Breast Cancer NCCN Evidence Blocks V.2.2019. © National Comprehensive Cancer Network, Inc. 2019. All rights reserved. Accessed August 10 2019]. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Invasive Breast Cancer NCCN Evidence Blocks V.2.2019. \u00a9 National Comprehensive Cancer Network, Inc. 2019. All rights reserved. Accessed August 10 2019]. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/breast_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2019-07-02",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 606,
+        "feature_id": 606,
+        "source_id": 174,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Germline Variant",
@@ -20833,7 +23257,11 @@
         "nct": "NCT01945775",
         "publication_date": "2020-10-01",
         "last_updated": "2021-09-16",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 607,
+        "feature_id": 607,
+        "source_id": 175,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Germline Variant",
@@ -20870,7 +23298,11 @@
         "nct": "",
         "publication_date": "2020-04-01",
         "last_updated": "2020-10-15",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 608,
+        "feature_id": 608,
+        "source_id": 86,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Germline Variant",
@@ -20907,7 +23339,11 @@
         "nct": "",
         "publication_date": "2020-04-01",
         "last_updated": "2020-10-15",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 609,
+        "feature_id": 609,
+        "source_id": 86,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Germline Variant",
@@ -20944,7 +23380,11 @@
         "nct": "",
         "publication_date": "2020-04-01",
         "last_updated": "2020-10-15",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 610,
+        "feature_id": 610,
+        "source_id": 86,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Germline Variant",
@@ -20981,7 +23421,11 @@
         "nct": "",
         "publication_date": "2020-05-01",
         "last_updated": "2020-10-22",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 611,
+        "feature_id": 611,
+        "source_id": 58,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Germline Variant",
@@ -21009,16 +23453,20 @@
         "favorable_prognosis": "",
         "adverse_event_risk": "",
         "predictive_implication": "Guideline",
-        "description": "Olaparib (Lynparza) is recommended by the National Comprehensive Cancer Network® (NCCN®) as a treatment option for patients with recurrent or stage IV disease that are also HER2-negative tumors with germline BRCA1/2 variants.",
+        "description": "Olaparib (Lynparza) is recommended by the National Comprehensive Cancer Network\u00ae (NCCN\u00ae) as a treatment option for patients with recurrent or stage IV disease that are also HER2-negative tumors with germline BRCA1/2 variants.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Invasive Breast Cancer NCCN Evidence Blocks V.2.2019. © National Comprehensive Cancer Network, Inc. 2019. All rights reserved. Accessed August 10 2019]. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Invasive Breast Cancer NCCN Evidence Blocks V.2.2019. \u00a9 National Comprehensive Cancer Network, Inc. 2019. All rights reserved. Accessed August 10 2019]. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/breast_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2019-07-02",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 612,
+        "feature_id": 612,
+        "source_id": 174,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Germline Variant",
@@ -21046,16 +23494,20 @@
         "favorable_prognosis": "",
         "adverse_event_risk": "",
         "predictive_implication": "Guideline",
-        "description": "Talazoparib (Talzenna) is recommended by the National Comprehensive Cancer Network® (NCCN®) as a treatment option for patients with recurrent or stage IV disease that are also HER2-negative tumors with germline BRCA1/2 variants.",
+        "description": "Talazoparib (Talzenna) is recommended by the National Comprehensive Cancer Network\u00ae (NCCN\u00ae) as a treatment option for patients with recurrent or stage IV disease that are also HER2-negative tumors with germline BRCA1/2 variants.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Invasive Breast Cancer NCCN Evidence Blocks V.2.2019. © National Comprehensive Cancer Network, Inc. 2019. All rights reserved. Accessed August 10 2019]. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Invasive Breast Cancer NCCN Evidence Blocks V.2.2019. \u00a9 National Comprehensive Cancer Network, Inc. 2019. All rights reserved. Accessed August 10 2019]. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/breast_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2019-07-02",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 613,
+        "feature_id": 613,
+        "source_id": 174,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Germline Variant",
@@ -21083,16 +23535,20 @@
         "favorable_prognosis": "",
         "adverse_event_risk": "",
         "predictive_implication": "Guideline",
-        "description": "Carboplatin is recommended by the National Comprehensive Cancer Network® (NCCN®) as a treatment option for patients with recurrent or stage IV disease with triple-negative tumors and germline BRCA 1/2 variants.",
+        "description": "Carboplatin is recommended by the National Comprehensive Cancer Network\u00ae (NCCN\u00ae) as a treatment option for patients with recurrent or stage IV disease with triple-negative tumors and germline BRCA 1/2 variants.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Invasive Breast Cancer NCCN Evidence Blocks V.2.2019. © National Comprehensive Cancer Network, Inc. 2019. All rights reserved. Accessed August 10 2019]. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Invasive Breast Cancer NCCN Evidence Blocks V.2.2019. \u00a9 National Comprehensive Cancer Network, Inc. 2019. All rights reserved. Accessed August 10 2019]. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/breast_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2019-07-02",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 614,
+        "feature_id": 614,
+        "source_id": 174,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Germline Variant",
@@ -21120,16 +23576,20 @@
         "favorable_prognosis": "",
         "adverse_event_risk": "",
         "predictive_implication": "Guideline",
-        "description": "Cisplatin is recommended by the National Comprehensive Cancer Network® (NCCN®) as a treatment option for patients with recurrent or stage IV disease with triple-negative tumors and germline BRCA 1/2 variants.",
+        "description": "Cisplatin is recommended by the National Comprehensive Cancer Network\u00ae (NCCN\u00ae) as a treatment option for patients with recurrent or stage IV disease with triple-negative tumors and germline BRCA 1/2 variants.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Invasive Breast Cancer NCCN Evidence Blocks V.2.2019. © National Comprehensive Cancer Network, Inc. 2019. All rights reserved. Accessed August 10 2019]. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Invasive Breast Cancer NCCN Evidence Blocks V.2.2019. \u00a9 National Comprehensive Cancer Network, Inc. 2019. All rights reserved. Accessed August 10 2019]. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/breast_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2019-07-02",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 615,
+        "feature_id": 615,
+        "source_id": 174,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Germline Variant",
@@ -21166,7 +23626,11 @@
         "nct": "NCT01945775",
         "publication_date": "2020-10-01",
         "last_updated": "2021-09-16",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 616,
+        "feature_id": 616,
+        "source_id": 176,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Germline Variant",
@@ -21203,7 +23667,11 @@
         "nct": "",
         "publication_date": "2023-03-11",
         "last_updated": "2023-07-06",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 617,
+        "feature_id": 617,
+        "source_id": 172,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Germline Variant",
@@ -21240,7 +23708,11 @@
         "nct": "",
         "publication_date": "2020-04-01",
         "last_updated": "2020-10-15",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 618,
+        "feature_id": 618,
+        "source_id": 86,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Germline Variant",
@@ -21277,7 +23749,11 @@
         "nct": "",
         "publication_date": "2020-04-01",
         "last_updated": "2020-10-15",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 619,
+        "feature_id": 619,
+        "source_id": 86,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Germline Variant",
@@ -21314,7 +23790,11 @@
         "nct": "",
         "publication_date": "2020-04-01",
         "last_updated": "2020-10-15",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 620,
+        "feature_id": 620,
+        "source_id": 86,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Germline Variant",
@@ -21351,7 +23831,11 @@
         "nct": "NCT01844986",
         "publication_date": "2020-11-01",
         "last_updated": "2020-11-12",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 621,
+        "feature_id": 621,
+        "source_id": 177,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Germline Variant",
@@ -21388,7 +23872,11 @@
         "nct": "NCT01844986",
         "publication_date": "2020-11-01",
         "last_updated": "2020-11-12",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 622,
+        "feature_id": 622,
+        "source_id": 177,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Germline Variant",
@@ -21425,7 +23913,11 @@
         "nct": "NCT01844986",
         "publication_date": "2020-11-01",
         "last_updated": "2020-11-12",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 623,
+        "feature_id": 623,
+        "source_id": 177,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Germline Variant",
@@ -21453,16 +23945,20 @@
         "favorable_prognosis": "",
         "adverse_event_risk": "",
         "predictive_implication": "Guideline",
-        "description": "Olaparib (Lynparza) is recommended by the National Comprehensive Cancer Network® (NCCN®) as a treatment option for patients with chemotherapy-refractory ovarian cancer. These patients have higher response rates to PARP inhibitor therapy in the presence of BRCA1 and BRCA2 mutations, particularly concomittant with platinum-sensitive disease. Platinum-resistant disease partially abrogates olaparib sensitvity in the setting of BRCA1 and BRCA2 mutations.",
+        "description": "Olaparib (Lynparza) is recommended by the National Comprehensive Cancer Network\u00ae (NCCN\u00ae) as a treatment option for patients with chemotherapy-refractory ovarian cancer. These patients have higher response rates to PARP inhibitor therapy in the presence of BRCA1 and BRCA2 mutations, particularly concomittant with platinum-sensitive disease. Platinum-resistant disease partially abrogates olaparib sensitvity in the setting of BRCA1 and BRCA2 mutations.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Ovarian Cancer V.1.2016. © National Comprehensive Cancer Network, Inc. 2016. All rights reserved. Accessed November 5 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Ovarian Cancer V.1.2016. \u00a9 National Comprehensive Cancer Network, Inc. 2016. All rights reserved. Accessed November 5 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/ovarian_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2016-01-01",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 624,
+        "feature_id": 624,
+        "source_id": 173,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Germline Variant",
@@ -21499,7 +23995,11 @@
         "nct": "NCT01682772",
         "publication_date": "2015-10-29",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 625,
+        "feature_id": 625,
+        "source_id": 88,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Germline Variant",
@@ -21536,7 +24036,11 @@
         "nct": "",
         "publication_date": "2015-02-25",
         "last_updated": "2019-03-07",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 626,
+        "feature_id": 626,
+        "source_id": 85,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Germline Variant",
@@ -21573,7 +24077,11 @@
         "nct": "",
         "publication_date": "2020-05-01",
         "last_updated": "2020-10-22",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 627,
+        "feature_id": 627,
+        "source_id": 58,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Germline Variant",
@@ -21610,7 +24118,11 @@
         "nct": "",
         "publication_date": "2014-02-02",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 628,
+        "feature_id": 628,
+        "source_id": 59,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Germline Variant",
@@ -21647,7 +24159,11 @@
         "nct": "",
         "publication_date": "2014-02-02",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 629,
+        "feature_id": 629,
+        "source_id": 59,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Germline Variant",
@@ -21684,7 +24200,11 @@
         "nct": "",
         "publication_date": "2014-02-02",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 630,
+        "feature_id": 630,
+        "source_id": 59,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Germline Variant",
@@ -21721,7 +24241,11 @@
         "nct": "",
         "publication_date": "2014-02-02",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 631,
+        "feature_id": 631,
+        "source_id": 59,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Germline Variant",
@@ -21758,7 +24282,11 @@
         "nct": "",
         "publication_date": "2014-02-02",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 632,
+        "feature_id": 632,
+        "source_id": 59,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Germline Variant",
@@ -21795,7 +24323,11 @@
         "nct": "",
         "publication_date": "2014-02-02",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 633,
+        "feature_id": 633,
+        "source_id": 59,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Germline Variant",
@@ -21832,7 +24364,11 @@
         "nct": "",
         "publication_date": "2014-02-02",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 634,
+        "feature_id": 634,
+        "source_id": 59,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Germline Variant",
@@ -21869,7 +24405,11 @@
         "nct": "",
         "publication_date": "2014-02-02",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 635,
+        "feature_id": 635,
+        "source_id": 59,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Germline Variant",
@@ -21906,7 +24446,11 @@
         "nct": "",
         "publication_date": "2014-02-02",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 636,
+        "feature_id": 636,
+        "source_id": 59,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Germline Variant",
@@ -21943,7 +24487,11 @@
         "nct": "",
         "publication_date": "2014-02-02",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 637,
+        "feature_id": 637,
+        "source_id": 59,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Germline Variant",
@@ -21980,7 +24528,11 @@
         "nct": "",
         "publication_date": "2014-02-02",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 638,
+        "feature_id": 638,
+        "source_id": 59,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Germline Variant",
@@ -22017,7 +24569,11 @@
         "nct": "",
         "publication_date": "2014-02-02",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 639,
+        "feature_id": 639,
+        "source_id": 59,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Germline Variant",
@@ -22054,7 +24610,11 @@
         "nct": "",
         "publication_date": "2019-01-24",
         "last_updated": "2019-04-16",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 640,
+        "feature_id": 640,
+        "source_id": 178,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Germline Variant",
@@ -22084,14 +24644,18 @@
         "predictive_implication": "Guideline",
         "description": "Patients with defects in DNA mismatch repair genes often have a favorable prognosis and a decreased likelihood of metastasis. These patients do not benefit from, and may be resistant to, 5-fluorouracil therapy.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Colon Cancer V.2.2016. © National Comprehensive Cancer Network, Inc. 2016. All rights reserved. Accessed November 5 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Colon Cancer V.2.2016. \u00a9 National Comprehensive Cancer Network, Inc. 2016. All rights reserved. Accessed November 5 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/colon_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2016-01-01",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 641,
+        "feature_id": 641,
+        "source_id": 80,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Germline Variant",
@@ -22128,7 +24692,11 @@
         "nct": "",
         "publication_date": "2016-06-22",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 642,
+        "feature_id": 642,
+        "source_id": 179,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Germline Variant",
@@ -22165,7 +24733,11 @@
         "nct": "",
         "publication_date": "2016-06-22",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 643,
+        "feature_id": 643,
+        "source_id": 179,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Germline Variant",
@@ -22202,7 +24774,11 @@
         "nct": "",
         "publication_date": "2016-06-22",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 644,
+        "feature_id": 644,
+        "source_id": 179,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Germline Variant",
@@ -22239,7 +24815,11 @@
         "nct": "",
         "publication_date": "2016-06-22",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 645,
+        "feature_id": 645,
+        "source_id": 179,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Germline Variant",
@@ -22276,7 +24856,11 @@
         "nct": "",
         "publication_date": "2016-06-22",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 646,
+        "feature_id": 646,
+        "source_id": 179,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Germline Variant",
@@ -22306,14 +24890,18 @@
         "predictive_implication": "Guideline",
         "description": "Patients with defects in DNA mismatch repair genes often have a favorable prognosis and a decreased likelihood of metastasis. These patients do not benefit from, and may be resistant to, 5-fluorouracil therapy.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Colon Cancer V.2.2016. © National Comprehensive Cancer Network, Inc. 2016. All rights reserved. Accessed November 5 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Colon Cancer V.2.2016. \u00a9 National Comprehensive Cancer Network, Inc. 2016. All rights reserved. Accessed November 5 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/colon_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2016-01-01",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 647,
+        "feature_id": 647,
+        "source_id": 80,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Germline Variant",
@@ -22350,7 +24938,11 @@
         "nct": "NCT01876511",
         "publication_date": "2015-06-25",
         "last_updated": "2023-10-31",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 648,
+        "feature_id": 648,
+        "source_id": 147,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Germline Variant",
@@ -22387,7 +24979,11 @@
         "nct": "",
         "publication_date": "2016-06-22",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 649,
+        "feature_id": 649,
+        "source_id": 179,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Germline Variant",
@@ -22424,7 +25020,11 @@
         "nct": "",
         "publication_date": "2016-06-22",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 650,
+        "feature_id": 650,
+        "source_id": 179,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Germline Variant",
@@ -22461,7 +25061,11 @@
         "nct": "",
         "publication_date": "2016-06-22",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 651,
+        "feature_id": 651,
+        "source_id": 179,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Germline Variant",
@@ -22491,14 +25095,18 @@
         "predictive_implication": "Guideline",
         "description": "Patients with defects in DNA mismatch repair genes often have a favorable prognosis and a decreased likelihood of metastasis. These patients do not benefit from, and may be resistant to, 5-fluorouracil therapy.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Colon Cancer V.2.2016. © National Comprehensive Cancer Network, Inc. 2016. All rights reserved. Accessed November 5 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Colon Cancer V.2.2016. \u00a9 National Comprehensive Cancer Network, Inc. 2016. All rights reserved. Accessed November 5 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/colon_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2016-01-01",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 652,
+        "feature_id": 652,
+        "source_id": 80,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Germline Variant",
@@ -22535,7 +25143,11 @@
         "nct": "NCT01876511",
         "publication_date": "2015-06-25",
         "last_updated": "2023-10-31",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 653,
+        "feature_id": 653,
+        "source_id": 147,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Germline Variant",
@@ -22565,14 +25177,18 @@
         "predictive_implication": "Guideline",
         "description": "Patients with defects in DNA mismatch repair genes often have a favorable prognosis and a decreased likelihood of metastasis. These patients do not benefit from, and may be resistant to, 5-fluorouracil therapy.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Colon Cancer V.2.2016. © National Comprehensive Cancer Network, Inc. 2016. All rights reserved. Accessed November 5 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Colon Cancer V.2.2016. \u00a9 National Comprehensive Cancer Network, Inc. 2016. All rights reserved. Accessed November 5 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/colon_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2016-01-01",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 654,
+        "feature_id": 654,
+        "source_id": 80,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Germline Variant",
@@ -22609,7 +25225,11 @@
         "nct": "NCT01876511",
         "publication_date": "2015-06-25",
         "last_updated": "2023-10-31",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 655,
+        "feature_id": 655,
+        "source_id": 147,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Germline Variant",
@@ -22646,7 +25266,11 @@
         "nct": "",
         "publication_date": "2008-12-16",
         "last_updated": "2019-09-12",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 656,
+        "feature_id": 656,
+        "source_id": 180,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Germline Variant",
@@ -22683,7 +25307,11 @@
         "nct": "",
         "publication_date": "2014-02-02",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 657,
+        "feature_id": 657,
+        "source_id": 59,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Germline Variant",
@@ -22720,7 +25348,11 @@
         "nct": "",
         "publication_date": "2014-02-02",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 658,
+        "feature_id": 658,
+        "source_id": 59,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Germline Variant",
@@ -22757,7 +25389,11 @@
         "nct": "",
         "publication_date": "2014-02-02",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 659,
+        "feature_id": 659,
+        "source_id": 59,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Germline Variant",
@@ -22794,7 +25430,11 @@
         "nct": "",
         "publication_date": "2014-02-02",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 660,
+        "feature_id": 660,
+        "source_id": 59,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Germline Variant",
@@ -22831,7 +25471,11 @@
         "nct": "",
         "publication_date": "2014-02-02",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 661,
+        "feature_id": 661,
+        "source_id": 59,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Germline Variant",
@@ -22868,7 +25512,11 @@
         "nct": "",
         "publication_date": "2014-02-02",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 662,
+        "feature_id": 662,
+        "source_id": 59,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Germline Variant",
@@ -22905,7 +25553,11 @@
         "nct": "",
         "publication_date": "2015-02-25",
         "last_updated": "2019-03-07",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 663,
+        "feature_id": 663,
+        "source_id": 85,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Germline Variant",
@@ -22942,7 +25594,11 @@
         "nct": "",
         "publication_date": "2018-02-22",
         "last_updated": "2019-04-16",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 664,
+        "feature_id": 664,
+        "source_id": 171,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Germline Variant",
@@ -22972,14 +25628,18 @@
         "predictive_implication": "Guideline",
         "description": "Patients with defects in DNA mismatch repair genes often have a favorable prognosis and a decreased likelihood of metastasis. These patients do not benefit from, and may be resistant to, 5-fluorouracil therapy.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Colon Cancer V.2.2016. © National Comprehensive Cancer Network, Inc. 2016. All rights reserved. Accessed November 5 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Colon Cancer V.2.2016. \u00a9 National Comprehensive Cancer Network, Inc. 2016. All rights reserved. Accessed November 5 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/colon_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2016-01-01",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 665,
+        "feature_id": 665,
+        "source_id": 80,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Germline Variant",
@@ -23016,7 +25676,11 @@
         "nct": "",
         "publication_date": "2016-06-22",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 666,
+        "feature_id": 666,
+        "source_id": 179,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Germline Variant",
@@ -23053,7 +25717,11 @@
         "nct": "",
         "publication_date": "2016-06-22",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 667,
+        "feature_id": 667,
+        "source_id": 179,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Germline Variant",
@@ -23090,7 +25758,11 @@
         "nct": "",
         "publication_date": "2016-06-22",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 668,
+        "feature_id": 668,
+        "source_id": 179,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Germline Variant",
@@ -23127,7 +25799,11 @@
         "nct": "",
         "publication_date": "2016-06-22",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 669,
+        "feature_id": 669,
+        "source_id": 179,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Germline Variant",
@@ -23164,7 +25840,11 @@
         "nct": "",
         "publication_date": "2014-02-02",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 670,
+        "feature_id": 670,
+        "source_id": 59,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Germline Variant",
@@ -23201,7 +25881,11 @@
         "nct": "",
         "publication_date": "2014-02-02",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 671,
+        "feature_id": 671,
+        "source_id": 59,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Germline Variant",
@@ -23238,7 +25922,11 @@
         "nct": "",
         "publication_date": "2014-02-02",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 672,
+        "feature_id": 672,
+        "source_id": 59,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Germline Variant",
@@ -23275,7 +25963,11 @@
         "nct": "",
         "publication_date": "2014-02-02",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 673,
+        "feature_id": 673,
+        "source_id": 59,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Germline Variant",
@@ -23312,7 +26004,11 @@
         "nct": "",
         "publication_date": "2014-02-02",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 674,
+        "feature_id": 674,
+        "source_id": 59,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Germline Variant",
@@ -23349,7 +26045,11 @@
         "nct": "",
         "publication_date": "2014-02-02",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 675,
+        "feature_id": 675,
+        "source_id": 59,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Germline Variant",
@@ -23386,7 +26086,11 @@
         "nct": "",
         "publication_date": "2014-02-02",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 676,
+        "feature_id": 676,
+        "source_id": 59,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Germline Variant",
@@ -23423,7 +26127,11 @@
         "nct": "",
         "publication_date": "2014-02-02",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 677,
+        "feature_id": 677,
+        "source_id": 59,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Germline Variant",
@@ -23460,7 +26168,11 @@
         "nct": "",
         "publication_date": "2014-02-02",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 678,
+        "feature_id": 678,
+        "source_id": 59,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Germline Variant",
@@ -23497,7 +26209,11 @@
         "nct": "",
         "publication_date": "2014-02-02",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 679,
+        "feature_id": 679,
+        "source_id": 59,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Germline Variant",
@@ -23534,7 +26250,11 @@
         "nct": "",
         "publication_date": "2014-02-02",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 680,
+        "feature_id": 680,
+        "source_id": 59,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Germline Variant",
@@ -23571,7 +26291,11 @@
         "nct": "",
         "publication_date": "2014-02-02",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 681,
+        "feature_id": 681,
+        "source_id": 59,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Germline Variant",
@@ -23608,7 +26332,11 @@
         "nct": "",
         "publication_date": "2009-12-16",
         "last_updated": "2019-09-12",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 682,
+        "feature_id": 682,
+        "source_id": 180,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Germline Variant",
@@ -23645,7 +26373,11 @@
         "nct": "",
         "publication_date": "2008-12-16",
         "last_updated": "2019-09-12",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 683,
+        "feature_id": 683,
+        "source_id": 180,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Copy Number",
@@ -23663,16 +26395,20 @@
         "therapy_resistance": 1,
         "favorable_prognosis": "",
         "predictive_implication": "Guideline",
-        "description": "Abiraterone (Zytiga) is not recommended by the National Comprehensive Cancer Network® (NCCN®) as a treatment option for patients with castration-resistant prostate cancer. Androgen receptor activation is a potential mechanism of recurrence of prostate cancer during androgen deprivation therapy.",
+        "description": "Abiraterone (Zytiga) is not recommended by the National Comprehensive Cancer Network\u00ae (NCCN\u00ae) as a treatment option for patients with castration-resistant prostate cancer. Androgen receptor activation is a potential mechanism of recurrence of prostate cancer during androgen deprivation therapy.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Prostate Cancer V.3.2016. © National Comprehensive Cancer Network, Inc. 2016. All rights reserved. Accessed November 5 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Prostate Cancer V.3.2016. \u00a9 National Comprehensive Cancer Network, Inc. 2016. All rights reserved. Accessed November 5 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/prostate_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2016-01-01",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 684,
+        "feature_id": 684,
+        "source_id": 181,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Copy Number",
@@ -23690,16 +26426,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": "",
         "predictive_implication": "Guideline",
-        "description": "Abiraterone (Zytiga) is recommended by the National Comprehensive Cancer Network® (NCCN®) as a treatment option for patients with prostate cancer. Androgen receptor activation may predict sensitivity to second generation androgen deprivation or direct androgen inhibitors.",
+        "description": "Abiraterone (Zytiga) is recommended by the National Comprehensive Cancer Network\u00ae (NCCN\u00ae) as a treatment option for patients with prostate cancer. Androgen receptor activation may predict sensitivity to second generation androgen deprivation or direct androgen inhibitors.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Prostate Cancer V.3.2016. © National Comprehensive Cancer Network, Inc. 2016. All rights reserved. Accessed November 5 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Prostate Cancer V.3.2016. \u00a9 National Comprehensive Cancer Network, Inc. 2016. All rights reserved. Accessed November 5 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/prostate_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2016-01-01",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 685,
+        "feature_id": 685,
+        "source_id": 181,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Copy Number",
@@ -23717,16 +26457,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": "",
         "predictive_implication": "Guideline",
-        "description": "Enzalutamide (Xtandi) is recommended by the National Comprehensive Cancer Network® (NCCN®) as a treatment option for patients with prostate cancer. Androgen receptor activation may predict sensitivity to second generation androgen deprivation or direct androgen inhibitors.",
+        "description": "Enzalutamide (Xtandi) is recommended by the National Comprehensive Cancer Network\u00ae (NCCN\u00ae) as a treatment option for patients with prostate cancer. Androgen receptor activation may predict sensitivity to second generation androgen deprivation or direct androgen inhibitors.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Prostate Cancer V.3.2016. © National Comprehensive Cancer Network, Inc. 2016. All rights reserved. Accessed November 5 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Prostate Cancer V.3.2016. \u00a9 National Comprehensive Cancer Network, Inc. 2016. All rights reserved. Accessed November 5 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/prostate_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2016-01-01",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 686,
+        "feature_id": 686,
+        "source_id": 181,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Copy Number",
@@ -23753,7 +26497,11 @@
         "nct": "",
         "publication_date": "2017-08-18",
         "last_updated": "2019-08-09",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 687,
+        "feature_id": 687,
+        "source_id": 182,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Copy Number",
@@ -23780,7 +26528,11 @@
         "nct": "",
         "publication_date": "2018-05-07",
         "last_updated": "2019-02-04",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 688,
+        "feature_id": 688,
+        "source_id": 53,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Copy Number",
@@ -23807,7 +26559,11 @@
         "nct": "",
         "publication_date": "2011-11-16",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 689,
+        "feature_id": 689,
+        "source_id": 183,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Copy Number",
@@ -23834,7 +26590,11 @@
         "nct": "",
         "publication_date": "2011-12-29",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 690,
+        "feature_id": 690,
+        "source_id": 184,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Copy Number",
@@ -23861,7 +26621,11 @@
         "nct": "",
         "publication_date": "2016-10-02",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 691,
+        "feature_id": 691,
+        "source_id": 185,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Copy Number",
@@ -23888,7 +26652,11 @@
         "nct": "",
         "publication_date": "2010-11-23",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 692,
+        "feature_id": 692,
+        "source_id": 186,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Copy Number",
@@ -23915,7 +26683,11 @@
         "nct": "",
         "publication_date": "2014-01-07",
         "last_updated": "2019-06-13",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 693,
+        "feature_id": 693,
+        "source_id": 78,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Copy Number",
@@ -23942,7 +26714,11 @@
         "nct": "NCT01682772",
         "publication_date": "2015-10-29",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 694,
+        "feature_id": 694,
+        "source_id": 88,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Copy Number",
@@ -23969,7 +26745,11 @@
         "nct": "",
         "publication_date": "2007-05-07",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 695,
+        "feature_id": 695,
+        "source_id": 187,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Copy Number",
@@ -23996,7 +26776,11 @@
         "nct": "",
         "publication_date": "2015-04-09",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 696,
+        "feature_id": 696,
+        "source_id": 54,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Copy Number",
@@ -24023,7 +26807,11 @@
         "nct": "",
         "publication_date": "2013-11-11",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 697,
+        "feature_id": 697,
+        "source_id": 188,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Copy Number",
@@ -24050,7 +26838,11 @@
         "nct": "NCT01295827",
         "publication_date": "2015-05-21",
         "last_updated": "2019-11-04",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 698,
+        "feature_id": 698,
+        "source_id": 189,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Copy Number",
@@ -24077,7 +26869,11 @@
         "nct": "",
         "publication_date": "2020-09-01",
         "last_updated": "2020-11-12",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 699,
+        "feature_id": 699,
+        "source_id": 190,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Copy Number",
@@ -24104,7 +26900,11 @@
         "nct": "",
         "publication_date": "2020-10-01",
         "last_updated": "2025-01-08",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 700,
+        "feature_id": 700,
+        "source_id": 191,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Copy Number",
@@ -24131,7 +26931,11 @@
         "nct": "",
         "publication_date": "2020-05-01",
         "last_updated": "2021-05-06",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 701,
+        "feature_id": 701,
+        "source_id": 192,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Copy Number",
@@ -24158,7 +26962,11 @@
         "nct": "",
         "publication_date": "2020-05-01",
         "last_updated": "2021-05-06",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 702,
+        "feature_id": 702,
+        "source_id": 192,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Copy Number",
@@ -24185,7 +26993,11 @@
         "nct": "",
         "publication_date": "2021-10-01",
         "last_updated": "2021-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 703,
+        "feature_id": 703,
+        "source_id": 193,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Copy Number",
@@ -24203,16 +27015,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": "",
         "predictive_implication": "Guideline",
-        "description": "Palbociclib (Ibrance) is recommended by the National Comprehensive Cancer Network® (NCCN®) as a treatment option for patients with well-differentiated liposarcoma and CDK4 amplification. CDK4 amplification is characteristic of well-differentiated and dedifferentiated liposarcomas, and palbociclib shows activity in this context.",
+        "description": "Palbociclib (Ibrance) is recommended by the National Comprehensive Cancer Network\u00ae (NCCN\u00ae) as a treatment option for patients with well-differentiated liposarcoma and CDK4 amplification. CDK4 amplification is characteristic of well-differentiated and dedifferentiated liposarcomas, and palbociclib shows activity in this context.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Soft Tissue Sarcoma V.1.2021. © National Comprehensive Cancer Network, Inc. 2019. All rights reserved. Accessed November 19th, 2019. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Soft Tissue Sarcoma V.1.2021. \u00a9 National Comprehensive Cancer Network, Inc. 2019. All rights reserved. Accessed November 19th, 2019. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/sarcoma_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2021-01-01",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 704,
+        "feature_id": 704,
+        "source_id": 194,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Copy Number",
@@ -24230,16 +27046,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": "",
         "predictive_implication": "Guideline",
-        "description": "Palbociclib (Ibrance) is recommended by the National Comprehensive Cancer Network® (NCCN®) as a treatment option for patients with dedifferentiated liposarcoma and CDK4 amplification. CDK4 amplification is characteristic of well-differentiated and dedifferentiated liposarcomas, and palbociclib shows activity in this context.",
+        "description": "Palbociclib (Ibrance) is recommended by the National Comprehensive Cancer Network\u00ae (NCCN\u00ae) as a treatment option for patients with dedifferentiated liposarcoma and CDK4 amplification. CDK4 amplification is characteristic of well-differentiated and dedifferentiated liposarcomas, and palbociclib shows activity in this context.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Soft Tissue Sarcoma V.1.2021. © National Comprehensive Cancer Network, Inc. 2019. All rights reserved. Accessed November 19th, 2019. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Soft Tissue Sarcoma V.1.2021. \u00a9 National Comprehensive Cancer Network, Inc. 2019. All rights reserved. Accessed November 19th, 2019. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/sarcoma_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2021-01-01",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 705,
+        "feature_id": 705,
+        "source_id": 194,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Copy Number",
@@ -24266,7 +27086,11 @@
         "nct": "NCT01209598",
         "publication_date": "2013-04-08",
         "last_updated": "2019-01-29",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 706,
+        "feature_id": 706,
+        "source_id": 195,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Copy Number",
@@ -24293,7 +27117,11 @@
         "nct": "",
         "publication_date": "2015-04-09",
         "last_updated": "2018-09-14",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 707,
+        "feature_id": 707,
+        "source_id": 54,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Copy Number",
@@ -24320,7 +27148,11 @@
         "nct": "",
         "publication_date": "2016-02-11",
         "last_updated": "2023-10-05",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 708,
+        "feature_id": 708,
+        "source_id": 196,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Copy Number",
@@ -24347,7 +27179,11 @@
         "nct": "",
         "publication_date": "2015-04-09",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 709,
+        "feature_id": 709,
+        "source_id": 54,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Copy Number",
@@ -24374,7 +27210,11 @@
         "nct": "",
         "publication_date": "2008-09-30",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 710,
+        "feature_id": 710,
+        "source_id": 197,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Copy Number",
@@ -24401,7 +27241,11 @@
         "nct": "",
         "publication_date": "2016-08-17",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 711,
+        "feature_id": 711,
+        "source_id": 16,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Copy Number",
@@ -24428,7 +27272,11 @@
         "nct": "",
         "publication_date": "2011-12-13",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 712,
+        "feature_id": 712,
+        "source_id": 198,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Copy Number",
@@ -24455,7 +27303,11 @@
         "nct": "",
         "publication_date": "2005-10-01",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 713,
+        "feature_id": 713,
+        "source_id": 96,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Copy Number",
@@ -24482,7 +27334,11 @@
         "nct": "NCT00320385",
         "publication_date": "2010-02-01",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 714,
+        "feature_id": 714,
+        "source_id": 199,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Copy Number",
@@ -24509,7 +27365,11 @@
         "nct": "",
         "publication_date": "2020-04-01",
         "last_updated": "2020-11-12",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 715,
+        "feature_id": 715,
+        "source_id": 200,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Copy Number",
@@ -24536,7 +27396,11 @@
         "nct": "",
         "publication_date": "2018-12-01",
         "last_updated": "2020-11-12",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 716,
+        "feature_id": 716,
+        "source_id": 201,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Copy Number",
@@ -24563,7 +27427,11 @@
         "nct": "",
         "publication_date": "2018-12-01",
         "last_updated": "2020-11-12",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 717,
+        "feature_id": 717,
+        "source_id": 201,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Copy Number",
@@ -24590,7 +27458,11 @@
         "nct": "",
         "publication_date": "2017-07-17",
         "last_updated": "2024-01-11",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 718,
+        "feature_id": 718,
+        "source_id": 202,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Copy Number",
@@ -24617,7 +27489,11 @@
         "nct": "",
         "publication_date": "2020-01-01",
         "last_updated": "2023-10-05",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 719,
+        "feature_id": 719,
+        "source_id": 203,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Copy Number",
@@ -24644,7 +27520,11 @@
         "nct": "",
         "publication_date": "2018-11-01",
         "last_updated": "2021-05-06",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 720,
+        "feature_id": 720,
+        "source_id": 204,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Copy Number",
@@ -24671,7 +27551,11 @@
         "nct": "",
         "publication_date": "2018-11-01",
         "last_updated": "2021-05-06",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 721,
+        "feature_id": 721,
+        "source_id": 204,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Copy Number",
@@ -24698,7 +27582,11 @@
         "nct": "",
         "publication_date": "2018-11-01",
         "last_updated": "2021-05-06",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 722,
+        "feature_id": 722,
+        "source_id": 204,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Copy Number",
@@ -24716,16 +27604,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": "",
         "predictive_implication": "Inferential",
-        "description": "Trastuzumab (Herceptin) in combination with chemotherapy is recommended by the National Comprehensive Cancer Network® (NCCN®) as a treatment option for patients with metastatic gastric cancer and HER2 overexpression or amplification. These patients showed significant improvement in median overall survival with the addition of trastuzumab to chemotherapy compared to chemotherapy alone. This benefit is limited to patients with a tumor score of IHC 3 + or IHC 2 + and FISH positive.",
+        "description": "Trastuzumab (Herceptin) in combination with chemotherapy is recommended by the National Comprehensive Cancer Network\u00ae (NCCN\u00ae) as a treatment option for patients with metastatic gastric cancer and HER2 overexpression or amplification. These patients showed significant improvement in median overall survival with the addition of trastuzumab to chemotherapy compared to chemotherapy alone. This benefit is limited to patients with a tumor score of IHC 3 + or IHC 2 + and FISH positive.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Gastric Cancer V.3.2016. © National Comprehensive Cancer Network, Inc. 2016. All rights reserved. Accessed November 5 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Gastric Cancer V.3.2016. \u00a9 National Comprehensive Cancer Network, Inc. 2016. All rights reserved. Accessed November 5 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/gastric_blocks.pdf",
         "doi": "",
         "pmid": 20728210,
         "nct": "NCT01041404",
         "publication_date": "2016-01-01",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 723,
+        "feature_id": 723,
+        "source_id": 205,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Copy Number",
@@ -24752,7 +27644,11 @@
         "nct": "",
         "publication_date": "2020-04-01",
         "last_updated": "2020-11-12",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 724,
+        "feature_id": 724,
+        "source_id": 206,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Copy Number",
@@ -24779,7 +27675,11 @@
         "nct": "",
         "publication_date": "1999-01-06",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 725,
+        "feature_id": 725,
+        "source_id": 207,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Copy Number",
@@ -24806,7 +27706,11 @@
         "nct": "",
         "publication_date": "2003-11-14",
         "last_updated": "2019-08-09",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 726,
+        "feature_id": 726,
+        "source_id": 208,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Copy Number",
@@ -24833,7 +27737,11 @@
         "nct": "",
         "publication_date": "2020-06-01",
         "last_updated": "2020-11-12",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 727,
+        "feature_id": 727,
+        "source_id": 209,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Copy Number",
@@ -24860,7 +27768,11 @@
         "nct": "",
         "publication_date": "2020-06-01",
         "last_updated": "2020-11-12",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 728,
+        "feature_id": 728,
+        "source_id": 209,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Copy Number",
@@ -24887,7 +27799,11 @@
         "nct": "",
         "publication_date": "2020-12-01",
         "last_updated": "2023-10-05",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 729,
+        "feature_id": 729,
+        "source_id": 210,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Copy Number",
@@ -24905,7 +27821,7 @@
         "therapy_resistance": "",
         "favorable_prognosis": "",
         "predictive_implication": "FDA-Approved",
-        "description": "The U.S. Food and Drug Administration (FDA) granted accelerated approval to pembrolizumab in combination with trastuzumab, fluoropyrimidine- and platinum- containing chemotherapy for the first-line treatments of patients with locally advanced unresectable or metastatic HER2-positive gastric adenocarcinoma. In November 2023, the FDA updated this indication to restrict use to patients whose tumors express PD-L1 (CPS ≥ 1), as determined by an FDA-approved test.",
+        "description": "The U.S. Food and Drug Administration (FDA) granted accelerated approval to pembrolizumab in combination with trastuzumab, fluoropyrimidine- and platinum- containing chemotherapy for the first-line treatments of patients with locally advanced unresectable or metastatic HER2-positive gastric adenocarcinoma. In November 2023, the FDA updated this indication to restrict use to patients whose tumors express PD-L1 (CPS \u2265 1), as determined by an FDA-approved test.",
         "source_type": "FDA",
         "citation": "Merck Sharp & Dohme Corp. Keytruda (pembrolizumab) [package insert]. U.S. Food and Drug Administration website. https://www.accessdata.fda.gov/drugsatfda_docs/label/2023/125514s148lbl.pdf. Revised November 2023. Accessed December 5, 2023.",
         "url": "https://www.accessdata.fda.gov/drugsatfda_docs/label/2023/125514s148lbl.pdf",
@@ -24914,7 +27830,11 @@
         "nct": "",
         "publication_date": "2023-11-08",
         "last_updated": "2023-12-05",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 730,
+        "feature_id": 730,
+        "source_id": 211,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Copy Number",
@@ -24932,7 +27852,7 @@
         "therapy_resistance": "",
         "favorable_prognosis": "",
         "predictive_implication": "FDA-Approved",
-        "description": "The U.S. Food and Drug Administration (FDA) granted accelerated approval to pembrolizumab in combination with trastuzumab, fluoropyrimidine- and platinum- containing chemotherapy for the first-line treatments of patients with locally advanced unresectable or metastatic HER2-positive gastroesophageal junction adenocarcinoma. In November 2023, the FDA updated this indication to restrict use to patients whose tumors express PD-L1 (CPS ≥ 1), as determined by an FDA-approved test.",
+        "description": "The U.S. Food and Drug Administration (FDA) granted accelerated approval to pembrolizumab in combination with trastuzumab, fluoropyrimidine- and platinum- containing chemotherapy for the first-line treatments of patients with locally advanced unresectable or metastatic HER2-positive gastroesophageal junction adenocarcinoma. In November 2023, the FDA updated this indication to restrict use to patients whose tumors express PD-L1 (CPS \u2265 1), as determined by an FDA-approved test.",
         "source_type": "FDA",
         "citation": "Merck Sharp & Dohme Corp. Keytruda (pembrolizumab) [package insert]. U.S. Food and Drug Administration website. https://www.accessdata.fda.gov/drugsatfda_docs/label/2023/125514s148lbl.pdf. Revised November 2023. Accessed December 5, 2023.",
         "url": "https://www.accessdata.fda.gov/drugsatfda_docs/label/2023/125514s148lbl.pdf",
@@ -24941,7 +27861,11 @@
         "nct": "",
         "publication_date": "2023-11-08",
         "last_updated": "2023-12-05",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 731,
+        "feature_id": 731,
+        "source_id": 211,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Copy Number",
@@ -24968,7 +27892,11 @@
         "nct": "",
         "publication_date": "2010-06-17",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 732,
+        "feature_id": 732,
+        "source_id": 212,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Copy Number",
@@ -24995,7 +27923,11 @@
         "nct": "",
         "publication_date": "2008-09-12",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 733,
+        "feature_id": 733,
+        "source_id": 109,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Copy Number",
@@ -25022,7 +27954,11 @@
         "nct": "",
         "publication_date": "2012-12-09",
         "last_updated": "2019-04-30",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 734,
+        "feature_id": 734,
+        "source_id": 213,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Copy Number",
@@ -25049,7 +27985,11 @@
         "nct": "",
         "publication_date": "2012-12-09",
         "last_updated": "2019-04-30",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 735,
+        "feature_id": 735,
+        "source_id": 213,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Copy Number",
@@ -25076,7 +28016,11 @@
         "nct": "",
         "publication_date": "2012-12-09",
         "last_updated": "2019-04-30",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 736,
+        "feature_id": 736,
+        "source_id": 213,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Copy Number",
@@ -25103,7 +28047,11 @@
         "nct": "",
         "publication_date": "2012-12-09",
         "last_updated": "2019-04-30",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 737,
+        "feature_id": 737,
+        "source_id": 213,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Copy Number",
@@ -25130,7 +28078,11 @@
         "nct": "",
         "publication_date": "2012-12-09",
         "last_updated": "2019-04-30",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 738,
+        "feature_id": 738,
+        "source_id": 213,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Copy Number",
@@ -25157,7 +28109,11 @@
         "nct": "",
         "publication_date": "2012-12-09",
         "last_updated": "2019-04-30",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 739,
+        "feature_id": 739,
+        "source_id": 213,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Copy Number",
@@ -25184,7 +28140,11 @@
         "nct": "",
         "publication_date": "2012-12-09",
         "last_updated": "2019-04-30",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 740,
+        "feature_id": 740,
+        "source_id": 213,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Copy Number",
@@ -25211,7 +28171,11 @@
         "nct": "",
         "publication_date": "2012-12-09",
         "last_updated": "2019-04-30",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 741,
+        "feature_id": 741,
+        "source_id": 213,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Copy Number",
@@ -25238,7 +28202,11 @@
         "nct": "",
         "publication_date": "2014-06-17",
         "last_updated": "2019-08-09",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 742,
+        "feature_id": 742,
+        "source_id": 214,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Copy Number",
@@ -25265,7 +28233,11 @@
         "nct": "",
         "publication_date": "2017-01-05",
         "last_updated": "2019-04-30",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 743,
+        "feature_id": 743,
+        "source_id": 215,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Copy Number",
@@ -25283,16 +28255,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": "",
         "predictive_implication": "Guideline",
-        "description": "Imatinib (Gleevec) is not recommended by the National Comprehensive Cancer Network® (NCCN®) as a treatment option for patients with melanoma and amplification of KIT; KIT amplifications appear to have minimal or no sensitivity to KIT inhibitors.",
+        "description": "Imatinib (Gleevec) is not recommended by the National Comprehensive Cancer Network\u00ae (NCCN\u00ae) as a treatment option for patients with melanoma and amplification of KIT; KIT amplifications appear to have minimal or no sensitivity to KIT inhibitors.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Cutaneous Melanoma V.2.2019. © National Comprehensive Cancer Network, Inc. 2019. All rights reserved. Accessed August 12 2019. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Cutaneous Melanoma V.2.2019. \u00a9 National Comprehensive Cancer Network, Inc. 2019. All rights reserved. Accessed August 12 2019. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/cutaneous_melanoma_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2019-01-01",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 744,
+        "feature_id": 744,
+        "source_id": 126,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Copy Number",
@@ -25319,7 +28295,11 @@
         "nct": "",
         "publication_date": "2010-12-07",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 745,
+        "feature_id": 745,
+        "source_id": 168,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Copy Number",
@@ -25337,16 +28317,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": "",
         "predictive_implication": "Guideline",
-        "description": "Crizotinib (Xalkori) is recommended by the National Comprehensive Cancer Network® (NCCN®) as a treatment option for patients with metastatic non-small cell lung cancer whose tumors harbor an amplification of MET.",
+        "description": "Crizotinib (Xalkori) is recommended by the National Comprehensive Cancer Network\u00ae (NCCN\u00ae) as a treatment option for patients with metastatic non-small cell lung cancer whose tumors harbor an amplification of MET.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Non-Small Lung Cancer V.5.2019. © National Comprehensive Cancer Network, Inc. 2019. All rights reserved. Accessed August 12, 2019. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Non-Small Lung Cancer V.5.2019. \u00a9 National Comprehensive Cancer Network, Inc. 2019. All rights reserved. Accessed August 12, 2019. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/nscl_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2019-01-01",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 746,
+        "feature_id": 746,
+        "source_id": 11,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Copy Number",
@@ -25364,16 +28348,20 @@
         "therapy_resistance": 1,
         "favorable_prognosis": "",
         "predictive_implication": "Guideline",
-        "description": "Gefitinib (Iressa) is not recommended by the National Comprehensive Cancer Network® (NCCN®) as a treatment option for patients with non-small cell lung cancer whose tumors harbor an amplification of MET, as amplification of alternative kinases, such as MET, may suggest resistance to EGFR TKIs.",
+        "description": "Gefitinib (Iressa) is not recommended by the National Comprehensive Cancer Network\u00ae (NCCN\u00ae) as a treatment option for patients with non-small cell lung cancer whose tumors harbor an amplification of MET, as amplification of alternative kinases, such as MET, may suggest resistance to EGFR TKIs.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Non-Small Lung Cancer V.1.2017. © National Comprehensive Cancer Network, Inc. 2017. All rights reserved. Accessed November 5, 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Non-Small Lung Cancer V.1.2017. \u00a9 National Comprehensive Cancer Network, Inc. 2017. All rights reserved. Accessed November 5, 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/nscl_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2017-01-01",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 747,
+        "feature_id": 747,
+        "source_id": 20,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Copy Number",
@@ -25400,7 +28388,11 @@
         "nct": "NCT01865747",
         "publication_date": "2015-11-05",
         "last_updated": "2019-08-12",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 748,
+        "feature_id": 748,
+        "source_id": 216,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Copy Number",
@@ -25427,7 +28419,11 @@
         "nct": "",
         "publication_date": "2021-03-04",
         "last_updated": "2025-01-08",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 749,
+        "feature_id": 749,
+        "source_id": 217,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Copy Number",
@@ -25454,7 +28450,11 @@
         "nct": "",
         "publication_date": "2016-05-06",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 750,
+        "feature_id": 750,
+        "source_id": 218,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Copy Number",
@@ -25481,7 +28481,11 @@
         "nct": "",
         "publication_date": "2016-05-06",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 751,
+        "feature_id": 751,
+        "source_id": 218,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Copy Number",
@@ -25508,7 +28512,11 @@
         "nct": "",
         "publication_date": "2010-09-14",
         "last_updated": "2019-08-08",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 752,
+        "feature_id": 752,
+        "source_id": 219,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Copy Number",
@@ -25535,7 +28543,11 @@
         "nct": "",
         "publication_date": "2011-12-03",
         "last_updated": "2019-01-29",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 753,
+        "feature_id": 753,
+        "source_id": 220,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Copy Number",
@@ -25562,7 +28574,11 @@
         "nct": "",
         "publication_date": "2015-04-09",
         "last_updated": "2019-04-30",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 754,
+        "feature_id": 754,
+        "source_id": 54,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Copy Number",
@@ -25589,7 +28605,11 @@
         "nct": "",
         "publication_date": "2007-05-07",
         "last_updated": "2019-01-29",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 755,
+        "feature_id": 755,
+        "source_id": 187,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Copy Number",
@@ -25616,7 +28636,11 @@
         "nct": "",
         "publication_date": "2007-05-07",
         "last_updated": "2019-01-29",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 756,
+        "feature_id": 756,
+        "source_id": 187,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Copy Number",
@@ -25643,7 +28667,11 @@
         "nct": "",
         "publication_date": "2018-01-04",
         "last_updated": "2018-11-29",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 757,
+        "feature_id": 757,
+        "source_id": 153,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Copy Number",
@@ -25670,7 +28698,11 @@
         "nct": "NCT00876122",
         "publication_date": "2015-01-05",
         "last_updated": "2019-01-29",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 758,
+        "feature_id": 758,
+        "source_id": 221,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Copy Number",
@@ -25697,7 +28729,11 @@
         "nct": "",
         "publication_date": "2014-12-16",
         "last_updated": "2023-10-05",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 759,
+        "feature_id": 759,
+        "source_id": 158,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Copy Number",
@@ -25724,7 +28760,11 @@
         "nct": "",
         "publication_date": "2017-02-21",
         "last_updated": "2019-03-07",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 760,
+        "feature_id": 760,
+        "source_id": 159,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Copy Number",
@@ -25751,7 +28791,11 @@
         "nct": "",
         "publication_date": "2014-04-09",
         "last_updated": "2019-03-07",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 761,
+        "feature_id": 761,
+        "source_id": 222,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Copy Number",
@@ -25778,7 +28822,11 @@
         "nct": "",
         "publication_date": "2016-02-04",
         "last_updated": "2019-03-07",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 762,
+        "feature_id": 762,
+        "source_id": 160,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Copy Number",
@@ -25805,7 +28853,11 @@
         "nct": "NCT00903175",
         "publication_date": "2019-01-15",
         "last_updated": "2019-08-12",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 763,
+        "feature_id": 763,
+        "source_id": 149,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Copy Number",
@@ -25832,7 +28884,11 @@
         "nct": "NCT00903175",
         "publication_date": "2019-01-15",
         "last_updated": "2019-08-12",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 764,
+        "feature_id": 764,
+        "source_id": 149,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Copy Number",
@@ -25852,14 +28908,18 @@
         "predictive_implication": "Guideline",
         "description": "Deletion of chromosome 13 seems to have an amplifying effect on cell cycle gene expression and is reported to be associated with short event-free survival (EFS) and overall survival (OS). This copy loss event results in haploinsufficiency of RB1 and other genes mapped to chromosome 13.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Multiple Myeloma V.2.2016. © National Comprehensive Cancer Network, Inc. 2016. All rights reserved. Accessed November 5 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Multiple Myeloma V.2.2016. \u00a9 National Comprehensive Cancer Network, Inc. 2016. All rights reserved. Accessed November 5 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/myeloma_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2016-01-01",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 765,
+        "feature_id": 765,
+        "source_id": 28,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Copy Number",
@@ -25879,14 +28939,18 @@
         "predictive_implication": "Guideline",
         "description": "Deletion of 17p13 leads to LoH of TP53 and is considered a high-risk feature of multiple myeloma.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Multiple Myeloma V.2.2016. © National Comprehensive Cancer Network, Inc. 2016. All rights reserved. Accessed November 5 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Multiple Myeloma V.2.2016. \u00a9 National Comprehensive Cancer Network, Inc. 2016. All rights reserved. Accessed November 5 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/myeloma_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2016-01-01",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 766,
+        "feature_id": 766,
+        "source_id": 28,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Copy Number",
@@ -25913,7 +28977,11 @@
         "nct": "",
         "publication_date": "2011-12-29",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 767,
+        "feature_id": 767,
+        "source_id": 184,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Microsatellite Stability",
@@ -25938,7 +29006,11 @@
         "nct": "",
         "publication_date": "2020-10-01",
         "last_updated": "2020-11-12",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 768,
+        "feature_id": 768,
+        "source_id": 223,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Microsatellite Stability",
@@ -25963,7 +29035,11 @@
         "nct": "",
         "publication_date": "2020-10-01",
         "last_updated": "2020-11-12",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 769,
+        "feature_id": 769,
+        "source_id": 223,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Microsatellite Stability",
@@ -25979,16 +29055,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": "",
         "predictive_implication": "Guideline",
-        "description": "5-Fluorouracil is not recommended by the National Comprehensive Cancer Network® (NCCN®) as a treatment option for patients with MSI-High colorectal cancer. These patients appear to not benefit from, and may be resistant to, 5-fluorouracil therapy.",
+        "description": "5-Fluorouracil is not recommended by the National Comprehensive Cancer Network\u00ae (NCCN\u00ae) as a treatment option for patients with MSI-High colorectal cancer. These patients appear to not benefit from, and may be resistant to, 5-fluorouracil therapy.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Colon Cancer V.2.2016. © National Comprehensive Cancer Network, Inc. 2016. All rights reserved. Accessed November 5 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Colon Cancer V.2.2016. \u00a9 National Comprehensive Cancer Network, Inc. 2016. All rights reserved. Accessed November 5 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/colon_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2016-01-01",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 770,
+        "feature_id": 770,
+        "source_id": 80,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Microsatellite Stability",
@@ -26004,16 +29084,20 @@
         "therapy_resistance": 1,
         "favorable_prognosis": "",
         "predictive_implication": "Guideline",
-        "description": "5-Fluorouracil is not recommended by the National Comprehensive Cancer Network® (NCCN®) as a treatment option for patients with MSI-High colorectal cancer. These patients appear to not benefit from, and may be resistant to, 5-fluorouracil therapy.",
+        "description": "5-Fluorouracil is not recommended by the National Comprehensive Cancer Network\u00ae (NCCN\u00ae) as a treatment option for patients with MSI-High colorectal cancer. These patients appear to not benefit from, and may be resistant to, 5-fluorouracil therapy.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Colon Cancer V.2.2016. © National Comprehensive Cancer Network, Inc. 2016. All rights reserved. Accessed November 5 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Colon Cancer V.2.2016. \u00a9 National Comprehensive Cancer Network, Inc. 2016. All rights reserved. Accessed November 5 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/colon_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2016-01-01",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 771,
+        "feature_id": 771,
+        "source_id": 80,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Microsatellite Stability",
@@ -26031,14 +29115,18 @@
         "predictive_implication": "Guideline",
         "description": "Patients with MSI-High colorectal cancer often have a favorable prognosis.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Colon Cancer V.2.2016. © National Comprehensive Cancer Network, Inc. 2016. All rights reserved. Accessed November 5 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Colon Cancer V.2.2016. \u00a9 National Comprehensive Cancer Network, Inc. 2016. All rights reserved. Accessed November 5 2016. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/colon_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2016-01-01",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 772,
+        "feature_id": 772,
+        "source_id": 80,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Microsatellite Stability",
@@ -26063,7 +29151,11 @@
         "nct": "NCT01876511",
         "publication_date": "2015-06-25",
         "last_updated": "2023-10-31",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 773,
+        "feature_id": 773,
+        "source_id": 147,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Mutational Signature",
@@ -26088,7 +29180,11 @@
         "nct": "NCT01876511",
         "publication_date": "2015-06-25",
         "last_updated": "2023-10-31",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 774,
+        "feature_id": 774,
+        "source_id": 147,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Mutational Signature",
@@ -26113,7 +29209,11 @@
         "nct": "NCT01876511",
         "publication_date": "2015-06-25",
         "last_updated": "2023-10-31",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 775,
+        "feature_id": 775,
+        "source_id": 147,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Mutational Signature",
@@ -26138,7 +29238,11 @@
         "nct": "",
         "publication_date": "2017-07-05",
         "last_updated": "2023-10-31",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 776,
+        "feature_id": 776,
+        "source_id": 157,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Mutational Signature",
@@ -26163,7 +29267,11 @@
         "nct": "",
         "publication_date": "2017-07-05",
         "last_updated": "2023-10-31",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 777,
+        "feature_id": 777,
+        "source_id": 157,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Mutational Signature",
@@ -26188,7 +29296,11 @@
         "nct": "",
         "publication_date": "2017-07-05",
         "last_updated": "2023-10-31",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 778,
+        "feature_id": 778,
+        "source_id": 157,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Mutational Signature",
@@ -26213,7 +29325,11 @@
         "nct": "",
         "publication_date": "2017-07-05",
         "last_updated": "2023-10-31",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 779,
+        "feature_id": 779,
+        "source_id": 157,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Mutational Signature",
@@ -26238,7 +29354,11 @@
         "nct": "",
         "publication_date": "2016-06-10",
         "last_updated": "2023-10-31",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 780,
+        "feature_id": 780,
+        "source_id": 224,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Mutational Signature",
@@ -26263,7 +29383,11 @@
         "nct": "",
         "publication_date": "2016-06-10",
         "last_updated": "2023-10-31",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 781,
+        "feature_id": 781,
+        "source_id": 224,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Mutational Signature",
@@ -26288,7 +29412,11 @@
         "nct": "",
         "publication_date": "2015-10-29",
         "last_updated": "2023-10-31",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 782,
+        "feature_id": 782,
+        "source_id": 225,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Mutational Signature",
@@ -26313,7 +29441,11 @@
         "nct": "",
         "publication_date": "2015-10-29",
         "last_updated": "2023-10-31",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 783,
+        "feature_id": 783,
+        "source_id": 225,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Mutational Signature",
@@ -26338,7 +29470,11 @@
         "nct": "",
         "publication_date": "2015-10-29",
         "last_updated": "2023-10-31",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 784,
+        "feature_id": 784,
+        "source_id": 225,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Mutational Signature",
@@ -26363,7 +29499,11 @@
         "nct": "",
         "publication_date": "2015-10-29",
         "last_updated": "2023-10-31",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 785,
+        "feature_id": 785,
+        "source_id": 225,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Mutational Signature",
@@ -26388,7 +29528,11 @@
         "nct": "",
         "publication_date": "2015-10-29",
         "last_updated": "2023-10-31",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 786,
+        "feature_id": 786,
+        "source_id": 225,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Mutational Signature",
@@ -26413,7 +29557,11 @@
         "nct": "",
         "publication_date": "2015-02-25",
         "last_updated": "2023-10-31",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 787,
+        "feature_id": 787,
+        "source_id": 85,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Mutational Signature",
@@ -26438,7 +29586,11 @@
         "nct": "",
         "publication_date": "2015-03-12",
         "last_updated": "2023-10-31",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 788,
+        "feature_id": 788,
+        "source_id": 136,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Mutational Signature",
@@ -26463,7 +29615,11 @@
         "nct": "",
         "publication_date": "2015-03-12",
         "last_updated": "2023-10-31",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 789,
+        "feature_id": 789,
+        "source_id": 136,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Mutational Signature",
@@ -26488,7 +29644,11 @@
         "nct": "",
         "publication_date": "2016-04-25",
         "last_updated": "2023-10-31",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 790,
+        "feature_id": 790,
+        "source_id": 226,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Mutational Signature",
@@ -26513,7 +29673,11 @@
         "nct": "",
         "publication_date": "2020-11-01",
         "last_updated": "2023-10-31",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 791,
+        "feature_id": 791,
+        "source_id": 87,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Mutational Signature",
@@ -26538,7 +29702,11 @@
         "nct": "",
         "publication_date": "2020-11-01",
         "last_updated": "2023-10-31",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 792,
+        "feature_id": 792,
+        "source_id": 87,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Mutational Signature",
@@ -26563,7 +29731,11 @@
         "nct": "",
         "publication_date": "2020-11-01",
         "last_updated": "2023-10-31",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 793,
+        "feature_id": 793,
+        "source_id": 87,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Mutational Burden",
@@ -26581,16 +29753,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": "",
         "predictive_implication": "Guideline",
-        "description": "Nivolumab (Opdivo) in combination with ipilimumab (Yervoy) is recommended by the National Comprehensive Cancer Network® (NCCN®) as a treatment option as an immunotherapy agent for patients with metastatic non-small cell lung cancer whose tumors have a high tumor mutational burden (TMB)",
+        "description": "Nivolumab (Opdivo) in combination with ipilimumab (Yervoy) is recommended by the National Comprehensive Cancer Network\u00ae (NCCN\u00ae) as a treatment option as an immunotherapy agent for patients with metastatic non-small cell lung cancer whose tumors have a high tumor mutational burden (TMB)",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Non-Small Lung Cancer V.5.2019. © National Comprehensive Cancer Network, Inc. 2019. All rights reserved. Accessed August 12, 2019. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Non-Small Lung Cancer V.5.2019. \u00a9 National Comprehensive Cancer Network, Inc. 2019. All rights reserved. Accessed August 12, 2019. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/nscl_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2019-01-01",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 794,
+        "feature_id": 794,
+        "source_id": 11,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Mutational Burden",
@@ -26608,16 +29784,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": "",
         "predictive_implication": "Guideline",
-        "description": "Nivolumab (Opdivo) is recommended by the National Comprehensive Cancer Network® (NCCN®) as a treatment option as an immunotherapy agent for patients with metastatic non-small cell lung cancer whose tumors have a high tumor mutational burden (TMB)",
+        "description": "Nivolumab (Opdivo) is recommended by the National Comprehensive Cancer Network\u00ae (NCCN\u00ae) as a treatment option as an immunotherapy agent for patients with metastatic non-small cell lung cancer whose tumors have a high tumor mutational burden (TMB)",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Non-Small Lung Cancer V.5.2019. © National Comprehensive Cancer Network, Inc. 2019. All rights reserved. Accessed August 12, 2019. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Non-Small Lung Cancer V.5.2019. \u00a9 National Comprehensive Cancer Network, Inc. 2019. All rights reserved. Accessed August 12, 2019. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/nscl_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2019-01-01",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 795,
+        "feature_id": 795,
+        "source_id": 11,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Mutational Burden",
@@ -26644,7 +29824,11 @@
         "nct": "",
         "publication_date": "2015-03-12",
         "last_updated": "2017-03-12",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 796,
+        "feature_id": 796,
+        "source_id": 136,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Mutational Burden",
@@ -26671,7 +29855,11 @@
         "nct": "",
         "publication_date": "2014-12-04",
         "last_updated": "2017-03-12",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 797,
+        "feature_id": 797,
+        "source_id": 227,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Mutational Burden",
@@ -26698,7 +29886,11 @@
         "nct": "",
         "publication_date": "2015-09-10",
         "last_updated": "2017-03-12",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 798,
+        "feature_id": 798,
+        "source_id": 228,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Mutational Burden",
@@ -26725,7 +29917,11 @@
         "nct": "",
         "publication_date": "2020-10-01",
         "last_updated": "2021-09-16",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 799,
+        "feature_id": 799,
+        "source_id": 223,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Knockdown",
@@ -26751,7 +29947,11 @@
         "nct": "",
         "publication_date": "2017-04-01",
         "last_updated": "2023-10-05",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 800,
+        "feature_id": 800,
+        "source_id": 57,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Knockdown",
@@ -26777,7 +29977,11 @@
         "nct": "",
         "publication_date": "2017-08-07",
         "last_updated": "2019-04-16",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 801,
+        "feature_id": 801,
+        "source_id": 229,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Knockdown",
@@ -26803,7 +30007,11 @@
         "nct": "",
         "publication_date": "2014-01-05",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 802,
+        "feature_id": 802,
+        "source_id": 230,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Knockdown",
@@ -26829,7 +30037,11 @@
         "nct": "",
         "publication_date": "2014-03-08",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 803,
+        "feature_id": 803,
+        "source_id": 231,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Knockdown",
@@ -26855,7 +30067,11 @@
         "nct": "",
         "publication_date": "2016-10-25",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 804,
+        "feature_id": 804,
+        "source_id": 232,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Knockdown",
@@ -26881,7 +30097,11 @@
         "nct": "",
         "publication_date": "2011-11-03",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 805,
+        "feature_id": 805,
+        "source_id": 233,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Knockdown",
@@ -26907,7 +30127,11 @@
         "nct": "",
         "publication_date": "2011-11-03",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 806,
+        "feature_id": 806,
+        "source_id": 233,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Knockdown",
@@ -26933,7 +30157,11 @@
         "nct": "",
         "publication_date": "2011-11-03",
         "last_updated": "2017-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 807,
+        "feature_id": 807,
+        "source_id": 233,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Knockdown",
@@ -26959,7 +30187,11 @@
         "nct": "",
         "publication_date": "2017-08-07",
         "last_updated": "2019-04-16",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 808,
+        "feature_id": 808,
+        "source_id": 229,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Knockdown",
@@ -26985,7 +30217,11 @@
         "nct": "",
         "publication_date": "2016-08-31",
         "last_updated": "2019-04-30",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 809,
+        "feature_id": 809,
+        "source_id": 234,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Aneuploidy",
@@ -27010,7 +30246,11 @@
         "nct": "",
         "publication_date": "2018-07-16",
         "last_updated": "2018-09-01",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 810,
+        "feature_id": 810,
+        "source_id": 235,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -27045,7 +30285,11 @@
         "nct": "",
         "publication_date": "2022-03-01",
         "last_updated": "2022-07-07",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 811,
+        "feature_id": 811,
+        "source_id": 236,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -27080,7 +30324,11 @@
         "nct": "",
         "publication_date": "2022-05-01",
         "last_updated": "2022-07-07",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 812,
+        "feature_id": 812,
+        "source_id": 237,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -27115,7 +30363,11 @@
         "nct": "",
         "publication_date": "2022-05-01",
         "last_updated": "2022-07-07",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 813,
+        "feature_id": 813,
+        "source_id": 237,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -27150,7 +30402,11 @@
         "nct": "",
         "publication_date": "2022-05-01",
         "last_updated": "2022-07-07",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 814,
+        "feature_id": 814,
+        "source_id": 237,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -27185,7 +30441,11 @@
         "nct": "",
         "publication_date": "2022-05-01",
         "last_updated": "2022-07-07",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 815,
+        "feature_id": 815,
+        "source_id": 237,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Microsatellite Stability",
@@ -27210,7 +30470,11 @@
         "nct": "NCT01876511",
         "publication_date": "2015-06-25",
         "last_updated": "2023-10-31",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 816,
+        "feature_id": 816,
+        "source_id": 147,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Microsatellite Stability",
@@ -27235,7 +30499,11 @@
         "nct": "",
         "publication_date": "2021-03-01",
         "last_updated": "2022-07-07",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 817,
+        "feature_id": 817,
+        "source_id": 238,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Germline Variant",
@@ -27272,7 +30540,11 @@
         "nct": "NCT00516373",
         "publication_date": "2009-07-09",
         "last_updated": "2022-08-04",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 818,
+        "feature_id": 818,
+        "source_id": 239,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Germline Variant",
@@ -27309,7 +30581,11 @@
         "nct": "NCT00516373",
         "publication_date": "2009-07-09",
         "last_updated": "2022-08-04",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 819,
+        "feature_id": 819,
+        "source_id": 239,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Germline Variant",
@@ -27346,7 +30622,11 @@
         "nct": "NCT00516373",
         "publication_date": "2009-07-09",
         "last_updated": "2022-08-04",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 820,
+        "feature_id": 820,
+        "source_id": 239,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Germline Variant",
@@ -27383,7 +30663,11 @@
         "nct": "NCT00516373",
         "publication_date": "2009-07-09",
         "last_updated": "2022-08-04",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 821,
+        "feature_id": 821,
+        "source_id": 239,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Germline Variant",
@@ -27420,7 +30704,11 @@
         "nct": "NCT00516373",
         "publication_date": "2009-07-09",
         "last_updated": "2022-08-04",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 822,
+        "feature_id": 822,
+        "source_id": 239,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Germline Variant",
@@ -27457,7 +30745,11 @@
         "nct": "NCT00516373",
         "publication_date": "2009-07-09",
         "last_updated": "2022-08-04",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 823,
+        "feature_id": 823,
+        "source_id": 239,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Knockdown",
@@ -27483,7 +30775,11 @@
         "nct": "",
         "publication_date": "2020-04-15",
         "last_updated": "2023-10-05",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 824,
+        "feature_id": 824,
+        "source_id": 240,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Knockdown",
@@ -27509,7 +30805,11 @@
         "nct": "",
         "publication_date": "2010-05-07",
         "last_updated": "2022-08-04",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 825,
+        "feature_id": 825,
+        "source_id": 241,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Rearrangement",
@@ -27537,7 +30837,11 @@
         "nct": "",
         "publication_date": "2022-07-14",
         "last_updated": "2024-03-04",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 826,
+        "feature_id": 826,
+        "source_id": 242,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -27572,7 +30876,11 @@
         "nct": "",
         "publication_date": "2005-04-14",
         "last_updated": "2022-08-04",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 827,
+        "feature_id": 827,
+        "source_id": 243,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -27607,7 +30915,11 @@
         "nct": "",
         "publication_date": "2005-04-14",
         "last_updated": "2022-08-04",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 828,
+        "feature_id": 828,
+        "source_id": 243,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -27642,7 +30954,11 @@
         "nct": "",
         "publication_date": "2005-04-14",
         "last_updated": "2022-08-04",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 829,
+        "feature_id": 829,
+        "source_id": 243,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -27677,7 +30993,11 @@
         "nct": "",
         "publication_date": "2005-04-14",
         "last_updated": "2022-08-04",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 830,
+        "feature_id": 830,
+        "source_id": 243,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -27712,7 +31032,11 @@
         "nct": "",
         "publication_date": "2005-04-14",
         "last_updated": "2022-08-04",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 831,
+        "feature_id": 831,
+        "source_id": 243,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -27747,7 +31071,11 @@
         "nct": "",
         "publication_date": "2005-04-14",
         "last_updated": "2022-08-04",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 832,
+        "feature_id": 832,
+        "source_id": 243,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -27782,7 +31110,11 @@
         "nct": "",
         "publication_date": "2005-04-14",
         "last_updated": "2022-08-04",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 833,
+        "feature_id": 833,
+        "source_id": 243,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -27817,7 +31149,11 @@
         "nct": "",
         "publication_date": "2005-04-14",
         "last_updated": "2022-08-04",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 834,
+        "feature_id": 834,
+        "source_id": 243,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -27852,7 +31188,11 @@
         "nct": "",
         "publication_date": "2018-12-12",
         "last_updated": "2023-10-31",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 835,
+        "feature_id": 835,
+        "source_id": 244,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -27887,7 +31227,11 @@
         "nct": "",
         "publication_date": "2018-12-12",
         "last_updated": "2022-08-04",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 836,
+        "feature_id": 836,
+        "source_id": 244,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -27922,7 +31266,11 @@
         "nct": "",
         "publication_date": "2020-04-15",
         "last_updated": "2022-08-04",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 837,
+        "feature_id": 837,
+        "source_id": 240,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -27957,7 +31305,11 @@
         "nct": "",
         "publication_date": "2020-04-15",
         "last_updated": "2022-08-04",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 838,
+        "feature_id": 838,
+        "source_id": 240,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Copy Number",
@@ -27985,7 +31337,11 @@
         "nct": "",
         "publication_date": "2015-02-01",
         "last_updated": "2022-08-04",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 839,
+        "feature_id": 839,
+        "source_id": 245,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Copy Number",
@@ -28013,7 +31369,11 @@
         "nct": "",
         "publication_date": "2005-04-14",
         "last_updated": "2022-08-04",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 840,
+        "feature_id": 840,
+        "source_id": 243,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Copy Number",
@@ -28041,7 +31401,11 @@
         "nct": "",
         "publication_date": "2005-04-14",
         "last_updated": "2022-08-04",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 841,
+        "feature_id": 841,
+        "source_id": 243,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Copy Number",
@@ -28069,7 +31433,11 @@
         "nct": "",
         "publication_date": "2018-12-12",
         "last_updated": "2022-08-04",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 842,
+        "feature_id": 842,
+        "source_id": 244,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Copy Number",
@@ -28097,7 +31465,11 @@
         "nct": "",
         "publication_date": "2017-03-10",
         "last_updated": "2022-08-04",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 843,
+        "feature_id": 843,
+        "source_id": 246,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Copy Number",
@@ -28125,7 +31497,11 @@
         "nct": "",
         "publication_date": "2020-09-01",
         "last_updated": "2022-08-04",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 844,
+        "feature_id": 844,
+        "source_id": 247,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Copy Number",
@@ -28153,7 +31529,11 @@
         "nct": "",
         "publication_date": "2012-07-01",
         "last_updated": "2022-08-04",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 845,
+        "feature_id": 845,
+        "source_id": 248,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Copy Number",
@@ -28181,7 +31561,11 @@
         "nct": "",
         "publication_date": "2012-07-01",
         "last_updated": "2025-01-08",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 846,
+        "feature_id": 846,
+        "source_id": 248,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Copy Number",
@@ -28209,7 +31593,11 @@
         "nct": "",
         "publication_date": "2012-07-01",
         "last_updated": "2025-01-08",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 847,
+        "feature_id": 847,
+        "source_id": 248,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Copy Number",
@@ -28237,7 +31625,11 @@
         "nct": "",
         "publication_date": "2012-07-01",
         "last_updated": "2022-08-04",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 848,
+        "feature_id": 848,
+        "source_id": 248,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Copy Number",
@@ -28265,7 +31657,11 @@
         "nct": "",
         "publication_date": "2009-03-17",
         "last_updated": "2022-08-04",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 849,
+        "feature_id": 849,
+        "source_id": 249,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Copy Number",
@@ -28293,7 +31689,11 @@
         "nct": "",
         "publication_date": "2005-08-01",
         "last_updated": "2022-08-04",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 850,
+        "feature_id": 850,
+        "source_id": 250,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Copy Number",
@@ -28321,7 +31721,11 @@
         "nct": "",
         "publication_date": "2017-02-28",
         "last_updated": "2022-08-04",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 851,
+        "feature_id": 851,
+        "source_id": 251,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Copy Number",
@@ -28349,7 +31753,11 @@
         "nct": "",
         "publication_date": "2017-02-28",
         "last_updated": "2022-08-04",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 852,
+        "feature_id": 852,
+        "source_id": 251,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Copy Number",
@@ -28377,7 +31785,11 @@
         "nct": "",
         "publication_date": "2020-04-15",
         "last_updated": "2022-08-04",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 853,
+        "feature_id": 853,
+        "source_id": 240,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Rearrangement",
@@ -28405,7 +31817,11 @@
         "nct": "",
         "publication_date": "2022-08-01",
         "last_updated": "2022-09-08",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 854,
+        "feature_id": 854,
+        "source_id": 252,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Rearrangement",
@@ -28433,7 +31849,11 @@
         "nct": "",
         "publication_date": "2022-09-01",
         "last_updated": "2022-10-06",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 855,
+        "feature_id": 855,
+        "source_id": 253,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Rearrangement",
@@ -28461,7 +31881,11 @@
         "nct": "",
         "publication_date": "2024-05-29",
         "last_updated": "2024-06-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 856,
+        "feature_id": 856,
+        "source_id": 254,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -28496,7 +31920,11 @@
         "nct": "",
         "publication_date": "2022-12-01",
         "last_updated": "2023-01-05",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 857,
+        "feature_id": 857,
+        "source_id": 255,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -28531,7 +31959,11 @@
         "nct": "",
         "publication_date": "2022-12-01",
         "last_updated": "2023-01-05",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 858,
+        "feature_id": 858,
+        "source_id": 255,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -28566,7 +31998,11 @@
         "nct": "",
         "publication_date": "2022-12-01",
         "last_updated": "2023-01-05",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 859,
+        "feature_id": 859,
+        "source_id": 255,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -28601,7 +32037,11 @@
         "nct": "",
         "publication_date": "2022-12-01",
         "last_updated": "2023-01-05",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 860,
+        "feature_id": 860,
+        "source_id": 255,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -28636,7 +32076,11 @@
         "nct": "",
         "publication_date": "2022-12-01",
         "last_updated": "2023-01-05",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 861,
+        "feature_id": 861,
+        "source_id": 255,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -28671,7 +32115,11 @@
         "nct": "",
         "publication_date": "2022-12-01",
         "last_updated": "2023-11-30",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 862,
+        "feature_id": 862,
+        "source_id": 256,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Copy Number",
@@ -28698,7 +32146,11 @@
         "nct": "",
         "publication_date": "2023-01-19",
         "last_updated": "2023-02-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 863,
+        "feature_id": 863,
+        "source_id": 257,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -28733,7 +32185,11 @@
         "nct": "",
         "publication_date": "2023-01-27",
         "last_updated": "2023-02-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 864,
+        "feature_id": 864,
+        "source_id": 258,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -28768,7 +32224,11 @@
         "nct": "",
         "publication_date": "2023-03-16",
         "last_updated": "2023-04-06",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 865,
+        "feature_id": 865,
+        "source_id": 259,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -28803,7 +32263,11 @@
         "nct": "",
         "publication_date": "2023-03-11",
         "last_updated": "2023-07-05",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 866,
+        "feature_id": 866,
+        "source_id": 172,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -28838,7 +32302,11 @@
         "nct": "",
         "publication_date": "2023-03-11",
         "last_updated": "2025-01-08",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 867,
+        "feature_id": 867,
+        "source_id": 172,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Germline Variant",
@@ -28874,7 +32342,11 @@
         "nct": "",
         "publication_date": "2023-03-11",
         "last_updated": "2023-07-05",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 868,
+        "feature_id": 868,
+        "source_id": 172,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Germline Variant",
@@ -28910,7 +32382,11 @@
         "nct": "",
         "publication_date": "2023-03-11",
         "last_updated": "2023-07-05",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 869,
+        "feature_id": 869,
+        "source_id": 172,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Germline Variant",
@@ -28946,7 +32422,11 @@
         "nct": "",
         "publication_date": "2023-03-11",
         "last_updated": "2023-07-05",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 870,
+        "feature_id": 870,
+        "source_id": 172,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Germline Variant",
@@ -28982,7 +32462,11 @@
         "nct": "",
         "publication_date": "2023-03-11",
         "last_updated": "2023-07-05",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 871,
+        "feature_id": 871,
+        "source_id": 172,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Germline Variant",
@@ -29019,7 +32503,11 @@
         "nct": "",
         "publication_date": "2023-03-11",
         "last_updated": "2023-07-06",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 872,
+        "feature_id": 872,
+        "source_id": 172,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Germline Variant",
@@ -29056,7 +32544,11 @@
         "nct": "",
         "publication_date": "2023-03-11",
         "last_updated": "2023-07-06",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 873,
+        "feature_id": 873,
+        "source_id": 172,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -29092,7 +32584,11 @@
         "nct": "",
         "publication_date": "2023-06-20",
         "last_updated": "2023-07-06",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 874,
+        "feature_id": 874,
+        "source_id": 260,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -29128,7 +32624,11 @@
         "nct": "",
         "publication_date": "2023-06-20",
         "last_updated": "2023-07-06",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 875,
+        "feature_id": 875,
+        "source_id": 260,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -29164,7 +32664,11 @@
         "nct": "",
         "publication_date": "2023-06-20",
         "last_updated": "2023-07-06",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 876,
+        "feature_id": 876,
+        "source_id": 260,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -29200,7 +32704,11 @@
         "nct": "",
         "publication_date": "2023-06-20",
         "last_updated": "2023-07-06",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 877,
+        "feature_id": 877,
+        "source_id": 260,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -29236,7 +32744,11 @@
         "nct": "",
         "publication_date": "2023-06-20",
         "last_updated": "2023-07-06",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 878,
+        "feature_id": 878,
+        "source_id": 260,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -29272,7 +32784,11 @@
         "nct": "",
         "publication_date": "2023-06-20",
         "last_updated": "2023-07-06",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 879,
+        "feature_id": 879,
+        "source_id": 260,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -29308,7 +32824,11 @@
         "nct": "",
         "publication_date": "2023-06-20",
         "last_updated": "2023-07-06",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 880,
+        "feature_id": 880,
+        "source_id": 260,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -29344,7 +32864,11 @@
         "nct": "",
         "publication_date": "2023-06-20",
         "last_updated": "2023-07-06",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 881,
+        "feature_id": 881,
+        "source_id": 260,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -29380,7 +32904,11 @@
         "nct": "",
         "publication_date": "2023-06-20",
         "last_updated": "2023-07-06",
-        "_deprecated": true
+        "_deprecated": true,
+        "assertion_id": 882,
+        "feature_id": 882,
+        "source_id": 260,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -29416,7 +32944,11 @@
         "nct": "",
         "publication_date": "2023-06-20",
         "last_updated": "2023-07-06",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 883,
+        "feature_id": 883,
+        "source_id": 260,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -29452,7 +32984,11 @@
         "nct": "",
         "publication_date": "2023-06-20",
         "last_updated": "2023-07-06",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 884,
+        "feature_id": 884,
+        "source_id": 260,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -29488,7 +33024,11 @@
         "nct": "",
         "publication_date": "2023-06-20",
         "last_updated": "2023-07-06",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 885,
+        "feature_id": 885,
+        "source_id": 260,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Germline Variant",
@@ -29525,7 +33065,11 @@
         "nct": "",
         "publication_date": "2023-08-11",
         "last_updated": "2023-09-06",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 886,
+        "feature_id": 886,
+        "source_id": 261,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -29561,7 +33105,11 @@
         "nct": "",
         "publication_date": "2023-08-11",
         "last_updated": "2023-09-06",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 887,
+        "feature_id": 887,
+        "source_id": 261,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Germline Variant",
@@ -29598,7 +33146,11 @@
         "nct": "",
         "publication_date": "2023-08-11",
         "last_updated": "2023-09-06",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 888,
+        "feature_id": 888,
+        "source_id": 261,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -29634,7 +33186,11 @@
         "nct": "",
         "publication_date": "2023-08-11",
         "last_updated": "2023-09-06",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 889,
+        "feature_id": 889,
+        "source_id": 261,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Microsatellite Stability",
@@ -29659,7 +33215,11 @@
         "nct": "",
         "publication_date": "2023-07-31",
         "last_updated": "2023-09-06",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 890,
+        "feature_id": 890,
+        "source_id": 262,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -29695,7 +33255,11 @@
         "nct": "",
         "publication_date": "2019-01-22",
         "last_updated": "2023-07-06",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 891,
+        "feature_id": 891,
+        "source_id": 263,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -29731,7 +33295,11 @@
         "nct": "",
         "publication_date": "2018-07-13",
         "last_updated": "2025-01-08",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 892,
+        "feature_id": 892,
+        "source_id": 264,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Copy Number",
@@ -29759,7 +33327,11 @@
         "nct": "",
         "publication_date": "2018-07-13",
         "last_updated": "2025-01-08",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 893,
+        "feature_id": 893,
+        "source_id": 264,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Copy Number",
@@ -29787,7 +33359,11 @@
         "nct": "",
         "publication_date": "2018-07-13",
         "last_updated": "2025-01-08",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 894,
+        "feature_id": 894,
+        "source_id": 264,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -29823,7 +33399,11 @@
         "nct": "",
         "publication_date": "2021-12-03",
         "last_updated": "2025-01-08",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 895,
+        "feature_id": 895,
+        "source_id": 265,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Copy Number",
@@ -29851,7 +33431,11 @@
         "nct": "",
         "publication_date": "2019-01-09",
         "last_updated": "2023-07-06",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 896,
+        "feature_id": 896,
+        "source_id": 266,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Copy Number",
@@ -29879,7 +33463,11 @@
         "nct": "",
         "publication_date": "2019-01-09",
         "last_updated": "2025-01-08",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 897,
+        "feature_id": 897,
+        "source_id": 266,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Copy Number",
@@ -29907,7 +33495,11 @@
         "nct": "",
         "publication_date": "2019-01-09",
         "last_updated": "2025-01-08",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 898,
+        "feature_id": 898,
+        "source_id": 266,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Copy Number",
@@ -29935,7 +33527,11 @@
         "nct": "",
         "publication_date": "2019-01-09",
         "last_updated": "2025-01-08",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 899,
+        "feature_id": 899,
+        "source_id": 266,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Copy Number",
@@ -29963,7 +33559,11 @@
         "nct": "",
         "publication_date": "2019-01-09",
         "last_updated": "2025-01-08",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 900,
+        "feature_id": 900,
+        "source_id": 266,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Copy Number",
@@ -29991,7 +33591,11 @@
         "nct": "",
         "publication_date": "2017-07-25",
         "last_updated": "2025-01-08",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 901,
+        "feature_id": 901,
+        "source_id": 267,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Copy Number",
@@ -30019,7 +33623,11 @@
         "nct": "",
         "publication_date": "2017-07-25",
         "last_updated": "2025-01-08",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 902,
+        "feature_id": 902,
+        "source_id": 267,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Copy Number",
@@ -30047,7 +33655,11 @@
         "nct": "",
         "publication_date": "2017-07-25",
         "last_updated": "2025-01-08",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 903,
+        "feature_id": 903,
+        "source_id": 267,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Copy Number",
@@ -30075,7 +33687,11 @@
         "nct": "",
         "publication_date": "2017-07-25",
         "last_updated": "2025-01-08",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 904,
+        "feature_id": 904,
+        "source_id": 267,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Copy Number",
@@ -30103,7 +33719,11 @@
         "nct": "",
         "publication_date": "2017-07-25",
         "last_updated": "2025-01-08",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 905,
+        "feature_id": 905,
+        "source_id": 267,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Copy Number",
@@ -30131,7 +33751,11 @@
         "nct": "",
         "publication_date": "2017-07-25",
         "last_updated": "2025-01-08",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 906,
+        "feature_id": 906,
+        "source_id": 267,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Rearrangement",
@@ -30160,7 +33784,11 @@
         "nct": "",
         "publication_date": "2023-09-26",
         "last_updated": "2023-11-01",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 907,
+        "feature_id": 907,
+        "source_id": 268,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -30195,7 +33823,11 @@
         "nct": "",
         "publication_date": "2023-10-24",
         "last_updated": "2023-11-01",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 908,
+        "feature_id": 908,
+        "source_id": 269,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -30230,7 +33862,11 @@
         "nct": "",
         "publication_date": "2023-10-24",
         "last_updated": "2023-11-01",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 909,
+        "feature_id": 909,
+        "source_id": 269,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -30265,7 +33901,11 @@
         "nct": "",
         "publication_date": "2023-10-24",
         "last_updated": "2023-11-01",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 910,
+        "feature_id": 910,
+        "source_id": 269,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -30300,7 +33940,11 @@
         "nct": "",
         "publication_date": "2023-10-11",
         "last_updated": "2023-11-01",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 911,
+        "feature_id": 911,
+        "source_id": 270,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -30326,16 +33970,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": 0,
         "predictive_implication": "Guideline",
-        "description": "The National Comprehensive Cancer Network® (NCCN®) highlights FLT3 Internal Tandem Duplication and D835 missense codon changes as being associated with poor prognosis in patients with myelodysplastic syndromes.",
+        "description": "The National Comprehensive Cancer Network\u00ae (NCCN\u00ae) highlights FLT3 Internal Tandem Duplication and D835 missense codon changes as being associated with poor prognosis in patients with myelodysplastic syndromes.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Myelodysplastic Syndromes V.2.2023. © National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Myelodysplastic Syndromes V.2.2023. \u00a9 National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/mds_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2023-10-17",
         "last_updated": "2023-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 912,
+        "feature_id": 912,
+        "source_id": 33,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -30361,16 +34009,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": 0,
         "predictive_implication": "Guideline",
-        "description": "The National Comprehensive Cancer Network® (NCCN®) highlights FLT3 Internal Tandem Duplication and D835 missense codon changes as being associated with poor prognosis in patients with myelodysplastic syndromes.",
+        "description": "The National Comprehensive Cancer Network\u00ae (NCCN\u00ae) highlights FLT3 Internal Tandem Duplication and D835 missense codon changes as being associated with poor prognosis in patients with myelodysplastic syndromes.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Myelodysplastic Syndromes V.2.2023. © National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Myelodysplastic Syndromes V.2.2023. \u00a9 National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/mds_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2023-10-17",
         "last_updated": "2023-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 913,
+        "feature_id": 913,
+        "source_id": 33,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -30396,16 +34048,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": 0,
         "predictive_implication": "Guideline",
-        "description": "The National Comprehensive Cancer Network® (NCCN®) highlights FLT3 Internal Tandem Duplication and D835 missense codon changes as being associated with poor prognosis in patients with myelodysplastic syndromes.",
+        "description": "The National Comprehensive Cancer Network\u00ae (NCCN\u00ae) highlights FLT3 Internal Tandem Duplication and D835 missense codon changes as being associated with poor prognosis in patients with myelodysplastic syndromes.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Myelodysplastic Syndromes V.2.2023. © National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Myelodysplastic Syndromes V.2.2023. \u00a9 National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/mds_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2023-10-17",
         "last_updated": "2023-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 914,
+        "feature_id": 914,
+        "source_id": 33,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -30431,16 +34087,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": 0,
         "predictive_implication": "Guideline",
-        "description": "The National Comprehensive Cancer Network® (NCCN®) highlights FLT3 Internal Tandem Duplication and D835 missense codon changes as being associated with poor prognosis in patients with myelodysplastic syndromes.",
+        "description": "The National Comprehensive Cancer Network\u00ae (NCCN\u00ae) highlights FLT3 Internal Tandem Duplication and D835 missense codon changes as being associated with poor prognosis in patients with myelodysplastic syndromes.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Myelodysplastic Syndromes V.2.2023. © National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Myelodysplastic Syndromes V.2.2023. \u00a9 National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/mds_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2023-10-17",
         "last_updated": "2023-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 915,
+        "feature_id": 915,
+        "source_id": 33,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -30466,16 +34126,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": 0,
         "predictive_implication": "Guideline",
-        "description": "The National Comprehensive Cancer Network® (NCCN®) highlights GATA2 nonsense, frameshift, splice site, and missense codon changes in codons 349 - 398 as being associated with poor prognosis in patients with myelodysplastic syndromes.",
+        "description": "The National Comprehensive Cancer Network\u00ae (NCCN\u00ae) highlights GATA2 nonsense, frameshift, splice site, and missense codon changes in codons 349 - 398 as being associated with poor prognosis in patients with myelodysplastic syndromes.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Myelodysplastic Syndromes V.2.2023. © National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Myelodysplastic Syndromes V.2.2023. \u00a9 National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/mds_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2023-10-17",
         "last_updated": "2023-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 916,
+        "feature_id": 916,
+        "source_id": 33,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -30501,16 +34165,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": 0,
         "predictive_implication": "Guideline",
-        "description": "The National Comprehensive Cancer Network® (NCCN®) highlights GATA2 nonsense, frameshift, splice site, and missense codon changes in codons 349 - 398 as being associated with poor prognosis in patients with myelodysplastic syndromes.",
+        "description": "The National Comprehensive Cancer Network\u00ae (NCCN\u00ae) highlights GATA2 nonsense, frameshift, splice site, and missense codon changes in codons 349 - 398 as being associated with poor prognosis in patients with myelodysplastic syndromes.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Myelodysplastic Syndromes V.2.2023. © National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Myelodysplastic Syndromes V.2.2023. \u00a9 National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/mds_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2023-10-17",
         "last_updated": "2023-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 917,
+        "feature_id": 917,
+        "source_id": 33,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -30536,16 +34204,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": 0,
         "predictive_implication": "Guideline",
-        "description": "The National Comprehensive Cancer Network® (NCCN®) highlights GATA2 nonsense, frameshift, splice site, and missense codon changes in codons 349 - 398 as being associated with poor prognosis in patients with myelodysplastic syndromes.",
+        "description": "The National Comprehensive Cancer Network\u00ae (NCCN\u00ae) highlights GATA2 nonsense, frameshift, splice site, and missense codon changes in codons 349 - 398 as being associated with poor prognosis in patients with myelodysplastic syndromes.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Myelodysplastic Syndromes V.2.2023. © National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Myelodysplastic Syndromes V.2.2023. \u00a9 National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/mds_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2023-10-17",
         "last_updated": "2023-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 918,
+        "feature_id": 918,
+        "source_id": 33,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -30571,16 +34243,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": 0,
         "predictive_implication": "Guideline",
-        "description": "The National Comprehensive Cancer Network® (NCCN®) highlights GATA2 nonsense, frameshift, splice site, and missense codon changes in codons 349 - 398 as being associated with poor prognosis in patients with myelodysplastic syndromes.",
+        "description": "The National Comprehensive Cancer Network\u00ae (NCCN\u00ae) highlights GATA2 nonsense, frameshift, splice site, and missense codon changes in codons 349 - 398 as being associated with poor prognosis in patients with myelodysplastic syndromes.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Myelodysplastic Syndromes V.2.2023. © National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Myelodysplastic Syndromes V.2.2023. \u00a9 National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/mds_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2023-10-17",
         "last_updated": "2023-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 919,
+        "feature_id": 919,
+        "source_id": 33,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -30606,16 +34282,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": 0,
         "predictive_implication": "Guideline",
-        "description": "The National Comprehensive Cancer Network® (NCCN®) highlights NPM1 p.W288Cfs*12 as being associated with poor prognosis in patients with myelodysplastic syndromes.",
+        "description": "The National Comprehensive Cancer Network\u00ae (NCCN\u00ae) highlights NPM1 p.W288Cfs*12 as being associated with poor prognosis in patients with myelodysplastic syndromes.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Myelodysplastic Syndromes V.2.2023. © National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Myelodysplastic Syndromes V.2.2023. \u00a9 National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/mds_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2023-10-17",
         "last_updated": "2023-11-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 920,
+        "feature_id": 920,
+        "source_id": 33,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -30641,16 +34321,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": 0,
         "predictive_implication": "Guideline",
-        "description": "The National Comprehensive Cancer Network® (NCCN®) highlights SRSF2 missense and in-frame deletion variants involving P95 codon as being associated with poor prognosis in patients with myelodysplastic syndromes.",
+        "description": "The National Comprehensive Cancer Network\u00ae (NCCN\u00ae) highlights SRSF2 missense and in-frame deletion variants involving P95 codon as being associated with poor prognosis in patients with myelodysplastic syndromes.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Myelodysplastic Syndromes V.2.2023. © National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Myelodysplastic Syndromes V.2.2023. \u00a9 National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/mds_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2023-10-17",
         "last_updated": "2023-11-06",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 921,
+        "feature_id": 921,
+        "source_id": 33,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -30676,16 +34360,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": 0,
         "predictive_implication": "Guideline",
-        "description": "The National Comprehensive Cancer Network® (NCCN®) highlights SRSF2 missense and in-frame deletion variants involving P95 codon as being associated with poor prognosis in patients with myelodysplastic syndromes.",
+        "description": "The National Comprehensive Cancer Network\u00ae (NCCN\u00ae) highlights SRSF2 missense and in-frame deletion variants involving P95 codon as being associated with poor prognosis in patients with myelodysplastic syndromes.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Myelodysplastic Syndromes V.2.2023. © National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Myelodysplastic Syndromes V.2.2023. \u00a9 National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/mds_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2023-10-17",
         "last_updated": "2023-11-06",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 922,
+        "feature_id": 922,
+        "source_id": 33,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -30711,16 +34399,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": 0,
         "predictive_implication": "Guideline",
-        "description": "The National Comprehensive Cancer Network® (NCCN®) highlights SRSF2 missense and in-frame deletion variants involving P95 codon as being associated with poor prognosis in patients with myelodysplastic syndromes.",
+        "description": "The National Comprehensive Cancer Network\u00ae (NCCN\u00ae) highlights SRSF2 missense and in-frame deletion variants involving P95 codon as being associated with poor prognosis in patients with myelodysplastic syndromes.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Myelodysplastic Syndromes V.2.2023. © National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Myelodysplastic Syndromes V.2.2023. \u00a9 National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/mds_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2023-10-17",
         "last_updated": "2023-11-06",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 923,
+        "feature_id": 923,
+        "source_id": 33,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -30746,16 +34438,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": 0,
         "predictive_implication": "Guideline",
-        "description": "The National Comprehensive Cancer Network® (NCCN®) highlights SRSF2 missense and in-frame deletion variants involving P95 codon as being associated with poor prognosis in patients with myelodysplastic syndromes.",
+        "description": "The National Comprehensive Cancer Network\u00ae (NCCN\u00ae) highlights SRSF2 missense and in-frame deletion variants involving P95 codon as being associated with poor prognosis in patients with myelodysplastic syndromes.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Myelodysplastic Syndromes V.2.2023. © National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Myelodysplastic Syndromes V.2.2023. \u00a9 National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/mds_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2023-10-17",
         "last_updated": "2023-11-06",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 924,
+        "feature_id": 924,
+        "source_id": 33,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -30781,16 +34477,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": 0,
         "predictive_implication": "Guideline",
-        "description": "The National Comprehensive Cancer Network® (NCCN®) highlights SRSF2 missense and in-frame deletion variants involving P95 codon as being associated with poor prognosis in patients with myelodysplastic syndromes.",
+        "description": "The National Comprehensive Cancer Network\u00ae (NCCN\u00ae) highlights SRSF2 missense and in-frame deletion variants involving P95 codon as being associated with poor prognosis in patients with myelodysplastic syndromes.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Myelodysplastic Syndromes V.2.2023. © National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Myelodysplastic Syndromes V.2.2023. \u00a9 National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/mds_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2023-10-17",
         "last_updated": "2023-11-06",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 925,
+        "feature_id": 925,
+        "source_id": 33,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -30816,16 +34516,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": 0,
         "predictive_implication": "Guideline",
-        "description": "The National Comprehensive Cancer Network® (NCCN®) highlights WT1 frameshift, splice site, and nonsense variants as associated with poor prognosis in myelodysplastic syndromes.",
+        "description": "The National Comprehensive Cancer Network\u00ae (NCCN\u00ae) highlights WT1 frameshift, splice site, and nonsense variants as associated with poor prognosis in myelodysplastic syndromes.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Myelodysplastic Syndromes V.2.2023. © National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Myelodysplastic Syndromes V.2.2023. \u00a9 National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/mds_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2023-10-17",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 926,
+        "feature_id": 926,
+        "source_id": 33,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -30851,16 +34555,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": 0,
         "predictive_implication": "Guideline",
-        "description": "The National Comprehensive Cancer Network® (NCCN®) highlights WT1 frameshift, splice site, and nonsense variants as associated with poor prognosis in myelodysplastic syndromes.",
+        "description": "The National Comprehensive Cancer Network\u00ae (NCCN\u00ae) highlights WT1 frameshift, splice site, and nonsense variants as associated with poor prognosis in myelodysplastic syndromes.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Myelodysplastic Syndromes V.2.2023. © National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Myelodysplastic Syndromes V.2.2023. \u00a9 National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/mds_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2023-10-17",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 927,
+        "feature_id": 927,
+        "source_id": 33,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -30886,16 +34594,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": 0,
         "predictive_implication": "Guideline",
-        "description": "The National Comprehensive Cancer Network® (NCCN®) highlights WT1 frameshift, splice site, and nonsense variants as associated with poor prognosis in myelodysplastic syndromes.",
+        "description": "The National Comprehensive Cancer Network\u00ae (NCCN\u00ae) highlights WT1 frameshift, splice site, and nonsense variants as associated with poor prognosis in myelodysplastic syndromes.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Myelodysplastic Syndromes V.2.2023. © National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Myelodysplastic Syndromes V.2.2023. \u00a9 National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/mds_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2023-10-17",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 928,
+        "feature_id": 928,
+        "source_id": 33,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -30921,16 +34633,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": 0,
         "predictive_implication": "Guideline",
-        "description": "The National Comprehensive Cancer Network® (NCCN®) highlights U2AF1 missense variants involving either S34 or Q157 codons as associated with poor prognosis in myelodysplastic syndromes.",
+        "description": "The National Comprehensive Cancer Network\u00ae (NCCN\u00ae) highlights U2AF1 missense variants involving either S34 or Q157 codons as associated with poor prognosis in myelodysplastic syndromes.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Myelodysplastic Syndromes V.2.2023. © National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Myelodysplastic Syndromes V.2.2023. \u00a9 National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/mds_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2023-10-17",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 929,
+        "feature_id": 929,
+        "source_id": 33,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -30956,16 +34672,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": 0,
         "predictive_implication": "Guideline",
-        "description": "The National Comprehensive Cancer Network® (NCCN®) highlights U2AF1 missense variants involving either S34 or Q157 codons as associated with poor prognosis in myelodysplastic syndromes.",
+        "description": "The National Comprehensive Cancer Network\u00ae (NCCN\u00ae) highlights U2AF1 missense variants involving either S34 or Q157 codons as associated with poor prognosis in myelodysplastic syndromes.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Myelodysplastic Syndromes V.2.2023. © National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Myelodysplastic Syndromes V.2.2023. \u00a9 National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/mds_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2023-10-17",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 930,
+        "feature_id": 930,
+        "source_id": 33,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -30991,16 +34711,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": 0,
         "predictive_implication": "Guideline",
-        "description": "The National Comprehensive Cancer Network® (NCCN®) highlights U2AF1 missense variants involving either S34 or Q157 codons as associated with poor prognosis in myelodysplastic syndromes.",
+        "description": "The National Comprehensive Cancer Network\u00ae (NCCN\u00ae) highlights U2AF1 missense variants involving either S34 or Q157 codons as associated with poor prognosis in myelodysplastic syndromes.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Myelodysplastic Syndromes V.2.2023. © National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Myelodysplastic Syndromes V.2.2023. \u00a9 National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/mds_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2023-10-17",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 931,
+        "feature_id": 931,
+        "source_id": 33,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -31026,16 +34750,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": 0,
         "predictive_implication": "Guideline",
-        "description": "The National Comprehensive Cancer Network® (NCCN®) highlights U2AF1 missense variants involving either S34 or Q157 codons as associated with poor prognosis in myelodysplastic syndromes.",
+        "description": "The National Comprehensive Cancer Network\u00ae (NCCN\u00ae) highlights U2AF1 missense variants involving either S34 or Q157 codons as associated with poor prognosis in myelodysplastic syndromes.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Myelodysplastic Syndromes V.2.2023. © National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Myelodysplastic Syndromes V.2.2023. \u00a9 National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/mds_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2023-10-17",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 932,
+        "feature_id": 932,
+        "source_id": 33,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -31061,16 +34789,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": 0,
         "predictive_implication": "Guideline",
-        "description": "The National Comprehensive Cancer Network® (NCCN®) highlights U2AF1 missense variants involving either S34 or Q157 codons as associated with poor prognosis in myelodysplastic syndromes.",
+        "description": "The National Comprehensive Cancer Network\u00ae (NCCN\u00ae) highlights U2AF1 missense variants involving either S34 or Q157 codons as associated with poor prognosis in myelodysplastic syndromes.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Myelodysplastic Syndromes V.2.2023. © National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Myelodysplastic Syndromes V.2.2023. \u00a9 National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/mds_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2023-10-17",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 933,
+        "feature_id": 933,
+        "source_id": 33,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -31096,16 +34828,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": 0,
         "predictive_implication": "Guideline",
-        "description": "The National Comprehensive Cancer Network® (NCCN®) highlights U2AF1 missense variants involving either S34 or Q157 codons as associated with poor prognosis in myelodysplastic syndromes.",
+        "description": "The National Comprehensive Cancer Network\u00ae (NCCN\u00ae) highlights U2AF1 missense variants involving either S34 or Q157 codons as associated with poor prognosis in myelodysplastic syndromes.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Myelodysplastic Syndromes V.2.2023. © National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Myelodysplastic Syndromes V.2.2023. \u00a9 National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/mds_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2023-10-17",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 934,
+        "feature_id": 934,
+        "source_id": 33,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -31131,16 +34867,20 @@
         "therapy_resistance": "",
         "favorable_prognosis": 0,
         "predictive_implication": "Guideline",
-        "description": "The National Comprehensive Cancer Network® (NCCN®) highlights U2AF1 missense variants involving either S34 or Q157 codons as associated with poor prognosis in myelodysplastic syndromes.",
+        "description": "The National Comprehensive Cancer Network\u00ae (NCCN\u00ae) highlights U2AF1 missense variants involving either S34 or Q157 codons as associated with poor prognosis in myelodysplastic syndromes.",
         "source_type": "Guideline",
-        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines®) for Myelodysplastic Syndromes V.2.2023. © National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
+        "citation": "Referenced with permission from the NCCN Clinical Practice Guidelines in Oncology (NCCN Guidelines\u00ae) for Myelodysplastic Syndromes V.2.2023. \u00a9 National Comprehensive Cancer Network, Inc. 2023. All rights reserved. Accessed November 2, 2023. To view the most recent and complete version of the guideline, go online to NCCN.org.",
         "url": "https://www.nccn.org/professionals/physician_gls/pdf/mds_blocks.pdf",
         "doi": "",
         "pmid": "",
         "nct": "",
         "publication_date": "2023-10-17",
         "last_updated": "2023-11-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 935,
+        "feature_id": 935,
+        "source_id": 33,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Rearrangement",
@@ -31168,7 +34908,11 @@
         "nct": "",
         "publication_date": "2023-11-15",
         "last_updated": "2023-12-05",
-        "_deprecated": true
+        "_deprecated": true,
+        "assertion_id": 936,
+        "feature_id": 936,
+        "source_id": 271,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -31203,7 +34947,11 @@
         "nct": "",
         "publication_date": "2023-11-16",
         "last_updated": "2023-12-07",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 937,
+        "feature_id": 937,
+        "source_id": 272,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -31238,7 +34986,11 @@
         "nct": "",
         "publication_date": "2023-11-16",
         "last_updated": "2023-12-07",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 938,
+        "feature_id": 938,
+        "source_id": 272,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -31273,7 +35025,11 @@
         "nct": "",
         "publication_date": "2023-11-16",
         "last_updated": "2023-12-07",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 939,
+        "feature_id": 939,
+        "source_id": 272,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -31308,7 +35064,11 @@
         "nct": "",
         "publication_date": "2023-11-16",
         "last_updated": "2023-12-07",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 940,
+        "feature_id": 940,
+        "source_id": 272,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -31343,7 +35103,11 @@
         "nct": "",
         "publication_date": "2023-11-16",
         "last_updated": "2023-12-07",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 941,
+        "feature_id": 941,
+        "source_id": 272,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Copy Number",
@@ -31370,7 +35134,11 @@
         "nct": "",
         "publication_date": "2023-11-16",
         "last_updated": "2023-12-07",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 942,
+        "feature_id": 942,
+        "source_id": 272,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Copy Number",
@@ -31397,7 +35165,11 @@
         "nct": "",
         "publication_date": "2020-02-25",
         "last_updated": "2025-01-08",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 943,
+        "feature_id": 943,
+        "source_id": 202,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -31432,7 +35204,11 @@
         "nct": "",
         "publication_date": "2017-11-06",
         "last_updated": "2024-01-30",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 944,
+        "feature_id": 944,
+        "source_id": 273,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -31467,7 +35243,11 @@
         "nct": "",
         "publication_date": "2017-11-06",
         "last_updated": "2024-01-30",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 945,
+        "feature_id": 945,
+        "source_id": 273,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -31502,7 +35282,11 @@
         "nct": "",
         "publication_date": "2024-03-01",
         "last_updated": "2024-03-04",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 946,
+        "feature_id": 946,
+        "source_id": 274,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -31537,7 +35321,11 @@
         "nct": "",
         "publication_date": "2024-02-16",
         "last_updated": "2024-03-04",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 947,
+        "feature_id": 947,
+        "source_id": 275,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -31572,7 +35360,11 @@
         "nct": "",
         "publication_date": "2024-02-16",
         "last_updated": "2024-03-04",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 948,
+        "feature_id": 948,
+        "source_id": 275,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -31607,7 +35399,11 @@
         "nct": "",
         "publication_date": "2018-04-18",
         "last_updated": "2024-03-04",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 949,
+        "feature_id": 949,
+        "source_id": 276,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -31642,7 +35438,11 @@
         "nct": "",
         "publication_date": "2018-04-18",
         "last_updated": "2024-03-04",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 950,
+        "feature_id": 950,
+        "source_id": 276,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -31677,7 +35477,11 @@
         "nct": "",
         "publication_date": "2024-02-15",
         "last_updated": "2024-03-04",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 951,
+        "feature_id": 951,
+        "source_id": 277,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -31712,7 +35516,11 @@
         "nct": "",
         "publication_date": "2024-02-15",
         "last_updated": "2024-03-04",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 952,
+        "feature_id": 952,
+        "source_id": 277,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Rearrangement",
@@ -31740,7 +35548,11 @@
         "nct": "",
         "publication_date": "2021-01-14",
         "last_updated": "2024-03-04",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 953,
+        "feature_id": 953,
+        "source_id": 278,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Rearrangement",
@@ -31768,7 +35580,11 @@
         "nct": "",
         "publication_date": "2019-08-01",
         "last_updated": "2024-04-11",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 954,
+        "feature_id": 954,
+        "source_id": 40,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Rearrangement",
@@ -31796,7 +35612,11 @@
         "nct": "",
         "publication_date": "2023-11-15",
         "last_updated": "2024-04-11",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 955,
+        "feature_id": 955,
+        "source_id": 271,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -31832,7 +35652,11 @@
         "nct": "",
         "publication_date": "2023-06-20",
         "last_updated": "2024-04-11",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 956,
+        "feature_id": 956,
+        "source_id": 260,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Rearrangement",
@@ -31861,7 +35685,11 @@
         "nct": "",
         "publication_date": "2024-03-19",
         "last_updated": "2024-04-11",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 957,
+        "feature_id": 957,
+        "source_id": 279,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Rearrangement",
@@ -31890,7 +35718,11 @@
         "nct": "",
         "publication_date": "2013-12-20",
         "last_updated": "2024-04-11",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 958,
+        "feature_id": 958,
+        "source_id": 280,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Rearrangement",
@@ -31919,7 +35751,11 @@
         "nct": "",
         "publication_date": "2013-12-20",
         "last_updated": "2024-04-11",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 959,
+        "feature_id": 959,
+        "source_id": 280,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -31955,7 +35791,11 @@
         "nct": "",
         "publication_date": "2013-12-20",
         "last_updated": "2024-04-11",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 960,
+        "feature_id": 960,
+        "source_id": 280,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -31991,7 +35831,11 @@
         "nct": "",
         "publication_date": "2013-12-20",
         "last_updated": "2024-04-11",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 961,
+        "feature_id": 961,
+        "source_id": 280,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Rearrangement",
@@ -32010,7 +35854,7 @@
         "therapy_resistance": "",
         "favorable_prognosis": "",
         "predictive_implication": "FDA-Approved",
-        "description": "The U.S. Food and Drug Administration (FDA) granted approval to alectinib for the adjuvant treatment of adult patients following tumor resection of with anaplastic lymphoma kinase (ALK)-positive non-small cell lung cancer (NSCLC) (tumors ≥ 4 cm or node positive) as detected by an FDA-approved test.",
+        "description": "The U.S. Food and Drug Administration (FDA) granted approval to alectinib for the adjuvant treatment of adult patients following tumor resection of with anaplastic lymphoma kinase (ALK)-positive non-small cell lung cancer (NSCLC) (tumors \u2265 4 cm or node positive) as detected by an FDA-approved test.",
         "source_type": "FDA",
         "citation": "Genentech, Inc. Alecensa (alectinib) [package insert]. U.S. Food and Drug Administration website. https://www.accessdata.fda.gov/drugsatfda_docs/label/2024/208434s015lbl.pdf. Revised April 2024. Accessed June 3, 2024.",
         "url": "https://www.accessdata.fda.gov/drugsatfda_docs/label/2024/208434s015lbl.pdf",
@@ -32019,7 +35863,11 @@
         "nct": "",
         "publication_date": "2024-04-18",
         "last_updated": "2024-06-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 962,
+        "feature_id": 962,
+        "source_id": 281,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -32054,7 +35902,11 @@
         "nct": "",
         "publication_date": "2024-04-23",
         "last_updated": "2024-06-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 963,
+        "feature_id": 963,
+        "source_id": 282,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Rearrangement",
@@ -32082,7 +35934,11 @@
         "nct": "",
         "publication_date": "2024-04-23",
         "last_updated": "2024-06-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 964,
+        "feature_id": 964,
+        "source_id": 282,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Rearrangement",
@@ -32110,7 +35966,11 @@
         "nct": "",
         "publication_date": "2024-04-23",
         "last_updated": "2024-06-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 965,
+        "feature_id": 965,
+        "source_id": 282,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -32145,7 +36005,11 @@
         "nct": "",
         "publication_date": "2016-10-18",
         "last_updated": "2024-06-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 966,
+        "feature_id": 966,
+        "source_id": 283,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -32180,7 +36044,11 @@
         "nct": "",
         "publication_date": "2016-10-18",
         "last_updated": "2024-06-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 967,
+        "feature_id": 967,
+        "source_id": 283,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -32215,7 +36083,11 @@
         "nct": "",
         "publication_date": "2021-05-05",
         "last_updated": "2024-06-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 968,
+        "feature_id": 968,
+        "source_id": 284,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -32250,7 +36122,11 @@
         "nct": "",
         "publication_date": "2021-05-05",
         "last_updated": "2024-06-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 969,
+        "feature_id": 969,
+        "source_id": 284,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Rearrangement",
@@ -32278,7 +36154,11 @@
         "nct": "",
         "publication_date": "2024-06-13",
         "last_updated": "2024-07-11",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 970,
+        "feature_id": 970,
+        "source_id": 285,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Rearrangement",
@@ -32306,7 +36186,11 @@
         "nct": "",
         "publication_date": "2024-06-13",
         "last_updated": "2024-07-11",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 971,
+        "feature_id": 971,
+        "source_id": 285,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Rearrangement",
@@ -32334,7 +36218,11 @@
         "nct": "",
         "publication_date": "2024-06-13",
         "last_updated": "2024-07-11",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 972,
+        "feature_id": 972,
+        "source_id": 285,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -32369,7 +36257,11 @@
         "nct": "",
         "publication_date": "2024-06-21",
         "last_updated": "2024-07-11",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 973,
+        "feature_id": 973,
+        "source_id": 286,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -32404,7 +36296,11 @@
         "nct": "",
         "publication_date": "2024-08-06",
         "last_updated": "2024-09-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 974,
+        "feature_id": 974,
+        "source_id": 287,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -32439,7 +36335,11 @@
         "nct": "",
         "publication_date": "2024-08-06",
         "last_updated": "2024-09-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 975,
+        "feature_id": 975,
+        "source_id": 287,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -32474,7 +36374,11 @@
         "nct": "",
         "publication_date": "2024-08-06",
         "last_updated": "2024-09-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 976,
+        "feature_id": 976,
+        "source_id": 287,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -32509,7 +36413,11 @@
         "nct": "",
         "publication_date": "2024-08-06",
         "last_updated": "2024-09-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 977,
+        "feature_id": 977,
+        "source_id": 287,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -32544,7 +36452,11 @@
         "nct": "",
         "publication_date": "2024-08-06",
         "last_updated": "2024-09-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 978,
+        "feature_id": 978,
+        "source_id": 287,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -32579,7 +36491,11 @@
         "nct": "",
         "publication_date": "2024-08-06",
         "last_updated": "2024-09-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 979,
+        "feature_id": 979,
+        "source_id": 287,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -32614,7 +36530,11 @@
         "nct": "",
         "publication_date": "2024-08-06",
         "last_updated": "2024-09-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 980,
+        "feature_id": 980,
+        "source_id": 287,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -32649,7 +36569,11 @@
         "nct": "",
         "publication_date": "2024-08-06",
         "last_updated": "2024-09-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 981,
+        "feature_id": 981,
+        "source_id": 287,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -32684,7 +36608,11 @@
         "nct": "",
         "publication_date": "2024-08-06",
         "last_updated": "2024-09-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 982,
+        "feature_id": 982,
+        "source_id": 287,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -32719,7 +36647,11 @@
         "nct": "",
         "publication_date": "2024-08-06",
         "last_updated": "2024-09-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 983,
+        "feature_id": 983,
+        "source_id": 287,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -32754,7 +36686,11 @@
         "nct": "",
         "publication_date": "2024-08-06",
         "last_updated": "2024-09-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 984,
+        "feature_id": 984,
+        "source_id": 287,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -32789,7 +36725,11 @@
         "nct": "",
         "publication_date": "2024-08-06",
         "last_updated": "2024-09-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 985,
+        "feature_id": 985,
+        "source_id": 287,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -32824,7 +36764,11 @@
         "nct": "",
         "publication_date": "2024-08-06",
         "last_updated": "2024-09-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 986,
+        "feature_id": 986,
+        "source_id": 287,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -32859,7 +36803,11 @@
         "nct": "",
         "publication_date": "2024-08-06",
         "last_updated": "2024-09-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 987,
+        "feature_id": 987,
+        "source_id": 287,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -32894,7 +36842,11 @@
         "nct": "",
         "publication_date": "2024-08-06",
         "last_updated": "2024-09-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 988,
+        "feature_id": 988,
+        "source_id": 287,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -32929,7 +36881,11 @@
         "nct": "",
         "publication_date": "2024-08-06",
         "last_updated": "2024-09-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 989,
+        "feature_id": 989,
+        "source_id": 287,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -32964,7 +36920,11 @@
         "nct": "",
         "publication_date": "2024-08-06",
         "last_updated": "2024-09-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 990,
+        "feature_id": 990,
+        "source_id": 287,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -32999,7 +36959,11 @@
         "nct": "",
         "publication_date": "2024-08-19",
         "last_updated": "2024-09-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 991,
+        "feature_id": 991,
+        "source_id": 288,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -33034,7 +36998,11 @@
         "nct": "",
         "publication_date": "2024-08-19",
         "last_updated": "2024-09-03",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 992,
+        "feature_id": 992,
+        "source_id": 288,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -33069,7 +37037,11 @@
         "nct": "",
         "publication_date": "2024-09-19",
         "last_updated": "2024-10-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 993,
+        "feature_id": 993,
+        "source_id": 289,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -33104,7 +37076,11 @@
         "nct": "",
         "publication_date": "2024-09-19",
         "last_updated": "2024-10-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 994,
+        "feature_id": 994,
+        "source_id": 289,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -33139,7 +37115,11 @@
         "nct": "",
         "publication_date": "2024-09-25",
         "last_updated": "2024-10-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 995,
+        "feature_id": 995,
+        "source_id": 290,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -33174,7 +37154,11 @@
         "nct": "",
         "publication_date": "2024-09-25",
         "last_updated": "2024-10-02",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 996,
+        "feature_id": 996,
+        "source_id": 290,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Rearrangement",
@@ -33202,7 +37186,11 @@
         "nct": "",
         "publication_date": "2024-10-29",
         "last_updated": "2024-11-06",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 997,
+        "feature_id": 997,
+        "source_id": 6,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Rearrangement",
@@ -33230,7 +37218,11 @@
         "nct": "",
         "publication_date": "2024-10-29",
         "last_updated": "2024-11-06",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 998,
+        "feature_id": 998,
+        "source_id": 6,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -33265,7 +37257,11 @@
         "nct": "",
         "publication_date": "2024-10-29",
         "last_updated": "2024-11-06",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 999,
+        "feature_id": 999,
+        "source_id": 6,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Somatic Variant",
@@ -33300,7 +37296,11 @@
         "nct": "",
         "publication_date": "2024-10-10",
         "last_updated": "2024-11-07",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 1000,
+        "feature_id": 1000,
+        "source_id": 291,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Rearrangement",
@@ -33328,7 +37328,11 @@
         "nct": "",
         "publication_date": "2024-11-15",
         "last_updated": "2024-12-05",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 1001,
+        "feature_id": 1001,
+        "source_id": 292,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Rearrangement",
@@ -33356,7 +37360,11 @@
         "nct": "",
         "publication_date": "2024-11-15",
         "last_updated": "2024-12-05",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 1002,
+        "feature_id": 1002,
+        "source_id": 292,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Rearrangement",
@@ -33384,7 +37392,11 @@
         "nct": "",
         "publication_date": "2024-12-04",
         "last_updated": "2024-12-05",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 1003,
+        "feature_id": 1003,
+        "source_id": 293,
+        "features_endpoint_feature_id": 1003
     },
     {
         "feature_type": "Rearrangement",
@@ -33412,6 +37424,10 @@
         "nct": "",
         "publication_date": "2024-12-04",
         "last_updated": "2024-12-05",
-        "_deprecated": false
+        "_deprecated": false,
+        "assertion_id": 1004,
+        "feature_id": 1004,
+        "source_id": 293,
+        "features_endpoint_feature_id": 1003
     }
 ]

--- a/molecular-oncology-almanac.json
+++ b/molecular-oncology-almanac.json
@@ -28,8 +28,7 @@
         "_deprecated": false,
         "assertion_id": 1,
         "feature_id": 1,
-        "source_id": 1,
-        "features_endpoint_feature_id": 1003
+        "source_id": 1
     },
     {
         "feature_type": "Rearrangement",
@@ -60,8 +59,7 @@
         "_deprecated": false,
         "assertion_id": 2,
         "feature_id": 2,
-        "source_id": 2,
-        "features_endpoint_feature_id": 1003
+        "source_id": 2
     },
     {
         "feature_type": "Rearrangement",
@@ -92,8 +90,7 @@
         "_deprecated": false,
         "assertion_id": 3,
         "feature_id": 3,
-        "source_id": 2,
-        "features_endpoint_feature_id": 1003
+        "source_id": 2
     },
     {
         "feature_type": "Rearrangement",
@@ -124,8 +121,7 @@
         "_deprecated": false,
         "assertion_id": 4,
         "feature_id": 4,
-        "source_id": 3,
-        "features_endpoint_feature_id": 1003
+        "source_id": 3
     },
     {
         "feature_type": "Rearrangement",
@@ -156,8 +152,7 @@
         "_deprecated": false,
         "assertion_id": 5,
         "feature_id": 5,
-        "source_id": 3,
-        "features_endpoint_feature_id": 1003
+        "source_id": 3
     },
     {
         "feature_type": "Rearrangement",
@@ -188,8 +183,7 @@
         "_deprecated": false,
         "assertion_id": 6,
         "feature_id": 6,
-        "source_id": 4,
-        "features_endpoint_feature_id": 1003
+        "source_id": 4
     },
     {
         "feature_type": "Rearrangement",
@@ -220,8 +214,7 @@
         "_deprecated": false,
         "assertion_id": 7,
         "feature_id": 7,
-        "source_id": 5,
-        "features_endpoint_feature_id": 1003
+        "source_id": 5
     },
     {
         "feature_type": "Rearrangement",
@@ -252,8 +245,7 @@
         "_deprecated": false,
         "assertion_id": 8,
         "feature_id": 8,
-        "source_id": 6,
-        "features_endpoint_feature_id": 1003
+        "source_id": 6
     },
     {
         "feature_type": "Rearrangement",
@@ -284,8 +276,7 @@
         "_deprecated": false,
         "assertion_id": 9,
         "feature_id": 9,
-        "source_id": 7,
-        "features_endpoint_feature_id": 1003
+        "source_id": 7
     },
     {
         "feature_type": "Rearrangement",
@@ -316,8 +307,7 @@
         "_deprecated": false,
         "assertion_id": 10,
         "feature_id": 10,
-        "source_id": 8,
-        "features_endpoint_feature_id": 1003
+        "source_id": 8
     },
     {
         "feature_type": "Rearrangement",
@@ -348,8 +338,7 @@
         "_deprecated": false,
         "assertion_id": 11,
         "feature_id": 11,
-        "source_id": 9,
-        "features_endpoint_feature_id": 1003
+        "source_id": 9
     },
     {
         "feature_type": "Rearrangement",
@@ -380,8 +369,7 @@
         "_deprecated": false,
         "assertion_id": 12,
         "feature_id": 12,
-        "source_id": 10,
-        "features_endpoint_feature_id": 1003
+        "source_id": 10
     },
     {
         "feature_type": "Rearrangement",
@@ -412,8 +400,7 @@
         "_deprecated": false,
         "assertion_id": 13,
         "feature_id": 13,
-        "source_id": 11,
-        "features_endpoint_feature_id": 1003
+        "source_id": 11
     },
     {
         "feature_type": "Rearrangement",
@@ -444,8 +431,7 @@
         "_deprecated": false,
         "assertion_id": 14,
         "feature_id": 14,
-        "source_id": 12,
-        "features_endpoint_feature_id": 1003
+        "source_id": 12
     },
     {
         "feature_type": "Rearrangement",
@@ -476,8 +462,7 @@
         "_deprecated": false,
         "assertion_id": 15,
         "feature_id": 15,
-        "source_id": 13,
-        "features_endpoint_feature_id": 1003
+        "source_id": 13
     },
     {
         "feature_type": "Rearrangement",
@@ -508,8 +493,7 @@
         "_deprecated": false,
         "assertion_id": 16,
         "feature_id": 16,
-        "source_id": 13,
-        "features_endpoint_feature_id": 1003
+        "source_id": 13
     },
     {
         "feature_type": "Rearrangement",
@@ -540,8 +524,7 @@
         "_deprecated": false,
         "assertion_id": 17,
         "feature_id": 17,
-        "source_id": 14,
-        "features_endpoint_feature_id": 1003
+        "source_id": 14
     },
     {
         "feature_type": "Rearrangement",
@@ -572,8 +555,7 @@
         "_deprecated": false,
         "assertion_id": 18,
         "feature_id": 18,
-        "source_id": 15,
-        "features_endpoint_feature_id": 1003
+        "source_id": 15
     },
     {
         "feature_type": "Rearrangement",
@@ -604,8 +586,7 @@
         "_deprecated": false,
         "assertion_id": 19,
         "feature_id": 19,
-        "source_id": 16,
-        "features_endpoint_feature_id": 1003
+        "source_id": 16
     },
     {
         "feature_type": "Rearrangement",
@@ -636,8 +617,7 @@
         "_deprecated": false,
         "assertion_id": 20,
         "feature_id": 20,
-        "source_id": 17,
-        "features_endpoint_feature_id": 1003
+        "source_id": 17
     },
     {
         "feature_type": "Rearrangement",
@@ -668,8 +648,7 @@
         "_deprecated": false,
         "assertion_id": 21,
         "feature_id": 21,
-        "source_id": 16,
-        "features_endpoint_feature_id": 1003
+        "source_id": 16
     },
     {
         "feature_type": "Rearrangement",
@@ -700,8 +679,7 @@
         "_deprecated": false,
         "assertion_id": 22,
         "feature_id": 22,
-        "source_id": 18,
-        "features_endpoint_feature_id": 1003
+        "source_id": 18
     },
     {
         "feature_type": "Rearrangement",
@@ -732,8 +710,7 @@
         "_deprecated": false,
         "assertion_id": 23,
         "feature_id": 23,
-        "source_id": 19,
-        "features_endpoint_feature_id": 1003
+        "source_id": 19
     },
     {
         "feature_type": "Rearrangement",
@@ -764,8 +741,7 @@
         "_deprecated": false,
         "assertion_id": 24,
         "feature_id": 24,
-        "source_id": 20,
-        "features_endpoint_feature_id": 1003
+        "source_id": 20
     },
     {
         "feature_type": "Rearrangement",
@@ -796,8 +772,7 @@
         "_deprecated": false,
         "assertion_id": 25,
         "feature_id": 25,
-        "source_id": 21,
-        "features_endpoint_feature_id": 1003
+        "source_id": 21
     },
     {
         "feature_type": "Rearrangement",
@@ -828,8 +803,7 @@
         "_deprecated": false,
         "assertion_id": 26,
         "feature_id": 26,
-        "source_id": 21,
-        "features_endpoint_feature_id": 1003
+        "source_id": 21
     },
     {
         "feature_type": "Rearrangement",
@@ -860,8 +834,7 @@
         "_deprecated": false,
         "assertion_id": 27,
         "feature_id": 27,
-        "source_id": 22,
-        "features_endpoint_feature_id": 1003
+        "source_id": 22
     },
     {
         "feature_type": "Rearrangement",
@@ -892,8 +865,7 @@
         "_deprecated": false,
         "assertion_id": 28,
         "feature_id": 28,
-        "source_id": 23,
-        "features_endpoint_feature_id": 1003
+        "source_id": 23
     },
     {
         "feature_type": "Rearrangement",
@@ -924,8 +896,7 @@
         "_deprecated": false,
         "assertion_id": 29,
         "feature_id": 29,
-        "source_id": 24,
-        "features_endpoint_feature_id": 1003
+        "source_id": 24
     },
     {
         "feature_type": "Rearrangement",
@@ -956,8 +927,7 @@
         "_deprecated": false,
         "assertion_id": 30,
         "feature_id": 30,
-        "source_id": 24,
-        "features_endpoint_feature_id": 1003
+        "source_id": 24
     },
     {
         "feature_type": "Rearrangement",
@@ -988,8 +958,7 @@
         "_deprecated": false,
         "assertion_id": 31,
         "feature_id": 31,
-        "source_id": 25,
-        "features_endpoint_feature_id": 1003
+        "source_id": 25
     },
     {
         "feature_type": "Rearrangement",
@@ -1020,8 +989,7 @@
         "_deprecated": false,
         "assertion_id": 32,
         "feature_id": 32,
-        "source_id": 26,
-        "features_endpoint_feature_id": 1003
+        "source_id": 26
     },
     {
         "feature_type": "Rearrangement",
@@ -1052,8 +1020,7 @@
         "_deprecated": false,
         "assertion_id": 33,
         "feature_id": 33,
-        "source_id": 27,
-        "features_endpoint_feature_id": 1003
+        "source_id": 27
     },
     {
         "feature_type": "Rearrangement",
@@ -1084,8 +1051,7 @@
         "_deprecated": false,
         "assertion_id": 34,
         "feature_id": 34,
-        "source_id": 28,
-        "features_endpoint_feature_id": 1003
+        "source_id": 28
     },
     {
         "feature_type": "Rearrangement",
@@ -1116,8 +1082,7 @@
         "_deprecated": false,
         "assertion_id": 35,
         "feature_id": 35,
-        "source_id": 28,
-        "features_endpoint_feature_id": 1003
+        "source_id": 28
     },
     {
         "feature_type": "Rearrangement",
@@ -1148,8 +1113,7 @@
         "_deprecated": false,
         "assertion_id": 36,
         "feature_id": 36,
-        "source_id": 29,
-        "features_endpoint_feature_id": 1003
+        "source_id": 29
     },
     {
         "feature_type": "Rearrangement",
@@ -1180,8 +1144,7 @@
         "_deprecated": false,
         "assertion_id": 37,
         "feature_id": 37,
-        "source_id": 30,
-        "features_endpoint_feature_id": 1003
+        "source_id": 30
     },
     {
         "feature_type": "Rearrangement",
@@ -1212,8 +1175,7 @@
         "_deprecated": false,
         "assertion_id": 38,
         "feature_id": 38,
-        "source_id": 31,
-        "features_endpoint_feature_id": 1003
+        "source_id": 31
     },
     {
         "feature_type": "Rearrangement",
@@ -1244,8 +1206,7 @@
         "_deprecated": false,
         "assertion_id": 39,
         "feature_id": 39,
-        "source_id": 29,
-        "features_endpoint_feature_id": 1003
+        "source_id": 29
     },
     {
         "feature_type": "Rearrangement",
@@ -1276,8 +1237,7 @@
         "_deprecated": false,
         "assertion_id": 40,
         "feature_id": 40,
-        "source_id": 30,
-        "features_endpoint_feature_id": 1003
+        "source_id": 30
     },
     {
         "feature_type": "Rearrangement",
@@ -1308,8 +1268,7 @@
         "_deprecated": false,
         "assertion_id": 41,
         "feature_id": 41,
-        "source_id": 31,
-        "features_endpoint_feature_id": 1003
+        "source_id": 31
     },
     {
         "feature_type": "Rearrangement",
@@ -1340,8 +1299,7 @@
         "_deprecated": false,
         "assertion_id": 42,
         "feature_id": 42,
-        "source_id": 29,
-        "features_endpoint_feature_id": 1003
+        "source_id": 29
     },
     {
         "feature_type": "Rearrangement",
@@ -1372,8 +1330,7 @@
         "_deprecated": false,
         "assertion_id": 43,
         "feature_id": 43,
-        "source_id": 30,
-        "features_endpoint_feature_id": 1003
+        "source_id": 30
     },
     {
         "feature_type": "Rearrangement",
@@ -1404,8 +1361,7 @@
         "_deprecated": false,
         "assertion_id": 44,
         "feature_id": 44,
-        "source_id": 31,
-        "features_endpoint_feature_id": 1003
+        "source_id": 31
     },
     {
         "feature_type": "Rearrangement",
@@ -1436,8 +1392,7 @@
         "_deprecated": false,
         "assertion_id": 45,
         "feature_id": 45,
-        "source_id": 3,
-        "features_endpoint_feature_id": 1003
+        "source_id": 3
     },
     {
         "feature_type": "Rearrangement",
@@ -1468,8 +1423,7 @@
         "_deprecated": false,
         "assertion_id": 46,
         "feature_id": 46,
-        "source_id": 3,
-        "features_endpoint_feature_id": 1003
+        "source_id": 3
     },
     {
         "feature_type": "Rearrangement",
@@ -1500,8 +1454,7 @@
         "_deprecated": false,
         "assertion_id": 47,
         "feature_id": 47,
-        "source_id": 32,
-        "features_endpoint_feature_id": 1003
+        "source_id": 32
     },
     {
         "feature_type": "Rearrangement",
@@ -1532,8 +1485,7 @@
         "_deprecated": false,
         "assertion_id": 48,
         "feature_id": 48,
-        "source_id": 3,
-        "features_endpoint_feature_id": 1003
+        "source_id": 3
     },
     {
         "feature_type": "Rearrangement",
@@ -1564,8 +1516,7 @@
         "_deprecated": false,
         "assertion_id": 49,
         "feature_id": 49,
-        "source_id": 33,
-        "features_endpoint_feature_id": 1003
+        "source_id": 33
     },
     {
         "feature_type": "Rearrangement",
@@ -1596,8 +1547,7 @@
         "_deprecated": false,
         "assertion_id": 50,
         "feature_id": 50,
-        "source_id": 11,
-        "features_endpoint_feature_id": 1003
+        "source_id": 11
     },
     {
         "feature_type": "Rearrangement",
@@ -1628,8 +1578,7 @@
         "_deprecated": false,
         "assertion_id": 51,
         "feature_id": 51,
-        "source_id": 11,
-        "features_endpoint_feature_id": 1003
+        "source_id": 11
     },
     {
         "feature_type": "Rearrangement",
@@ -1660,8 +1609,7 @@
         "_deprecated": false,
         "assertion_id": 52,
         "feature_id": 52,
-        "source_id": 34,
-        "features_endpoint_feature_id": 1003
+        "source_id": 34
     },
     {
         "feature_type": "Rearrangement",
@@ -1692,8 +1640,7 @@
         "_deprecated": false,
         "assertion_id": 53,
         "feature_id": 53,
-        "source_id": 35,
-        "features_endpoint_feature_id": 1003
+        "source_id": 35
     },
     {
         "feature_type": "Rearrangement",
@@ -1724,8 +1671,7 @@
         "_deprecated": false,
         "assertion_id": 54,
         "feature_id": 54,
-        "source_id": 36,
-        "features_endpoint_feature_id": 1003
+        "source_id": 36
     },
     {
         "feature_type": "Rearrangement",
@@ -1756,8 +1702,7 @@
         "_deprecated": false,
         "assertion_id": 55,
         "feature_id": 55,
-        "source_id": 37,
-        "features_endpoint_feature_id": 1003
+        "source_id": 37
     },
     {
         "feature_type": "Rearrangement",
@@ -1788,8 +1733,7 @@
         "_deprecated": false,
         "assertion_id": 56,
         "feature_id": 56,
-        "source_id": 38,
-        "features_endpoint_feature_id": 1003
+        "source_id": 38
     },
     {
         "feature_type": "Rearrangement",
@@ -1820,8 +1764,7 @@
         "_deprecated": false,
         "assertion_id": 57,
         "feature_id": 57,
-        "source_id": 39,
-        "features_endpoint_feature_id": 1003
+        "source_id": 39
     },
     {
         "feature_type": "Rearrangement",
@@ -1852,8 +1795,7 @@
         "_deprecated": true,
         "assertion_id": 58,
         "feature_id": 58,
-        "source_id": 40,
-        "features_endpoint_feature_id": 1003
+        "source_id": 40
     },
     {
         "feature_type": "Rearrangement",
@@ -1884,8 +1826,7 @@
         "_deprecated": false,
         "assertion_id": 59,
         "feature_id": 59,
-        "source_id": 41,
-        "features_endpoint_feature_id": 1003
+        "source_id": 41
     },
     {
         "feature_type": "Rearrangement",
@@ -1916,8 +1857,7 @@
         "_deprecated": false,
         "assertion_id": 60,
         "feature_id": 60,
-        "source_id": 21,
-        "features_endpoint_feature_id": 1003
+        "source_id": 21
     },
     {
         "feature_type": "Rearrangement",
@@ -1948,8 +1888,7 @@
         "_deprecated": false,
         "assertion_id": 61,
         "feature_id": 61,
-        "source_id": 21,
-        "features_endpoint_feature_id": 1003
+        "source_id": 21
     },
     {
         "feature_type": "Rearrangement",
@@ -1980,8 +1919,7 @@
         "_deprecated": false,
         "assertion_id": 62,
         "feature_id": 62,
-        "source_id": 42,
-        "features_endpoint_feature_id": 1003
+        "source_id": 42
     },
     {
         "feature_type": "Rearrangement",
@@ -2012,8 +1950,7 @@
         "_deprecated": false,
         "assertion_id": 63,
         "feature_id": 63,
-        "source_id": 43,
-        "features_endpoint_feature_id": 1003
+        "source_id": 43
     },
     {
         "feature_type": "Rearrangement",
@@ -2044,8 +1981,7 @@
         "_deprecated": false,
         "assertion_id": 64,
         "feature_id": 64,
-        "source_id": 44,
-        "features_endpoint_feature_id": 1003
+        "source_id": 44
     },
     {
         "feature_type": "Rearrangement",
@@ -2076,8 +2012,7 @@
         "_deprecated": false,
         "assertion_id": 65,
         "feature_id": 65,
-        "source_id": 44,
-        "features_endpoint_feature_id": 1003
+        "source_id": 44
     },
     {
         "feature_type": "Somatic Variant",
@@ -2115,8 +2050,7 @@
         "_deprecated": false,
         "assertion_id": 66,
         "feature_id": 66,
-        "source_id": 45,
-        "features_endpoint_feature_id": 1003
+        "source_id": 45
     },
     {
         "feature_type": "Somatic Variant",
@@ -2154,8 +2088,7 @@
         "_deprecated": false,
         "assertion_id": 67,
         "feature_id": 67,
-        "source_id": 46,
-        "features_endpoint_feature_id": 1003
+        "source_id": 46
     },
     {
         "feature_type": "Somatic Variant",
@@ -2193,8 +2126,7 @@
         "_deprecated": false,
         "assertion_id": 68,
         "feature_id": 68,
-        "source_id": 46,
-        "features_endpoint_feature_id": 1003
+        "source_id": 46
     },
     {
         "feature_type": "Somatic Variant",
@@ -2232,8 +2164,7 @@
         "_deprecated": false,
         "assertion_id": 69,
         "feature_id": 69,
-        "source_id": 46,
-        "features_endpoint_feature_id": 1003
+        "source_id": 46
     },
     {
         "feature_type": "Somatic Variant",
@@ -2271,8 +2202,7 @@
         "_deprecated": false,
         "assertion_id": 70,
         "feature_id": 70,
-        "source_id": 46,
-        "features_endpoint_feature_id": 1003
+        "source_id": 46
     },
     {
         "feature_type": "Somatic Variant",
@@ -2310,8 +2240,7 @@
         "_deprecated": false,
         "assertion_id": 71,
         "feature_id": 71,
-        "source_id": 46,
-        "features_endpoint_feature_id": 1003
+        "source_id": 46
     },
     {
         "feature_type": "Somatic Variant",
@@ -2349,8 +2278,7 @@
         "_deprecated": false,
         "assertion_id": 72,
         "feature_id": 72,
-        "source_id": 46,
-        "features_endpoint_feature_id": 1003
+        "source_id": 46
     },
     {
         "feature_type": "Somatic Variant",
@@ -2388,8 +2316,7 @@
         "_deprecated": false,
         "assertion_id": 73,
         "feature_id": 73,
-        "source_id": 46,
-        "features_endpoint_feature_id": 1003
+        "source_id": 46
     },
     {
         "feature_type": "Somatic Variant",
@@ -2427,8 +2354,7 @@
         "_deprecated": false,
         "assertion_id": 74,
         "feature_id": 74,
-        "source_id": 46,
-        "features_endpoint_feature_id": 1003
+        "source_id": 46
     },
     {
         "feature_type": "Somatic Variant",
@@ -2466,8 +2392,7 @@
         "_deprecated": false,
         "assertion_id": 75,
         "feature_id": 75,
-        "source_id": 46,
-        "features_endpoint_feature_id": 1003
+        "source_id": 46
     },
     {
         "feature_type": "Somatic Variant",
@@ -2505,8 +2430,7 @@
         "_deprecated": false,
         "assertion_id": 76,
         "feature_id": 76,
-        "source_id": 46,
-        "features_endpoint_feature_id": 1003
+        "source_id": 46
     },
     {
         "feature_type": "Somatic Variant",
@@ -2544,8 +2468,7 @@
         "_deprecated": false,
         "assertion_id": 77,
         "feature_id": 77,
-        "source_id": 46,
-        "features_endpoint_feature_id": 1003
+        "source_id": 46
     },
     {
         "feature_type": "Somatic Variant",
@@ -2583,8 +2506,7 @@
         "_deprecated": false,
         "assertion_id": 78,
         "feature_id": 78,
-        "source_id": 46,
-        "features_endpoint_feature_id": 1003
+        "source_id": 46
     },
     {
         "feature_type": "Somatic Variant",
@@ -2622,8 +2544,7 @@
         "_deprecated": false,
         "assertion_id": 79,
         "feature_id": 79,
-        "source_id": 46,
-        "features_endpoint_feature_id": 1003
+        "source_id": 46
     },
     {
         "feature_type": "Somatic Variant",
@@ -2661,8 +2582,7 @@
         "_deprecated": false,
         "assertion_id": 80,
         "feature_id": 80,
-        "source_id": 46,
-        "features_endpoint_feature_id": 1003
+        "source_id": 46
     },
     {
         "feature_type": "Somatic Variant",
@@ -2700,8 +2620,7 @@
         "_deprecated": false,
         "assertion_id": 81,
         "feature_id": 81,
-        "source_id": 47,
-        "features_endpoint_feature_id": 1003
+        "source_id": 47
     },
     {
         "feature_type": "Somatic Variant",
@@ -2739,8 +2658,7 @@
         "_deprecated": false,
         "assertion_id": 82,
         "feature_id": 82,
-        "source_id": 47,
-        "features_endpoint_feature_id": 1003
+        "source_id": 47
     },
     {
         "feature_type": "Somatic Variant",
@@ -2778,8 +2696,7 @@
         "_deprecated": false,
         "assertion_id": 83,
         "feature_id": 83,
-        "source_id": 47,
-        "features_endpoint_feature_id": 1003
+        "source_id": 47
     },
     {
         "feature_type": "Somatic Variant",
@@ -2817,8 +2734,7 @@
         "_deprecated": false,
         "assertion_id": 84,
         "feature_id": 84,
-        "source_id": 47,
-        "features_endpoint_feature_id": 1003
+        "source_id": 47
     },
     {
         "feature_type": "Somatic Variant",
@@ -2856,8 +2772,7 @@
         "_deprecated": false,
         "assertion_id": 85,
         "feature_id": 85,
-        "source_id": 47,
-        "features_endpoint_feature_id": 1003
+        "source_id": 47
     },
     {
         "feature_type": "Somatic Variant",
@@ -2895,8 +2810,7 @@
         "_deprecated": false,
         "assertion_id": 86,
         "feature_id": 86,
-        "source_id": 47,
-        "features_endpoint_feature_id": 1003
+        "source_id": 47
     },
     {
         "feature_type": "Somatic Variant",
@@ -2934,8 +2848,7 @@
         "_deprecated": false,
         "assertion_id": 87,
         "feature_id": 87,
-        "source_id": 47,
-        "features_endpoint_feature_id": 1003
+        "source_id": 47
     },
     {
         "feature_type": "Somatic Variant",
@@ -2973,8 +2886,7 @@
         "_deprecated": false,
         "assertion_id": 88,
         "feature_id": 88,
-        "source_id": 47,
-        "features_endpoint_feature_id": 1003
+        "source_id": 47
     },
     {
         "feature_type": "Somatic Variant",
@@ -3012,8 +2924,7 @@
         "_deprecated": false,
         "assertion_id": 89,
         "feature_id": 89,
-        "source_id": 47,
-        "features_endpoint_feature_id": 1003
+        "source_id": 47
     },
     {
         "feature_type": "Somatic Variant",
@@ -3051,8 +2962,7 @@
         "_deprecated": false,
         "assertion_id": 90,
         "feature_id": 90,
-        "source_id": 47,
-        "features_endpoint_feature_id": 1003
+        "source_id": 47
     },
     {
         "feature_type": "Somatic Variant",
@@ -3090,8 +3000,7 @@
         "_deprecated": false,
         "assertion_id": 91,
         "feature_id": 91,
-        "source_id": 47,
-        "features_endpoint_feature_id": 1003
+        "source_id": 47
     },
     {
         "feature_type": "Somatic Variant",
@@ -3129,8 +3038,7 @@
         "_deprecated": false,
         "assertion_id": 92,
         "feature_id": 92,
-        "source_id": 47,
-        "features_endpoint_feature_id": 1003
+        "source_id": 47
     },
     {
         "feature_type": "Somatic Variant",
@@ -3168,8 +3076,7 @@
         "_deprecated": false,
         "assertion_id": 93,
         "feature_id": 93,
-        "source_id": 47,
-        "features_endpoint_feature_id": 1003
+        "source_id": 47
     },
     {
         "feature_type": "Somatic Variant",
@@ -3207,8 +3114,7 @@
         "_deprecated": false,
         "assertion_id": 94,
         "feature_id": 94,
-        "source_id": 47,
-        "features_endpoint_feature_id": 1003
+        "source_id": 47
     },
     {
         "feature_type": "Somatic Variant",
@@ -3246,8 +3152,7 @@
         "_deprecated": false,
         "assertion_id": 95,
         "feature_id": 95,
-        "source_id": 47,
-        "features_endpoint_feature_id": 1003
+        "source_id": 47
     },
     {
         "feature_type": "Somatic Variant",
@@ -3285,8 +3190,7 @@
         "_deprecated": false,
         "assertion_id": 96,
         "feature_id": 96,
-        "source_id": 47,
-        "features_endpoint_feature_id": 1003
+        "source_id": 47
     },
     {
         "feature_type": "Somatic Variant",
@@ -3324,8 +3228,7 @@
         "_deprecated": false,
         "assertion_id": 97,
         "feature_id": 97,
-        "source_id": 47,
-        "features_endpoint_feature_id": 1003
+        "source_id": 47
     },
     {
         "feature_type": "Somatic Variant",
@@ -3363,8 +3266,7 @@
         "_deprecated": false,
         "assertion_id": 98,
         "feature_id": 98,
-        "source_id": 47,
-        "features_endpoint_feature_id": 1003
+        "source_id": 47
     },
     {
         "feature_type": "Somatic Variant",
@@ -3402,8 +3304,7 @@
         "_deprecated": false,
         "assertion_id": 99,
         "feature_id": 99,
-        "source_id": 47,
-        "features_endpoint_feature_id": 1003
+        "source_id": 47
     },
     {
         "feature_type": "Somatic Variant",
@@ -3441,8 +3342,7 @@
         "_deprecated": false,
         "assertion_id": 100,
         "feature_id": 100,
-        "source_id": 47,
-        "features_endpoint_feature_id": 1003
+        "source_id": 47
     },
     {
         "feature_type": "Somatic Variant",
@@ -3480,8 +3380,7 @@
         "_deprecated": false,
         "assertion_id": 101,
         "feature_id": 101,
-        "source_id": 47,
-        "features_endpoint_feature_id": 1003
+        "source_id": 47
     },
     {
         "feature_type": "Somatic Variant",
@@ -3519,8 +3418,7 @@
         "_deprecated": false,
         "assertion_id": 102,
         "feature_id": 102,
-        "source_id": 47,
-        "features_endpoint_feature_id": 1003
+        "source_id": 47
     },
     {
         "feature_type": "Somatic Variant",
@@ -3558,8 +3456,7 @@
         "_deprecated": false,
         "assertion_id": 103,
         "feature_id": 103,
-        "source_id": 47,
-        "features_endpoint_feature_id": 1003
+        "source_id": 47
     },
     {
         "feature_type": "Somatic Variant",
@@ -3597,8 +3494,7 @@
         "_deprecated": false,
         "assertion_id": 104,
         "feature_id": 104,
-        "source_id": 47,
-        "features_endpoint_feature_id": 1003
+        "source_id": 47
     },
     {
         "feature_type": "Somatic Variant",
@@ -3636,8 +3532,7 @@
         "_deprecated": false,
         "assertion_id": 105,
         "feature_id": 105,
-        "source_id": 47,
-        "features_endpoint_feature_id": 1003
+        "source_id": 47
     },
     {
         "feature_type": "Somatic Variant",
@@ -3675,8 +3570,7 @@
         "_deprecated": false,
         "assertion_id": 106,
         "feature_id": 106,
-        "source_id": 48,
-        "features_endpoint_feature_id": 1003
+        "source_id": 48
     },
     {
         "feature_type": "Somatic Variant",
@@ -3714,8 +3608,7 @@
         "_deprecated": false,
         "assertion_id": 107,
         "feature_id": 107,
-        "source_id": 48,
-        "features_endpoint_feature_id": 1003
+        "source_id": 48
     },
     {
         "feature_type": "Somatic Variant",
@@ -3753,8 +3646,7 @@
         "_deprecated": false,
         "assertion_id": 108,
         "feature_id": 108,
-        "source_id": 49,
-        "features_endpoint_feature_id": 1003
+        "source_id": 49
     },
     {
         "feature_type": "Somatic Variant",
@@ -3792,8 +3684,7 @@
         "_deprecated": false,
         "assertion_id": 109,
         "feature_id": 109,
-        "source_id": 49,
-        "features_endpoint_feature_id": 1003
+        "source_id": 49
     },
     {
         "feature_type": "Somatic Variant",
@@ -3831,8 +3722,7 @@
         "_deprecated": false,
         "assertion_id": 110,
         "feature_id": 110,
-        "source_id": 50,
-        "features_endpoint_feature_id": 1003
+        "source_id": 50
     },
     {
         "feature_type": "Somatic Variant",
@@ -3870,8 +3760,7 @@
         "_deprecated": false,
         "assertion_id": 111,
         "feature_id": 111,
-        "source_id": 50,
-        "features_endpoint_feature_id": 1003
+        "source_id": 50
     },
     {
         "feature_type": "Somatic Variant",
@@ -3909,8 +3798,7 @@
         "_deprecated": false,
         "assertion_id": 112,
         "feature_id": 112,
-        "source_id": 50,
-        "features_endpoint_feature_id": 1003
+        "source_id": 50
     },
     {
         "feature_type": "Somatic Variant",
@@ -3948,8 +3836,7 @@
         "_deprecated": false,
         "assertion_id": 113,
         "feature_id": 113,
-        "source_id": 50,
-        "features_endpoint_feature_id": 1003
+        "source_id": 50
     },
     {
         "feature_type": "Somatic Variant",
@@ -3987,8 +3874,7 @@
         "_deprecated": false,
         "assertion_id": 114,
         "feature_id": 114,
-        "source_id": 50,
-        "features_endpoint_feature_id": 1003
+        "source_id": 50
     },
     {
         "feature_type": "Somatic Variant",
@@ -4026,8 +3912,7 @@
         "_deprecated": false,
         "assertion_id": 115,
         "feature_id": 115,
-        "source_id": 51,
-        "features_endpoint_feature_id": 1003
+        "source_id": 51
     },
     {
         "feature_type": "Somatic Variant",
@@ -4065,8 +3950,7 @@
         "_deprecated": false,
         "assertion_id": 116,
         "feature_id": 116,
-        "source_id": 51,
-        "features_endpoint_feature_id": 1003
+        "source_id": 51
     },
     {
         "feature_type": "Somatic Variant",
@@ -4104,8 +3988,7 @@
         "_deprecated": false,
         "assertion_id": 117,
         "feature_id": 117,
-        "source_id": 52,
-        "features_endpoint_feature_id": 1003
+        "source_id": 52
     },
     {
         "feature_type": "Somatic Variant",
@@ -4143,8 +4026,7 @@
         "_deprecated": false,
         "assertion_id": 118,
         "feature_id": 118,
-        "source_id": 53,
-        "features_endpoint_feature_id": 1003
+        "source_id": 53
     },
     {
         "feature_type": "Somatic Variant",
@@ -4182,8 +4064,7 @@
         "_deprecated": false,
         "assertion_id": 119,
         "feature_id": 119,
-        "source_id": 53,
-        "features_endpoint_feature_id": 1003
+        "source_id": 53
     },
     {
         "feature_type": "Somatic Variant",
@@ -4221,8 +4102,7 @@
         "_deprecated": false,
         "assertion_id": 120,
         "feature_id": 120,
-        "source_id": 54,
-        "features_endpoint_feature_id": 1003
+        "source_id": 54
     },
     {
         "feature_type": "Somatic Variant",
@@ -4260,8 +4140,7 @@
         "_deprecated": false,
         "assertion_id": 121,
         "feature_id": 121,
-        "source_id": 33,
-        "features_endpoint_feature_id": 1003
+        "source_id": 33
     },
     {
         "feature_type": "Somatic Variant",
@@ -4299,8 +4178,7 @@
         "_deprecated": false,
         "assertion_id": 122,
         "feature_id": 122,
-        "source_id": 33,
-        "features_endpoint_feature_id": 1003
+        "source_id": 33
     },
     {
         "feature_type": "Somatic Variant",
@@ -4338,8 +4216,7 @@
         "_deprecated": false,
         "assertion_id": 123,
         "feature_id": 123,
-        "source_id": 55,
-        "features_endpoint_feature_id": 1003
+        "source_id": 55
     },
     {
         "feature_type": "Somatic Variant",
@@ -4377,8 +4254,7 @@
         "_deprecated": false,
         "assertion_id": 124,
         "feature_id": 124,
-        "source_id": 55,
-        "features_endpoint_feature_id": 1003
+        "source_id": 55
     },
     {
         "feature_type": "Somatic Variant",
@@ -4416,8 +4292,7 @@
         "_deprecated": false,
         "assertion_id": 125,
         "feature_id": 125,
-        "source_id": 55,
-        "features_endpoint_feature_id": 1003
+        "source_id": 55
     },
     {
         "feature_type": "Somatic Variant",
@@ -4455,8 +4330,7 @@
         "_deprecated": false,
         "assertion_id": 126,
         "feature_id": 126,
-        "source_id": 56,
-        "features_endpoint_feature_id": 1003
+        "source_id": 56
     },
     {
         "feature_type": "Somatic Variant",
@@ -4494,8 +4368,7 @@
         "_deprecated": false,
         "assertion_id": 127,
         "feature_id": 127,
-        "source_id": 56,
-        "features_endpoint_feature_id": 1003
+        "source_id": 56
     },
     {
         "feature_type": "Somatic Variant",
@@ -4533,8 +4406,7 @@
         "_deprecated": false,
         "assertion_id": 128,
         "feature_id": 128,
-        "source_id": 56,
-        "features_endpoint_feature_id": 1003
+        "source_id": 56
     },
     {
         "feature_type": "Somatic Variant",
@@ -4572,8 +4444,7 @@
         "_deprecated": false,
         "assertion_id": 129,
         "feature_id": 129,
-        "source_id": 57,
-        "features_endpoint_feature_id": 1003
+        "source_id": 57
     },
     {
         "feature_type": "Somatic Variant",
@@ -4611,8 +4482,7 @@
         "_deprecated": false,
         "assertion_id": 130,
         "feature_id": 130,
-        "source_id": 58,
-        "features_endpoint_feature_id": 1003
+        "source_id": 58
     },
     {
         "feature_type": "Somatic Variant",
@@ -4650,8 +4520,7 @@
         "_deprecated": false,
         "assertion_id": 131,
         "feature_id": 131,
-        "source_id": 59,
-        "features_endpoint_feature_id": 1003
+        "source_id": 59
     },
     {
         "feature_type": "Somatic Variant",
@@ -4689,8 +4558,7 @@
         "_deprecated": false,
         "assertion_id": 132,
         "feature_id": 132,
-        "source_id": 59,
-        "features_endpoint_feature_id": 1003
+        "source_id": 59
     },
     {
         "feature_type": "Somatic Variant",
@@ -4728,8 +4596,7 @@
         "_deprecated": false,
         "assertion_id": 133,
         "feature_id": 133,
-        "source_id": 59,
-        "features_endpoint_feature_id": 1003
+        "source_id": 59
     },
     {
         "feature_type": "Somatic Variant",
@@ -4767,8 +4634,7 @@
         "_deprecated": false,
         "assertion_id": 134,
         "feature_id": 134,
-        "source_id": 59,
-        "features_endpoint_feature_id": 1003
+        "source_id": 59
     },
     {
         "feature_type": "Somatic Variant",
@@ -4806,8 +4672,7 @@
         "_deprecated": false,
         "assertion_id": 135,
         "feature_id": 135,
-        "source_id": 59,
-        "features_endpoint_feature_id": 1003
+        "source_id": 59
     },
     {
         "feature_type": "Somatic Variant",
@@ -4845,8 +4710,7 @@
         "_deprecated": false,
         "assertion_id": 136,
         "feature_id": 136,
-        "source_id": 59,
-        "features_endpoint_feature_id": 1003
+        "source_id": 59
     },
     {
         "feature_type": "Somatic Variant",
@@ -4884,8 +4748,7 @@
         "_deprecated": false,
         "assertion_id": 137,
         "feature_id": 137,
-        "source_id": 58,
-        "features_endpoint_feature_id": 1003
+        "source_id": 58
     },
     {
         "feature_type": "Somatic Variant",
@@ -4923,8 +4786,7 @@
         "_deprecated": false,
         "assertion_id": 138,
         "feature_id": 138,
-        "source_id": 33,
-        "features_endpoint_feature_id": 1003
+        "source_id": 33
     },
     {
         "feature_type": "Somatic Variant",
@@ -4962,8 +4824,7 @@
         "_deprecated": false,
         "assertion_id": 139,
         "feature_id": 139,
-        "source_id": 33,
-        "features_endpoint_feature_id": 1003
+        "source_id": 33
     },
     {
         "feature_type": "Somatic Variant",
@@ -5001,8 +4862,7 @@
         "_deprecated": false,
         "assertion_id": 140,
         "feature_id": 140,
-        "source_id": 33,
-        "features_endpoint_feature_id": 1003
+        "source_id": 33
     },
     {
         "feature_type": "Somatic Variant",
@@ -5040,8 +4900,7 @@
         "_deprecated": false,
         "assertion_id": 141,
         "feature_id": 141,
-        "source_id": 60,
-        "features_endpoint_feature_id": 1003
+        "source_id": 60
     },
     {
         "feature_type": "Somatic Variant",
@@ -5079,8 +4938,7 @@
         "_deprecated": false,
         "assertion_id": 142,
         "feature_id": 142,
-        "source_id": 46,
-        "features_endpoint_feature_id": 1003
+        "source_id": 46
     },
     {
         "feature_type": "Somatic Variant",
@@ -5118,8 +4976,7 @@
         "_deprecated": false,
         "assertion_id": 143,
         "feature_id": 143,
-        "source_id": 61,
-        "features_endpoint_feature_id": 1003
+        "source_id": 61
     },
     {
         "feature_type": "Somatic Variant",
@@ -5157,8 +5014,7 @@
         "_deprecated": false,
         "assertion_id": 144,
         "feature_id": 144,
-        "source_id": 62,
-        "features_endpoint_feature_id": 1003
+        "source_id": 62
     },
     {
         "feature_type": "Somatic Variant",
@@ -5196,8 +5052,7 @@
         "_deprecated": false,
         "assertion_id": 145,
         "feature_id": 145,
-        "source_id": 62,
-        "features_endpoint_feature_id": 1003
+        "source_id": 62
     },
     {
         "feature_type": "Somatic Variant",
@@ -5235,8 +5090,7 @@
         "_deprecated": false,
         "assertion_id": 146,
         "feature_id": 146,
-        "source_id": 62,
-        "features_endpoint_feature_id": 1003
+        "source_id": 62
     },
     {
         "feature_type": "Somatic Variant",
@@ -5274,8 +5128,7 @@
         "_deprecated": false,
         "assertion_id": 147,
         "feature_id": 147,
-        "source_id": 62,
-        "features_endpoint_feature_id": 1003
+        "source_id": 62
     },
     {
         "feature_type": "Somatic Variant",
@@ -5313,8 +5166,7 @@
         "_deprecated": false,
         "assertion_id": 148,
         "feature_id": 148,
-        "source_id": 62,
-        "features_endpoint_feature_id": 1003
+        "source_id": 62
     },
     {
         "feature_type": "Somatic Variant",
@@ -5352,8 +5204,7 @@
         "_deprecated": false,
         "assertion_id": 149,
         "feature_id": 149,
-        "source_id": 62,
-        "features_endpoint_feature_id": 1003
+        "source_id": 62
     },
     {
         "feature_type": "Somatic Variant",
@@ -5391,8 +5242,7 @@
         "_deprecated": false,
         "assertion_id": 150,
         "feature_id": 150,
-        "source_id": 63,
-        "features_endpoint_feature_id": 1003
+        "source_id": 63
     },
     {
         "feature_type": "Somatic Variant",
@@ -5430,8 +5280,7 @@
         "_deprecated": false,
         "assertion_id": 151,
         "feature_id": 151,
-        "source_id": 63,
-        "features_endpoint_feature_id": 1003
+        "source_id": 63
     },
     {
         "feature_type": "Somatic Variant",
@@ -5469,8 +5318,7 @@
         "_deprecated": false,
         "assertion_id": 152,
         "feature_id": 152,
-        "source_id": 64,
-        "features_endpoint_feature_id": 1003
+        "source_id": 64
     },
     {
         "feature_type": "Somatic Variant",
@@ -5508,8 +5356,7 @@
         "_deprecated": false,
         "assertion_id": 153,
         "feature_id": 153,
-        "source_id": 64,
-        "features_endpoint_feature_id": 1003
+        "source_id": 64
     },
     {
         "feature_type": "Somatic Variant",
@@ -5547,8 +5394,7 @@
         "_deprecated": false,
         "assertion_id": 154,
         "feature_id": 154,
-        "source_id": 64,
-        "features_endpoint_feature_id": 1003
+        "source_id": 64
     },
     {
         "feature_type": "Somatic Variant",
@@ -5586,8 +5432,7 @@
         "_deprecated": false,
         "assertion_id": 155,
         "feature_id": 155,
-        "source_id": 65,
-        "features_endpoint_feature_id": 1003
+        "source_id": 65
     },
     {
         "feature_type": "Somatic Variant",
@@ -5625,8 +5470,7 @@
         "_deprecated": false,
         "assertion_id": 156,
         "feature_id": 156,
-        "source_id": 66,
-        "features_endpoint_feature_id": 1003
+        "source_id": 66
     },
     {
         "feature_type": "Somatic Variant",
@@ -5664,8 +5508,7 @@
         "_deprecated": false,
         "assertion_id": 157,
         "feature_id": 157,
-        "source_id": 67,
-        "features_endpoint_feature_id": 1003
+        "source_id": 67
     },
     {
         "feature_type": "Somatic Variant",
@@ -5703,8 +5546,7 @@
         "_deprecated": false,
         "assertion_id": 158,
         "feature_id": 158,
-        "source_id": 68,
-        "features_endpoint_feature_id": 1003
+        "source_id": 68
     },
     {
         "feature_type": "Somatic Variant",
@@ -5742,8 +5584,7 @@
         "_deprecated": false,
         "assertion_id": 159,
         "feature_id": 159,
-        "source_id": 68,
-        "features_endpoint_feature_id": 1003
+        "source_id": 68
     },
     {
         "feature_type": "Somatic Variant",
@@ -5781,8 +5622,7 @@
         "_deprecated": false,
         "assertion_id": 160,
         "feature_id": 160,
-        "source_id": 68,
-        "features_endpoint_feature_id": 1003
+        "source_id": 68
     },
     {
         "feature_type": "Somatic Variant",
@@ -5820,8 +5660,7 @@
         "_deprecated": false,
         "assertion_id": 161,
         "feature_id": 161,
-        "source_id": 68,
-        "features_endpoint_feature_id": 1003
+        "source_id": 68
     },
     {
         "feature_type": "Somatic Variant",
@@ -5859,8 +5698,7 @@
         "_deprecated": false,
         "assertion_id": 162,
         "feature_id": 162,
-        "source_id": 69,
-        "features_endpoint_feature_id": 1003
+        "source_id": 69
     },
     {
         "feature_type": "Somatic Variant",
@@ -5898,8 +5736,7 @@
         "_deprecated": false,
         "assertion_id": 163,
         "feature_id": 163,
-        "source_id": 69,
-        "features_endpoint_feature_id": 1003
+        "source_id": 69
     },
     {
         "feature_type": "Somatic Variant",
@@ -5937,8 +5774,7 @@
         "_deprecated": false,
         "assertion_id": 164,
         "feature_id": 164,
-        "source_id": 70,
-        "features_endpoint_feature_id": 1003
+        "source_id": 70
     },
     {
         "feature_type": "Somatic Variant",
@@ -5976,8 +5812,7 @@
         "_deprecated": false,
         "assertion_id": 165,
         "feature_id": 165,
-        "source_id": 70,
-        "features_endpoint_feature_id": 1003
+        "source_id": 70
     },
     {
         "feature_type": "Somatic Variant",
@@ -6015,8 +5850,7 @@
         "_deprecated": false,
         "assertion_id": 166,
         "feature_id": 166,
-        "source_id": 71,
-        "features_endpoint_feature_id": 1003
+        "source_id": 71
     },
     {
         "feature_type": "Somatic Variant",
@@ -6054,8 +5888,7 @@
         "_deprecated": false,
         "assertion_id": 167,
         "feature_id": 167,
-        "source_id": 72,
-        "features_endpoint_feature_id": 1003
+        "source_id": 72
     },
     {
         "feature_type": "Somatic Variant",
@@ -6093,8 +5926,7 @@
         "_deprecated": false,
         "assertion_id": 168,
         "feature_id": 168,
-        "source_id": 73,
-        "features_endpoint_feature_id": 1003
+        "source_id": 73
     },
     {
         "feature_type": "Somatic Variant",
@@ -6132,8 +5964,7 @@
         "_deprecated": false,
         "assertion_id": 169,
         "feature_id": 169,
-        "source_id": 74,
-        "features_endpoint_feature_id": 1003
+        "source_id": 74
     },
     {
         "feature_type": "Somatic Variant",
@@ -6171,8 +6002,7 @@
         "_deprecated": false,
         "assertion_id": 170,
         "feature_id": 170,
-        "source_id": 74,
-        "features_endpoint_feature_id": 1003
+        "source_id": 74
     },
     {
         "feature_type": "Somatic Variant",
@@ -6210,8 +6040,7 @@
         "_deprecated": false,
         "assertion_id": 171,
         "feature_id": 171,
-        "source_id": 74,
-        "features_endpoint_feature_id": 1003
+        "source_id": 74
     },
     {
         "feature_type": "Somatic Variant",
@@ -6249,8 +6078,7 @@
         "_deprecated": false,
         "assertion_id": 172,
         "feature_id": 172,
-        "source_id": 75,
-        "features_endpoint_feature_id": 1003
+        "source_id": 75
     },
     {
         "feature_type": "Somatic Variant",
@@ -6288,8 +6116,7 @@
         "_deprecated": false,
         "assertion_id": 173,
         "feature_id": 173,
-        "source_id": 76,
-        "features_endpoint_feature_id": 1003
+        "source_id": 76
     },
     {
         "feature_type": "Somatic Variant",
@@ -6327,8 +6154,7 @@
         "_deprecated": false,
         "assertion_id": 174,
         "feature_id": 174,
-        "source_id": 76,
-        "features_endpoint_feature_id": 1003
+        "source_id": 76
     },
     {
         "feature_type": "Somatic Variant",
@@ -6366,8 +6192,7 @@
         "_deprecated": false,
         "assertion_id": 175,
         "feature_id": 175,
-        "source_id": 77,
-        "features_endpoint_feature_id": 1003
+        "source_id": 77
     },
     {
         "feature_type": "Somatic Variant",
@@ -6405,8 +6230,7 @@
         "_deprecated": false,
         "assertion_id": 176,
         "feature_id": 176,
-        "source_id": 78,
-        "features_endpoint_feature_id": 1003
+        "source_id": 78
     },
     {
         "feature_type": "Somatic Variant",
@@ -6444,8 +6268,7 @@
         "_deprecated": false,
         "assertion_id": 177,
         "feature_id": 177,
-        "source_id": 78,
-        "features_endpoint_feature_id": 1003
+        "source_id": 78
     },
     {
         "feature_type": "Somatic Variant",
@@ -6483,8 +6306,7 @@
         "_deprecated": false,
         "assertion_id": 178,
         "feature_id": 178,
-        "source_id": 78,
-        "features_endpoint_feature_id": 1003
+        "source_id": 78
     },
     {
         "feature_type": "Somatic Variant",
@@ -6522,8 +6344,7 @@
         "_deprecated": false,
         "assertion_id": 179,
         "feature_id": 179,
-        "source_id": 78,
-        "features_endpoint_feature_id": 1003
+        "source_id": 78
     },
     {
         "feature_type": "Somatic Variant",
@@ -6561,8 +6382,7 @@
         "_deprecated": false,
         "assertion_id": 180,
         "feature_id": 180,
-        "source_id": 54,
-        "features_endpoint_feature_id": 1003
+        "source_id": 54
     },
     {
         "feature_type": "Somatic Variant",
@@ -6600,8 +6420,7 @@
         "_deprecated": false,
         "assertion_id": 181,
         "feature_id": 181,
-        "source_id": 79,
-        "features_endpoint_feature_id": 1003
+        "source_id": 79
     },
     {
         "feature_type": "Somatic Variant",
@@ -6639,8 +6458,7 @@
         "_deprecated": false,
         "assertion_id": 182,
         "feature_id": 182,
-        "source_id": 66,
-        "features_endpoint_feature_id": 1003
+        "source_id": 66
     },
     {
         "feature_type": "Somatic Variant",
@@ -6678,8 +6496,7 @@
         "_deprecated": false,
         "assertion_id": 183,
         "feature_id": 183,
-        "source_id": 80,
-        "features_endpoint_feature_id": 1003
+        "source_id": 80
     },
     {
         "feature_type": "Somatic Variant",
@@ -6717,8 +6534,7 @@
         "_deprecated": false,
         "assertion_id": 184,
         "feature_id": 184,
-        "source_id": 74,
-        "features_endpoint_feature_id": 1003
+        "source_id": 74
     },
     {
         "feature_type": "Somatic Variant",
@@ -6756,8 +6572,7 @@
         "_deprecated": false,
         "assertion_id": 185,
         "feature_id": 185,
-        "source_id": 81,
-        "features_endpoint_feature_id": 1003
+        "source_id": 81
     },
     {
         "feature_type": "Somatic Variant",
@@ -6795,8 +6610,7 @@
         "_deprecated": false,
         "assertion_id": 186,
         "feature_id": 186,
-        "source_id": 81,
-        "features_endpoint_feature_id": 1003
+        "source_id": 81
     },
     {
         "feature_type": "Somatic Variant",
@@ -6834,8 +6648,7 @@
         "_deprecated": false,
         "assertion_id": 187,
         "feature_id": 187,
-        "source_id": 81,
-        "features_endpoint_feature_id": 1003
+        "source_id": 81
     },
     {
         "feature_type": "Somatic Variant",
@@ -6873,8 +6686,7 @@
         "_deprecated": false,
         "assertion_id": 188,
         "feature_id": 188,
-        "source_id": 82,
-        "features_endpoint_feature_id": 1003
+        "source_id": 82
     },
     {
         "feature_type": "Somatic Variant",
@@ -6912,8 +6724,7 @@
         "_deprecated": false,
         "assertion_id": 189,
         "feature_id": 189,
-        "source_id": 82,
-        "features_endpoint_feature_id": 1003
+        "source_id": 82
     },
     {
         "feature_type": "Somatic Variant",
@@ -6951,8 +6762,7 @@
         "_deprecated": false,
         "assertion_id": 190,
         "feature_id": 190,
-        "source_id": 82,
-        "features_endpoint_feature_id": 1003
+        "source_id": 82
     },
     {
         "feature_type": "Somatic Variant",
@@ -6990,8 +6800,7 @@
         "_deprecated": false,
         "assertion_id": 191,
         "feature_id": 191,
-        "source_id": 83,
-        "features_endpoint_feature_id": 1003
+        "source_id": 83
     },
     {
         "feature_type": "Somatic Variant",
@@ -7029,8 +6838,7 @@
         "_deprecated": false,
         "assertion_id": 192,
         "feature_id": 192,
-        "source_id": 84,
-        "features_endpoint_feature_id": 1003
+        "source_id": 84
     },
     {
         "feature_type": "Somatic Variant",
@@ -7068,8 +6876,7 @@
         "_deprecated": false,
         "assertion_id": 193,
         "feature_id": 193,
-        "source_id": 85,
-        "features_endpoint_feature_id": 1003
+        "source_id": 85
     },
     {
         "feature_type": "Somatic Variant",
@@ -7107,8 +6914,7 @@
         "_deprecated": false,
         "assertion_id": 194,
         "feature_id": 194,
-        "source_id": 86,
-        "features_endpoint_feature_id": 1003
+        "source_id": 86
     },
     {
         "feature_type": "Somatic Variant",
@@ -7146,8 +6952,7 @@
         "_deprecated": false,
         "assertion_id": 195,
         "feature_id": 195,
-        "source_id": 86,
-        "features_endpoint_feature_id": 1003
+        "source_id": 86
     },
     {
         "feature_type": "Somatic Variant",
@@ -7185,8 +6990,7 @@
         "_deprecated": false,
         "assertion_id": 196,
         "feature_id": 196,
-        "source_id": 86,
-        "features_endpoint_feature_id": 1003
+        "source_id": 86
     },
     {
         "feature_type": "Somatic Variant",
@@ -7224,8 +7028,7 @@
         "_deprecated": false,
         "assertion_id": 197,
         "feature_id": 197,
-        "source_id": 58,
-        "features_endpoint_feature_id": 1003
+        "source_id": 58
     },
     {
         "feature_type": "Somatic Variant",
@@ -7263,8 +7066,7 @@
         "_deprecated": false,
         "assertion_id": 198,
         "feature_id": 198,
-        "source_id": 87,
-        "features_endpoint_feature_id": 1003
+        "source_id": 87
     },
     {
         "feature_type": "Somatic Variant",
@@ -7302,8 +7104,7 @@
         "_deprecated": false,
         "assertion_id": 199,
         "feature_id": 199,
-        "source_id": 87,
-        "features_endpoint_feature_id": 1003
+        "source_id": 87
     },
     {
         "feature_type": "Somatic Variant",
@@ -7341,8 +7142,7 @@
         "_deprecated": false,
         "assertion_id": 200,
         "feature_id": 200,
-        "source_id": 87,
-        "features_endpoint_feature_id": 1003
+        "source_id": 87
     },
     {
         "feature_type": "Somatic Variant",
@@ -7380,8 +7180,7 @@
         "_deprecated": false,
         "assertion_id": 201,
         "feature_id": 201,
-        "source_id": 86,
-        "features_endpoint_feature_id": 1003
+        "source_id": 86
     },
     {
         "feature_type": "Somatic Variant",
@@ -7419,8 +7218,7 @@
         "_deprecated": false,
         "assertion_id": 202,
         "feature_id": 202,
-        "source_id": 86,
-        "features_endpoint_feature_id": 1003
+        "source_id": 86
     },
     {
         "feature_type": "Somatic Variant",
@@ -7458,8 +7256,7 @@
         "_deprecated": false,
         "assertion_id": 203,
         "feature_id": 203,
-        "source_id": 86,
-        "features_endpoint_feature_id": 1003
+        "source_id": 86
     },
     {
         "feature_type": "Somatic Variant",
@@ -7497,8 +7294,7 @@
         "_deprecated": false,
         "assertion_id": 204,
         "feature_id": 204,
-        "source_id": 81,
-        "features_endpoint_feature_id": 1003
+        "source_id": 81
     },
     {
         "feature_type": "Somatic Variant",
@@ -7536,8 +7332,7 @@
         "_deprecated": false,
         "assertion_id": 205,
         "feature_id": 205,
-        "source_id": 81,
-        "features_endpoint_feature_id": 1003
+        "source_id": 81
     },
     {
         "feature_type": "Somatic Variant",
@@ -7575,8 +7370,7 @@
         "_deprecated": false,
         "assertion_id": 206,
         "feature_id": 206,
-        "source_id": 81,
-        "features_endpoint_feature_id": 1003
+        "source_id": 81
     },
     {
         "feature_type": "Somatic Variant",
@@ -7614,8 +7408,7 @@
         "_deprecated": false,
         "assertion_id": 207,
         "feature_id": 207,
-        "source_id": 82,
-        "features_endpoint_feature_id": 1003
+        "source_id": 82
     },
     {
         "feature_type": "Somatic Variant",
@@ -7653,8 +7446,7 @@
         "_deprecated": false,
         "assertion_id": 208,
         "feature_id": 208,
-        "source_id": 82,
-        "features_endpoint_feature_id": 1003
+        "source_id": 82
     },
     {
         "feature_type": "Somatic Variant",
@@ -7692,8 +7484,7 @@
         "_deprecated": false,
         "assertion_id": 209,
         "feature_id": 209,
-        "source_id": 82,
-        "features_endpoint_feature_id": 1003
+        "source_id": 82
     },
     {
         "feature_type": "Somatic Variant",
@@ -7731,8 +7522,7 @@
         "_deprecated": false,
         "assertion_id": 210,
         "feature_id": 210,
-        "source_id": 83,
-        "features_endpoint_feature_id": 1003
+        "source_id": 83
     },
     {
         "feature_type": "Somatic Variant",
@@ -7770,8 +7560,7 @@
         "_deprecated": false,
         "assertion_id": 211,
         "feature_id": 211,
-        "source_id": 84,
-        "features_endpoint_feature_id": 1003
+        "source_id": 84
     },
     {
         "feature_type": "Somatic Variant",
@@ -7809,8 +7598,7 @@
         "_deprecated": false,
         "assertion_id": 212,
         "feature_id": 212,
-        "source_id": 88,
-        "features_endpoint_feature_id": 1003
+        "source_id": 88
     },
     {
         "feature_type": "Somatic Variant",
@@ -7848,8 +7636,7 @@
         "_deprecated": false,
         "assertion_id": 213,
         "feature_id": 213,
-        "source_id": 85,
-        "features_endpoint_feature_id": 1003
+        "source_id": 85
     },
     {
         "feature_type": "Somatic Variant",
@@ -7887,8 +7674,7 @@
         "_deprecated": false,
         "assertion_id": 214,
         "feature_id": 214,
-        "source_id": 89,
-        "features_endpoint_feature_id": 1003
+        "source_id": 89
     },
     {
         "feature_type": "Somatic Variant",
@@ -7926,8 +7712,7 @@
         "_deprecated": false,
         "assertion_id": 215,
         "feature_id": 215,
-        "source_id": 58,
-        "features_endpoint_feature_id": 1003
+        "source_id": 58
     },
     {
         "feature_type": "Somatic Variant",
@@ -7965,8 +7750,7 @@
         "_deprecated": false,
         "assertion_id": 216,
         "feature_id": 216,
-        "source_id": 87,
-        "features_endpoint_feature_id": 1003
+        "source_id": 87
     },
     {
         "feature_type": "Somatic Variant",
@@ -8004,8 +7788,7 @@
         "_deprecated": false,
         "assertion_id": 217,
         "feature_id": 217,
-        "source_id": 87,
-        "features_endpoint_feature_id": 1003
+        "source_id": 87
     },
     {
         "feature_type": "Somatic Variant",
@@ -8043,8 +7826,7 @@
         "_deprecated": false,
         "assertion_id": 218,
         "feature_id": 218,
-        "source_id": 87,
-        "features_endpoint_feature_id": 1003
+        "source_id": 87
     },
     {
         "feature_type": "Somatic Variant",
@@ -8082,8 +7864,7 @@
         "_deprecated": false,
         "assertion_id": 219,
         "feature_id": 219,
-        "source_id": 59,
-        "features_endpoint_feature_id": 1003
+        "source_id": 59
     },
     {
         "feature_type": "Somatic Variant",
@@ -8121,8 +7902,7 @@
         "_deprecated": false,
         "assertion_id": 220,
         "feature_id": 220,
-        "source_id": 59,
-        "features_endpoint_feature_id": 1003
+        "source_id": 59
     },
     {
         "feature_type": "Somatic Variant",
@@ -8160,8 +7940,7 @@
         "_deprecated": false,
         "assertion_id": 221,
         "feature_id": 221,
-        "source_id": 59,
-        "features_endpoint_feature_id": 1003
+        "source_id": 59
     },
     {
         "feature_type": "Somatic Variant",
@@ -8199,8 +7978,7 @@
         "_deprecated": false,
         "assertion_id": 222,
         "feature_id": 222,
-        "source_id": 59,
-        "features_endpoint_feature_id": 1003
+        "source_id": 59
     },
     {
         "feature_type": "Somatic Variant",
@@ -8238,8 +8016,7 @@
         "_deprecated": false,
         "assertion_id": 223,
         "feature_id": 223,
-        "source_id": 59,
-        "features_endpoint_feature_id": 1003
+        "source_id": 59
     },
     {
         "feature_type": "Somatic Variant",
@@ -8277,8 +8054,7 @@
         "_deprecated": false,
         "assertion_id": 224,
         "feature_id": 224,
-        "source_id": 59,
-        "features_endpoint_feature_id": 1003
+        "source_id": 59
     },
     {
         "feature_type": "Somatic Variant",
@@ -8316,8 +8092,7 @@
         "_deprecated": false,
         "assertion_id": 225,
         "feature_id": 225,
-        "source_id": 58,
-        "features_endpoint_feature_id": 1003
+        "source_id": 58
     },
     {
         "feature_type": "Somatic Variant",
@@ -8355,8 +8130,7 @@
         "_deprecated": false,
         "assertion_id": 226,
         "feature_id": 226,
-        "source_id": 58,
-        "features_endpoint_feature_id": 1003
+        "source_id": 58
     },
     {
         "feature_type": "Somatic Variant",
@@ -8394,8 +8168,7 @@
         "_deprecated": false,
         "assertion_id": 227,
         "feature_id": 227,
-        "source_id": 59,
-        "features_endpoint_feature_id": 1003
+        "source_id": 59
     },
     {
         "feature_type": "Somatic Variant",
@@ -8433,8 +8206,7 @@
         "_deprecated": false,
         "assertion_id": 228,
         "feature_id": 228,
-        "source_id": 59,
-        "features_endpoint_feature_id": 1003
+        "source_id": 59
     },
     {
         "feature_type": "Somatic Variant",
@@ -8472,8 +8244,7 @@
         "_deprecated": false,
         "assertion_id": 229,
         "feature_id": 229,
-        "source_id": 59,
-        "features_endpoint_feature_id": 1003
+        "source_id": 59
     },
     {
         "feature_type": "Somatic Variant",
@@ -8511,8 +8282,7 @@
         "_deprecated": false,
         "assertion_id": 230,
         "feature_id": 230,
-        "source_id": 59,
-        "features_endpoint_feature_id": 1003
+        "source_id": 59
     },
     {
         "feature_type": "Somatic Variant",
@@ -8550,8 +8320,7 @@
         "_deprecated": false,
         "assertion_id": 231,
         "feature_id": 231,
-        "source_id": 59,
-        "features_endpoint_feature_id": 1003
+        "source_id": 59
     },
     {
         "feature_type": "Somatic Variant",
@@ -8589,8 +8358,7 @@
         "_deprecated": false,
         "assertion_id": 232,
         "feature_id": 232,
-        "source_id": 59,
-        "features_endpoint_feature_id": 1003
+        "source_id": 59
     },
     {
         "feature_type": "Somatic Variant",
@@ -8628,8 +8396,7 @@
         "_deprecated": false,
         "assertion_id": 233,
         "feature_id": 233,
-        "source_id": 58,
-        "features_endpoint_feature_id": 1003
+        "source_id": 58
     },
     {
         "feature_type": "Somatic Variant",
@@ -8667,8 +8434,7 @@
         "_deprecated": false,
         "assertion_id": 234,
         "feature_id": 234,
-        "source_id": 59,
-        "features_endpoint_feature_id": 1003
+        "source_id": 59
     },
     {
         "feature_type": "Somatic Variant",
@@ -8706,8 +8472,7 @@
         "_deprecated": false,
         "assertion_id": 235,
         "feature_id": 235,
-        "source_id": 59,
-        "features_endpoint_feature_id": 1003
+        "source_id": 59
     },
     {
         "feature_type": "Somatic Variant",
@@ -8745,8 +8510,7 @@
         "_deprecated": false,
         "assertion_id": 236,
         "feature_id": 236,
-        "source_id": 59,
-        "features_endpoint_feature_id": 1003
+        "source_id": 59
     },
     {
         "feature_type": "Somatic Variant",
@@ -8784,8 +8548,7 @@
         "_deprecated": false,
         "assertion_id": 237,
         "feature_id": 237,
-        "source_id": 59,
-        "features_endpoint_feature_id": 1003
+        "source_id": 59
     },
     {
         "feature_type": "Somatic Variant",
@@ -8823,8 +8586,7 @@
         "_deprecated": false,
         "assertion_id": 238,
         "feature_id": 238,
-        "source_id": 59,
-        "features_endpoint_feature_id": 1003
+        "source_id": 59
     },
     {
         "feature_type": "Somatic Variant",
@@ -8862,8 +8624,7 @@
         "_deprecated": false,
         "assertion_id": 239,
         "feature_id": 239,
-        "source_id": 59,
-        "features_endpoint_feature_id": 1003
+        "source_id": 59
     },
     {
         "feature_type": "Somatic Variant",
@@ -8901,8 +8662,7 @@
         "_deprecated": false,
         "assertion_id": 240,
         "feature_id": 240,
-        "source_id": 58,
-        "features_endpoint_feature_id": 1003
+        "source_id": 58
     },
     {
         "feature_type": "Somatic Variant",
@@ -8940,8 +8700,7 @@
         "_deprecated": false,
         "assertion_id": 241,
         "feature_id": 241,
-        "source_id": 90,
-        "features_endpoint_feature_id": 1003
+        "source_id": 90
     },
     {
         "feature_type": "Somatic Variant",
@@ -8979,8 +8738,7 @@
         "_deprecated": false,
         "assertion_id": 242,
         "feature_id": 242,
-        "source_id": 91,
-        "features_endpoint_feature_id": 1003
+        "source_id": 91
     },
     {
         "feature_type": "Somatic Variant",
@@ -9018,8 +8776,7 @@
         "_deprecated": false,
         "assertion_id": 243,
         "feature_id": 243,
-        "source_id": 20,
-        "features_endpoint_feature_id": 1003
+        "source_id": 20
     },
     {
         "feature_type": "Somatic Variant",
@@ -9057,8 +8814,7 @@
         "_deprecated": false,
         "assertion_id": 244,
         "feature_id": 244,
-        "source_id": 20,
-        "features_endpoint_feature_id": 1003
+        "source_id": 20
     },
     {
         "feature_type": "Somatic Variant",
@@ -9096,8 +8852,7 @@
         "_deprecated": false,
         "assertion_id": 245,
         "feature_id": 245,
-        "source_id": 20,
-        "features_endpoint_feature_id": 1003
+        "source_id": 20
     },
     {
         "feature_type": "Somatic Variant",
@@ -9135,8 +8890,7 @@
         "_deprecated": false,
         "assertion_id": 246,
         "feature_id": 246,
-        "source_id": 20,
-        "features_endpoint_feature_id": 1003
+        "source_id": 20
     },
     {
         "feature_type": "Somatic Variant",
@@ -9174,8 +8928,7 @@
         "_deprecated": false,
         "assertion_id": 247,
         "feature_id": 247,
-        "source_id": 20,
-        "features_endpoint_feature_id": 1003
+        "source_id": 20
     },
     {
         "feature_type": "Somatic Variant",
@@ -9213,8 +8966,7 @@
         "_deprecated": false,
         "assertion_id": 248,
         "feature_id": 248,
-        "source_id": 20,
-        "features_endpoint_feature_id": 1003
+        "source_id": 20
     },
     {
         "feature_type": "Somatic Variant",
@@ -9252,8 +9004,7 @@
         "_deprecated": false,
         "assertion_id": 249,
         "feature_id": 249,
-        "source_id": 92,
-        "features_endpoint_feature_id": 1003
+        "source_id": 92
     },
     {
         "feature_type": "Somatic Variant",
@@ -9291,8 +9042,7 @@
         "_deprecated": false,
         "assertion_id": 250,
         "feature_id": 250,
-        "source_id": 93,
-        "features_endpoint_feature_id": 1003
+        "source_id": 93
     },
     {
         "feature_type": "Somatic Variant",
@@ -9330,8 +9080,7 @@
         "_deprecated": false,
         "assertion_id": 251,
         "feature_id": 251,
-        "source_id": 94,
-        "features_endpoint_feature_id": 1003
+        "source_id": 94
     },
     {
         "feature_type": "Somatic Variant",
@@ -9369,8 +9118,7 @@
         "_deprecated": false,
         "assertion_id": 252,
         "feature_id": 252,
-        "source_id": 94,
-        "features_endpoint_feature_id": 1003
+        "source_id": 94
     },
     {
         "feature_type": "Somatic Variant",
@@ -9408,8 +9156,7 @@
         "_deprecated": false,
         "assertion_id": 253,
         "feature_id": 253,
-        "source_id": 94,
-        "features_endpoint_feature_id": 1003
+        "source_id": 94
     },
     {
         "feature_type": "Somatic Variant",
@@ -9447,8 +9194,7 @@
         "_deprecated": false,
         "assertion_id": 254,
         "feature_id": 254,
-        "source_id": 94,
-        "features_endpoint_feature_id": 1003
+        "source_id": 94
     },
     {
         "feature_type": "Somatic Variant",
@@ -9486,8 +9232,7 @@
         "_deprecated": false,
         "assertion_id": 255,
         "feature_id": 255,
-        "source_id": 94,
-        "features_endpoint_feature_id": 1003
+        "source_id": 94
     },
     {
         "feature_type": "Somatic Variant",
@@ -9525,8 +9270,7 @@
         "_deprecated": false,
         "assertion_id": 256,
         "feature_id": 256,
-        "source_id": 94,
-        "features_endpoint_feature_id": 1003
+        "source_id": 94
     },
     {
         "feature_type": "Somatic Variant",
@@ -9564,8 +9308,7 @@
         "_deprecated": false,
         "assertion_id": 257,
         "feature_id": 257,
-        "source_id": 95,
-        "features_endpoint_feature_id": 1003
+        "source_id": 95
     },
     {
         "feature_type": "Somatic Variant",
@@ -9603,8 +9346,7 @@
         "_deprecated": false,
         "assertion_id": 258,
         "feature_id": 258,
-        "source_id": 96,
-        "features_endpoint_feature_id": 1003
+        "source_id": 96
     },
     {
         "feature_type": "Somatic Variant",
@@ -9642,8 +9384,7 @@
         "_deprecated": false,
         "assertion_id": 259,
         "feature_id": 259,
-        "source_id": 97,
-        "features_endpoint_feature_id": 1003
+        "source_id": 97
     },
     {
         "feature_type": "Somatic Variant",
@@ -9681,8 +9422,7 @@
         "_deprecated": false,
         "assertion_id": 260,
         "feature_id": 260,
-        "source_id": 97,
-        "features_endpoint_feature_id": 1003
+        "source_id": 97
     },
     {
         "feature_type": "Somatic Variant",
@@ -9720,8 +9460,7 @@
         "_deprecated": false,
         "assertion_id": 261,
         "feature_id": 261,
-        "source_id": 97,
-        "features_endpoint_feature_id": 1003
+        "source_id": 97
     },
     {
         "feature_type": "Somatic Variant",
@@ -9759,8 +9498,7 @@
         "_deprecated": false,
         "assertion_id": 262,
         "feature_id": 262,
-        "source_id": 97,
-        "features_endpoint_feature_id": 1003
+        "source_id": 97
     },
     {
         "feature_type": "Somatic Variant",
@@ -9798,8 +9536,7 @@
         "_deprecated": false,
         "assertion_id": 263,
         "feature_id": 263,
-        "source_id": 97,
-        "features_endpoint_feature_id": 1003
+        "source_id": 97
     },
     {
         "feature_type": "Somatic Variant",
@@ -9837,8 +9574,7 @@
         "_deprecated": false,
         "assertion_id": 264,
         "feature_id": 264,
-        "source_id": 98,
-        "features_endpoint_feature_id": 1003
+        "source_id": 98
     },
     {
         "feature_type": "Somatic Variant",
@@ -9876,8 +9612,7 @@
         "_deprecated": false,
         "assertion_id": 265,
         "feature_id": 265,
-        "source_id": 98,
-        "features_endpoint_feature_id": 1003
+        "source_id": 98
     },
     {
         "feature_type": "Somatic Variant",
@@ -9915,8 +9650,7 @@
         "_deprecated": false,
         "assertion_id": 266,
         "feature_id": 266,
-        "source_id": 99,
-        "features_endpoint_feature_id": 1003
+        "source_id": 99
     },
     {
         "feature_type": "Somatic Variant",
@@ -9954,8 +9688,7 @@
         "_deprecated": false,
         "assertion_id": 267,
         "feature_id": 267,
-        "source_id": 99,
-        "features_endpoint_feature_id": 1003
+        "source_id": 99
     },
     {
         "feature_type": "Somatic Variant",
@@ -9993,8 +9726,7 @@
         "_deprecated": false,
         "assertion_id": 268,
         "feature_id": 268,
-        "source_id": 99,
-        "features_endpoint_feature_id": 1003
+        "source_id": 99
     },
     {
         "feature_type": "Somatic Variant",
@@ -10032,8 +9764,7 @@
         "_deprecated": false,
         "assertion_id": 269,
         "feature_id": 269,
-        "source_id": 19,
-        "features_endpoint_feature_id": 1003
+        "source_id": 19
     },
     {
         "feature_type": "Somatic Variant",
@@ -10071,8 +9802,7 @@
         "_deprecated": false,
         "assertion_id": 270,
         "feature_id": 270,
-        "source_id": 100,
-        "features_endpoint_feature_id": 1003
+        "source_id": 100
     },
     {
         "feature_type": "Somatic Variant",
@@ -10110,8 +9840,7 @@
         "_deprecated": false,
         "assertion_id": 271,
         "feature_id": 271,
-        "source_id": 100,
-        "features_endpoint_feature_id": 1003
+        "source_id": 100
     },
     {
         "feature_type": "Somatic Variant",
@@ -10149,8 +9878,7 @@
         "_deprecated": false,
         "assertion_id": 272,
         "feature_id": 272,
-        "source_id": 101,
-        "features_endpoint_feature_id": 1003
+        "source_id": 101
     },
     {
         "feature_type": "Somatic Variant",
@@ -10188,8 +9916,7 @@
         "_deprecated": false,
         "assertion_id": 273,
         "feature_id": 273,
-        "source_id": 101,
-        "features_endpoint_feature_id": 1003
+        "source_id": 101
     },
     {
         "feature_type": "Somatic Variant",
@@ -10227,8 +9954,7 @@
         "_deprecated": false,
         "assertion_id": 274,
         "feature_id": 274,
-        "source_id": 102,
-        "features_endpoint_feature_id": 1003
+        "source_id": 102
     },
     {
         "feature_type": "Somatic Variant",
@@ -10266,8 +9992,7 @@
         "_deprecated": false,
         "assertion_id": 275,
         "feature_id": 275,
-        "source_id": 103,
-        "features_endpoint_feature_id": 1003
+        "source_id": 103
     },
     {
         "feature_type": "Somatic Variant",
@@ -10305,8 +10030,7 @@
         "_deprecated": false,
         "assertion_id": 276,
         "feature_id": 276,
-        "source_id": 104,
-        "features_endpoint_feature_id": 1003
+        "source_id": 104
     },
     {
         "feature_type": "Somatic Variant",
@@ -10344,8 +10068,7 @@
         "_deprecated": false,
         "assertion_id": 277,
         "feature_id": 277,
-        "source_id": 11,
-        "features_endpoint_feature_id": 1003
+        "source_id": 11
     },
     {
         "feature_type": "Somatic Variant",
@@ -10383,8 +10106,7 @@
         "_deprecated": false,
         "assertion_id": 278,
         "feature_id": 278,
-        "source_id": 104,
-        "features_endpoint_feature_id": 1003
+        "source_id": 104
     },
     {
         "feature_type": "Somatic Variant",
@@ -10422,8 +10144,7 @@
         "_deprecated": false,
         "assertion_id": 279,
         "feature_id": 279,
-        "source_id": 105,
-        "features_endpoint_feature_id": 1003
+        "source_id": 105
     },
     {
         "feature_type": "Somatic Variant",
@@ -10461,8 +10182,7 @@
         "_deprecated": false,
         "assertion_id": 280,
         "feature_id": 280,
-        "source_id": 106,
-        "features_endpoint_feature_id": 1003
+        "source_id": 106
     },
     {
         "feature_type": "Somatic Variant",
@@ -10500,8 +10220,7 @@
         "_deprecated": false,
         "assertion_id": 281,
         "feature_id": 281,
-        "source_id": 23,
-        "features_endpoint_feature_id": 1003
+        "source_id": 23
     },
     {
         "feature_type": "Somatic Variant",
@@ -10539,8 +10258,7 @@
         "_deprecated": false,
         "assertion_id": 282,
         "feature_id": 282,
-        "source_id": 107,
-        "features_endpoint_feature_id": 1003
+        "source_id": 107
     },
     {
         "feature_type": "Somatic Variant",
@@ -10578,8 +10296,7 @@
         "_deprecated": false,
         "assertion_id": 283,
         "feature_id": 283,
-        "source_id": 33,
-        "features_endpoint_feature_id": 1003
+        "source_id": 33
     },
     {
         "feature_type": "Somatic Variant",
@@ -10617,8 +10334,7 @@
         "_deprecated": false,
         "assertion_id": 284,
         "feature_id": 284,
-        "source_id": 33,
-        "features_endpoint_feature_id": 1003
+        "source_id": 33
     },
     {
         "feature_type": "Somatic Variant",
@@ -10656,8 +10372,7 @@
         "_deprecated": false,
         "assertion_id": 285,
         "feature_id": 285,
-        "source_id": 33,
-        "features_endpoint_feature_id": 1003
+        "source_id": 33
     },
     {
         "feature_type": "Somatic Variant",
@@ -10695,8 +10410,7 @@
         "_deprecated": false,
         "assertion_id": 286,
         "feature_id": 286,
-        "source_id": 33,
-        "features_endpoint_feature_id": 1003
+        "source_id": 33
     },
     {
         "feature_type": "Somatic Variant",
@@ -10734,8 +10448,7 @@
         "_deprecated": false,
         "assertion_id": 287,
         "feature_id": 287,
-        "source_id": 108,
-        "features_endpoint_feature_id": 1003
+        "source_id": 108
     },
     {
         "feature_type": "Somatic Variant",
@@ -10773,8 +10486,7 @@
         "_deprecated": false,
         "assertion_id": 288,
         "feature_id": 288,
-        "source_id": 108,
-        "features_endpoint_feature_id": 1003
+        "source_id": 108
     },
     {
         "feature_type": "Somatic Variant",
@@ -10812,8 +10524,7 @@
         "_deprecated": false,
         "assertion_id": 289,
         "feature_id": 289,
-        "source_id": 108,
-        "features_endpoint_feature_id": 1003
+        "source_id": 108
     },
     {
         "feature_type": "Somatic Variant",
@@ -10851,8 +10562,7 @@
         "_deprecated": false,
         "assertion_id": 290,
         "feature_id": 290,
-        "source_id": 108,
-        "features_endpoint_feature_id": 1003
+        "source_id": 108
     },
     {
         "feature_type": "Somatic Variant",
@@ -10890,8 +10600,7 @@
         "_deprecated": false,
         "assertion_id": 291,
         "feature_id": 291,
-        "source_id": 108,
-        "features_endpoint_feature_id": 1003
+        "source_id": 108
     },
     {
         "feature_type": "Somatic Variant",
@@ -10929,8 +10638,7 @@
         "_deprecated": false,
         "assertion_id": 292,
         "feature_id": 292,
-        "source_id": 58,
-        "features_endpoint_feature_id": 1003
+        "source_id": 58
     },
     {
         "feature_type": "Somatic Variant",
@@ -10968,8 +10676,7 @@
         "_deprecated": false,
         "assertion_id": 293,
         "feature_id": 293,
-        "source_id": 109,
-        "features_endpoint_feature_id": 1003
+        "source_id": 109
     },
     {
         "feature_type": "Somatic Variant",
@@ -11007,8 +10714,7 @@
         "_deprecated": false,
         "assertion_id": 294,
         "feature_id": 294,
-        "source_id": 26,
-        "features_endpoint_feature_id": 1003
+        "source_id": 26
     },
     {
         "feature_type": "Somatic Variant",
@@ -11046,8 +10752,7 @@
         "_deprecated": false,
         "assertion_id": 295,
         "feature_id": 295,
-        "source_id": 26,
-        "features_endpoint_feature_id": 1003
+        "source_id": 26
     },
     {
         "feature_type": "Somatic Variant",
@@ -11085,8 +10790,7 @@
         "_deprecated": false,
         "assertion_id": 296,
         "feature_id": 296,
-        "source_id": 26,
-        "features_endpoint_feature_id": 1003
+        "source_id": 26
     },
     {
         "feature_type": "Somatic Variant",
@@ -11124,8 +10828,7 @@
         "_deprecated": false,
         "assertion_id": 297,
         "feature_id": 297,
-        "source_id": 26,
-        "features_endpoint_feature_id": 1003
+        "source_id": 26
     },
     {
         "feature_type": "Somatic Variant",
@@ -11163,8 +10866,7 @@
         "_deprecated": false,
         "assertion_id": 298,
         "feature_id": 298,
-        "source_id": 110,
-        "features_endpoint_feature_id": 1003
+        "source_id": 110
     },
     {
         "feature_type": "Somatic Variant",
@@ -11202,8 +10904,7 @@
         "_deprecated": false,
         "assertion_id": 299,
         "feature_id": 299,
-        "source_id": 110,
-        "features_endpoint_feature_id": 1003
+        "source_id": 110
     },
     {
         "feature_type": "Somatic Variant",
@@ -11241,8 +10942,7 @@
         "_deprecated": false,
         "assertion_id": 300,
         "feature_id": 300,
-        "source_id": 111,
-        "features_endpoint_feature_id": 1003
+        "source_id": 111
     },
     {
         "feature_type": "Somatic Variant",
@@ -11280,8 +10980,7 @@
         "_deprecated": false,
         "assertion_id": 301,
         "feature_id": 301,
-        "source_id": 111,
-        "features_endpoint_feature_id": 1003
+        "source_id": 111
     },
     {
         "feature_type": "Somatic Variant",
@@ -11319,8 +11018,7 @@
         "_deprecated": false,
         "assertion_id": 302,
         "feature_id": 302,
-        "source_id": 111,
-        "features_endpoint_feature_id": 1003
+        "source_id": 111
     },
     {
         "feature_type": "Somatic Variant",
@@ -11358,8 +11056,7 @@
         "_deprecated": false,
         "assertion_id": 303,
         "feature_id": 303,
-        "source_id": 111,
-        "features_endpoint_feature_id": 1003
+        "source_id": 111
     },
     {
         "feature_type": "Somatic Variant",
@@ -11397,8 +11094,7 @@
         "_deprecated": false,
         "assertion_id": 304,
         "feature_id": 304,
-        "source_id": 112,
-        "features_endpoint_feature_id": 1003
+        "source_id": 112
     },
     {
         "feature_type": "Somatic Variant",
@@ -11436,8 +11132,7 @@
         "_deprecated": false,
         "assertion_id": 305,
         "feature_id": 305,
-        "source_id": 113,
-        "features_endpoint_feature_id": 1003
+        "source_id": 113
     },
     {
         "feature_type": "Somatic Variant",
@@ -11475,8 +11170,7 @@
         "_deprecated": false,
         "assertion_id": 306,
         "feature_id": 306,
-        "source_id": 114,
-        "features_endpoint_feature_id": 1003
+        "source_id": 114
     },
     {
         "feature_type": "Somatic Variant",
@@ -11514,8 +11208,7 @@
         "_deprecated": false,
         "assertion_id": 307,
         "feature_id": 307,
-        "source_id": 115,
-        "features_endpoint_feature_id": 1003
+        "source_id": 115
     },
     {
         "feature_type": "Somatic Variant",
@@ -11553,8 +11246,7 @@
         "_deprecated": false,
         "assertion_id": 308,
         "feature_id": 308,
-        "source_id": 116,
-        "features_endpoint_feature_id": 1003
+        "source_id": 116
     },
     {
         "feature_type": "Somatic Variant",
@@ -11592,8 +11284,7 @@
         "_deprecated": false,
         "assertion_id": 309,
         "feature_id": 309,
-        "source_id": 116,
-        "features_endpoint_feature_id": 1003
+        "source_id": 116
     },
     {
         "feature_type": "Somatic Variant",
@@ -11631,8 +11322,7 @@
         "_deprecated": false,
         "assertion_id": 310,
         "feature_id": 310,
-        "source_id": 117,
-        "features_endpoint_feature_id": 1003
+        "source_id": 117
     },
     {
         "feature_type": "Somatic Variant",
@@ -11670,8 +11360,7 @@
         "_deprecated": false,
         "assertion_id": 311,
         "feature_id": 311,
-        "source_id": 117,
-        "features_endpoint_feature_id": 1003
+        "source_id": 117
     },
     {
         "feature_type": "Somatic Variant",
@@ -11709,8 +11398,7 @@
         "_deprecated": false,
         "assertion_id": 312,
         "feature_id": 312,
-        "source_id": 117,
-        "features_endpoint_feature_id": 1003
+        "source_id": 117
     },
     {
         "feature_type": "Somatic Variant",
@@ -11748,8 +11436,7 @@
         "_deprecated": false,
         "assertion_id": 313,
         "feature_id": 313,
-        "source_id": 117,
-        "features_endpoint_feature_id": 1003
+        "source_id": 117
     },
     {
         "feature_type": "Somatic Variant",
@@ -11787,8 +11474,7 @@
         "_deprecated": false,
         "assertion_id": 314,
         "feature_id": 314,
-        "source_id": 117,
-        "features_endpoint_feature_id": 1003
+        "source_id": 117
     },
     {
         "feature_type": "Somatic Variant",
@@ -11826,8 +11512,7 @@
         "_deprecated": false,
         "assertion_id": 315,
         "feature_id": 315,
-        "source_id": 117,
-        "features_endpoint_feature_id": 1003
+        "source_id": 117
     },
     {
         "feature_type": "Somatic Variant",
@@ -11865,8 +11550,7 @@
         "_deprecated": false,
         "assertion_id": 316,
         "feature_id": 316,
-        "source_id": 118,
-        "features_endpoint_feature_id": 1003
+        "source_id": 118
     },
     {
         "feature_type": "Somatic Variant",
@@ -11904,8 +11588,7 @@
         "_deprecated": false,
         "assertion_id": 317,
         "feature_id": 317,
-        "source_id": 118,
-        "features_endpoint_feature_id": 1003
+        "source_id": 118
     },
     {
         "feature_type": "Somatic Variant",
@@ -11943,8 +11626,7 @@
         "_deprecated": false,
         "assertion_id": 318,
         "feature_id": 318,
-        "source_id": 118,
-        "features_endpoint_feature_id": 1003
+        "source_id": 118
     },
     {
         "feature_type": "Somatic Variant",
@@ -11982,8 +11664,7 @@
         "_deprecated": false,
         "assertion_id": 319,
         "feature_id": 319,
-        "source_id": 116,
-        "features_endpoint_feature_id": 1003
+        "source_id": 116
     },
     {
         "feature_type": "Somatic Variant",
@@ -12021,8 +11702,7 @@
         "_deprecated": false,
         "assertion_id": 320,
         "feature_id": 320,
-        "source_id": 116,
-        "features_endpoint_feature_id": 1003
+        "source_id": 116
     },
     {
         "feature_type": "Somatic Variant",
@@ -12060,8 +11740,7 @@
         "_deprecated": false,
         "assertion_id": 321,
         "feature_id": 321,
-        "source_id": 33,
-        "features_endpoint_feature_id": 1003
+        "source_id": 33
     },
     {
         "feature_type": "Somatic Variant",
@@ -12099,8 +11778,7 @@
         "_deprecated": false,
         "assertion_id": 322,
         "feature_id": 322,
-        "source_id": 33,
-        "features_endpoint_feature_id": 1003
+        "source_id": 33
     },
     {
         "feature_type": "Somatic Variant",
@@ -12138,8 +11816,7 @@
         "_deprecated": false,
         "assertion_id": 323,
         "feature_id": 323,
-        "source_id": 33,
-        "features_endpoint_feature_id": 1003
+        "source_id": 33
     },
     {
         "feature_type": "Somatic Variant",
@@ -12177,8 +11854,7 @@
         "_deprecated": false,
         "assertion_id": 324,
         "feature_id": 324,
-        "source_id": 119,
-        "features_endpoint_feature_id": 1003
+        "source_id": 119
     },
     {
         "feature_type": "Somatic Variant",
@@ -12216,8 +11892,7 @@
         "_deprecated": false,
         "assertion_id": 325,
         "feature_id": 325,
-        "source_id": 120,
-        "features_endpoint_feature_id": 1003
+        "source_id": 120
     },
     {
         "feature_type": "Somatic Variant",
@@ -12255,8 +11930,7 @@
         "_deprecated": false,
         "assertion_id": 326,
         "feature_id": 326,
-        "source_id": 120,
-        "features_endpoint_feature_id": 1003
+        "source_id": 120
     },
     {
         "feature_type": "Somatic Variant",
@@ -12294,8 +11968,7 @@
         "_deprecated": false,
         "assertion_id": 327,
         "feature_id": 327,
-        "source_id": 119,
-        "features_endpoint_feature_id": 1003
+        "source_id": 119
     },
     {
         "feature_type": "Somatic Variant",
@@ -12333,8 +12006,7 @@
         "_deprecated": false,
         "assertion_id": 328,
         "feature_id": 328,
-        "source_id": 121,
-        "features_endpoint_feature_id": 1003
+        "source_id": 121
     },
     {
         "feature_type": "Somatic Variant",
@@ -12372,8 +12044,7 @@
         "_deprecated": false,
         "assertion_id": 329,
         "feature_id": 329,
-        "source_id": 122,
-        "features_endpoint_feature_id": 1003
+        "source_id": 122
     },
     {
         "feature_type": "Somatic Variant",
@@ -12411,8 +12082,7 @@
         "_deprecated": false,
         "assertion_id": 330,
         "feature_id": 330,
-        "source_id": 122,
-        "features_endpoint_feature_id": 1003
+        "source_id": 122
     },
     {
         "feature_type": "Somatic Variant",
@@ -12450,8 +12120,7 @@
         "_deprecated": false,
         "assertion_id": 331,
         "feature_id": 331,
-        "source_id": 122,
-        "features_endpoint_feature_id": 1003
+        "source_id": 122
     },
     {
         "feature_type": "Somatic Variant",
@@ -12489,8 +12158,7 @@
         "_deprecated": false,
         "assertion_id": 332,
         "feature_id": 332,
-        "source_id": 122,
-        "features_endpoint_feature_id": 1003
+        "source_id": 122
     },
     {
         "feature_type": "Somatic Variant",
@@ -12528,8 +12196,7 @@
         "_deprecated": false,
         "assertion_id": 333,
         "feature_id": 333,
-        "source_id": 122,
-        "features_endpoint_feature_id": 1003
+        "source_id": 122
     },
     {
         "feature_type": "Somatic Variant",
@@ -12567,8 +12234,7 @@
         "_deprecated": false,
         "assertion_id": 334,
         "feature_id": 334,
-        "source_id": 122,
-        "features_endpoint_feature_id": 1003
+        "source_id": 122
     },
     {
         "feature_type": "Somatic Variant",
@@ -12606,8 +12272,7 @@
         "_deprecated": false,
         "assertion_id": 335,
         "feature_id": 335,
-        "source_id": 3,
-        "features_endpoint_feature_id": 1003
+        "source_id": 3
     },
     {
         "feature_type": "Somatic Variant",
@@ -12645,8 +12310,7 @@
         "_deprecated": false,
         "assertion_id": 336,
         "feature_id": 336,
-        "source_id": 3,
-        "features_endpoint_feature_id": 1003
+        "source_id": 3
     },
     {
         "feature_type": "Somatic Variant",
@@ -12684,8 +12348,7 @@
         "_deprecated": false,
         "assertion_id": 337,
         "feature_id": 337,
-        "source_id": 123,
-        "features_endpoint_feature_id": 1003
+        "source_id": 123
     },
     {
         "feature_type": "Somatic Variant",
@@ -12723,8 +12386,7 @@
         "_deprecated": false,
         "assertion_id": 338,
         "feature_id": 338,
-        "source_id": 123,
-        "features_endpoint_feature_id": 1003
+        "source_id": 123
     },
     {
         "feature_type": "Somatic Variant",
@@ -12762,8 +12424,7 @@
         "_deprecated": false,
         "assertion_id": 339,
         "feature_id": 339,
-        "source_id": 123,
-        "features_endpoint_feature_id": 1003
+        "source_id": 123
     },
     {
         "feature_type": "Somatic Variant",
@@ -12801,8 +12462,7 @@
         "_deprecated": false,
         "assertion_id": 340,
         "feature_id": 340,
-        "source_id": 123,
-        "features_endpoint_feature_id": 1003
+        "source_id": 123
     },
     {
         "feature_type": "Somatic Variant",
@@ -12840,8 +12500,7 @@
         "_deprecated": false,
         "assertion_id": 341,
         "feature_id": 341,
-        "source_id": 124,
-        "features_endpoint_feature_id": 1003
+        "source_id": 124
     },
     {
         "feature_type": "Somatic Variant",
@@ -12879,8 +12538,7 @@
         "_deprecated": false,
         "assertion_id": 342,
         "feature_id": 342,
-        "source_id": 124,
-        "features_endpoint_feature_id": 1003
+        "source_id": 124
     },
     {
         "feature_type": "Somatic Variant",
@@ -12918,8 +12576,7 @@
         "_deprecated": false,
         "assertion_id": 343,
         "feature_id": 343,
-        "source_id": 124,
-        "features_endpoint_feature_id": 1003
+        "source_id": 124
     },
     {
         "feature_type": "Somatic Variant",
@@ -12957,8 +12614,7 @@
         "_deprecated": false,
         "assertion_id": 344,
         "feature_id": 344,
-        "source_id": 125,
-        "features_endpoint_feature_id": 1003
+        "source_id": 125
     },
     {
         "feature_type": "Somatic Variant",
@@ -12996,8 +12652,7 @@
         "_deprecated": false,
         "assertion_id": 345,
         "feature_id": 345,
-        "source_id": 126,
-        "features_endpoint_feature_id": 1003
+        "source_id": 126
     },
     {
         "feature_type": "Somatic Variant",
@@ -13035,8 +12690,7 @@
         "_deprecated": false,
         "assertion_id": 346,
         "feature_id": 346,
-        "source_id": 126,
-        "features_endpoint_feature_id": 1003
+        "source_id": 126
     },
     {
         "feature_type": "Somatic Variant",
@@ -13074,8 +12728,7 @@
         "_deprecated": false,
         "assertion_id": 347,
         "feature_id": 347,
-        "source_id": 126,
-        "features_endpoint_feature_id": 1003
+        "source_id": 126
     },
     {
         "feature_type": "Somatic Variant",
@@ -13113,8 +12766,7 @@
         "_deprecated": false,
         "assertion_id": 348,
         "feature_id": 348,
-        "source_id": 126,
-        "features_endpoint_feature_id": 1003
+        "source_id": 126
     },
     {
         "feature_type": "Somatic Variant",
@@ -13152,8 +12804,7 @@
         "_deprecated": false,
         "assertion_id": 349,
         "feature_id": 349,
-        "source_id": 126,
-        "features_endpoint_feature_id": 1003
+        "source_id": 126
     },
     {
         "feature_type": "Somatic Variant",
@@ -13191,8 +12842,7 @@
         "_deprecated": false,
         "assertion_id": 350,
         "feature_id": 350,
-        "source_id": 126,
-        "features_endpoint_feature_id": 1003
+        "source_id": 126
     },
     {
         "feature_type": "Somatic Variant",
@@ -13230,8 +12880,7 @@
         "_deprecated": false,
         "assertion_id": 351,
         "feature_id": 351,
-        "source_id": 126,
-        "features_endpoint_feature_id": 1003
+        "source_id": 126
     },
     {
         "feature_type": "Somatic Variant",
@@ -13269,8 +12918,7 @@
         "_deprecated": false,
         "assertion_id": 352,
         "feature_id": 352,
-        "source_id": 126,
-        "features_endpoint_feature_id": 1003
+        "source_id": 126
     },
     {
         "feature_type": "Somatic Variant",
@@ -13308,8 +12956,7 @@
         "_deprecated": false,
         "assertion_id": 353,
         "feature_id": 353,
-        "source_id": 126,
-        "features_endpoint_feature_id": 1003
+        "source_id": 126
     },
     {
         "feature_type": "Somatic Variant",
@@ -13347,8 +12994,7 @@
         "_deprecated": false,
         "assertion_id": 354,
         "feature_id": 354,
-        "source_id": 126,
-        "features_endpoint_feature_id": 1003
+        "source_id": 126
     },
     {
         "feature_type": "Somatic Variant",
@@ -13386,8 +13032,7 @@
         "_deprecated": false,
         "assertion_id": 355,
         "feature_id": 355,
-        "source_id": 126,
-        "features_endpoint_feature_id": 1003
+        "source_id": 126
     },
     {
         "feature_type": "Somatic Variant",
@@ -13425,8 +13070,7 @@
         "_deprecated": false,
         "assertion_id": 356,
         "feature_id": 356,
-        "source_id": 68,
-        "features_endpoint_feature_id": 1003
+        "source_id": 68
     },
     {
         "feature_type": "Somatic Variant",
@@ -13464,8 +13108,7 @@
         "_deprecated": false,
         "assertion_id": 357,
         "feature_id": 357,
-        "source_id": 127,
-        "features_endpoint_feature_id": 1003
+        "source_id": 127
     },
     {
         "feature_type": "Somatic Variant",
@@ -13503,8 +13146,7 @@
         "_deprecated": false,
         "assertion_id": 358,
         "feature_id": 358,
-        "source_id": 127,
-        "features_endpoint_feature_id": 1003
+        "source_id": 127
     },
     {
         "feature_type": "Somatic Variant",
@@ -13542,8 +13184,7 @@
         "_deprecated": false,
         "assertion_id": 359,
         "feature_id": 359,
-        "source_id": 128,
-        "features_endpoint_feature_id": 1003
+        "source_id": 128
     },
     {
         "feature_type": "Somatic Variant",
@@ -13581,8 +13222,7 @@
         "_deprecated": false,
         "assertion_id": 360,
         "feature_id": 360,
-        "source_id": 129,
-        "features_endpoint_feature_id": 1003
+        "source_id": 129
     },
     {
         "feature_type": "Somatic Variant",
@@ -13620,8 +13260,7 @@
         "_deprecated": false,
         "assertion_id": 361,
         "feature_id": 361,
-        "source_id": 129,
-        "features_endpoint_feature_id": 1003
+        "source_id": 129
     },
     {
         "feature_type": "Somatic Variant",
@@ -13659,8 +13298,7 @@
         "_deprecated": false,
         "assertion_id": 362,
         "feature_id": 362,
-        "source_id": 129,
-        "features_endpoint_feature_id": 1003
+        "source_id": 129
     },
     {
         "feature_type": "Somatic Variant",
@@ -13698,8 +13336,7 @@
         "_deprecated": false,
         "assertion_id": 363,
         "feature_id": 363,
-        "source_id": 129,
-        "features_endpoint_feature_id": 1003
+        "source_id": 129
     },
     {
         "feature_type": "Somatic Variant",
@@ -13737,8 +13374,7 @@
         "_deprecated": false,
         "assertion_id": 364,
         "feature_id": 364,
-        "source_id": 130,
-        "features_endpoint_feature_id": 1003
+        "source_id": 130
     },
     {
         "feature_type": "Somatic Variant",
@@ -13776,8 +13412,7 @@
         "_deprecated": false,
         "assertion_id": 365,
         "feature_id": 365,
-        "source_id": 131,
-        "features_endpoint_feature_id": 1003
+        "source_id": 131
     },
     {
         "feature_type": "Somatic Variant",
@@ -13815,8 +13450,7 @@
         "_deprecated": false,
         "assertion_id": 366,
         "feature_id": 366,
-        "source_id": 66,
-        "features_endpoint_feature_id": 1003
+        "source_id": 66
     },
     {
         "feature_type": "Somatic Variant",
@@ -13854,8 +13488,7 @@
         "_deprecated": false,
         "assertion_id": 367,
         "feature_id": 367,
-        "source_id": 66,
-        "features_endpoint_feature_id": 1003
+        "source_id": 66
     },
     {
         "feature_type": "Somatic Variant",
@@ -13893,8 +13526,7 @@
         "_deprecated": false,
         "assertion_id": 368,
         "feature_id": 368,
-        "source_id": 66,
-        "features_endpoint_feature_id": 1003
+        "source_id": 66
     },
     {
         "feature_type": "Somatic Variant",
@@ -13932,8 +13564,7 @@
         "_deprecated": false,
         "assertion_id": 369,
         "feature_id": 369,
-        "source_id": 66,
-        "features_endpoint_feature_id": 1003
+        "source_id": 66
     },
     {
         "feature_type": "Somatic Variant",
@@ -13971,8 +13602,7 @@
         "_deprecated": false,
         "assertion_id": 370,
         "feature_id": 370,
-        "source_id": 66,
-        "features_endpoint_feature_id": 1003
+        "source_id": 66
     },
     {
         "feature_type": "Somatic Variant",
@@ -14010,8 +13640,7 @@
         "_deprecated": false,
         "assertion_id": 371,
         "feature_id": 371,
-        "source_id": 66,
-        "features_endpoint_feature_id": 1003
+        "source_id": 66
     },
     {
         "feature_type": "Somatic Variant",
@@ -14049,8 +13678,7 @@
         "_deprecated": false,
         "assertion_id": 372,
         "feature_id": 372,
-        "source_id": 132,
-        "features_endpoint_feature_id": 1003
+        "source_id": 132
     },
     {
         "feature_type": "Somatic Variant",
@@ -14088,8 +13716,7 @@
         "_deprecated": false,
         "assertion_id": 373,
         "feature_id": 373,
-        "source_id": 20,
-        "features_endpoint_feature_id": 1003
+        "source_id": 20
     },
     {
         "feature_type": "Somatic Variant",
@@ -14127,8 +13754,7 @@
         "_deprecated": false,
         "assertion_id": 374,
         "feature_id": 374,
-        "source_id": 133,
-        "features_endpoint_feature_id": 1003
+        "source_id": 133
     },
     {
         "feature_type": "Somatic Variant",
@@ -14166,8 +13792,7 @@
         "_deprecated": false,
         "assertion_id": 375,
         "feature_id": 375,
-        "source_id": 134,
-        "features_endpoint_feature_id": 1003
+        "source_id": 134
     },
     {
         "feature_type": "Somatic Variant",
@@ -14205,8 +13830,7 @@
         "_deprecated": false,
         "assertion_id": 376,
         "feature_id": 376,
-        "source_id": 134,
-        "features_endpoint_feature_id": 1003
+        "source_id": 134
     },
     {
         "feature_type": "Somatic Variant",
@@ -14244,8 +13868,7 @@
         "_deprecated": false,
         "assertion_id": 377,
         "feature_id": 377,
-        "source_id": 134,
-        "features_endpoint_feature_id": 1003
+        "source_id": 134
     },
     {
         "feature_type": "Somatic Variant",
@@ -14283,8 +13906,7 @@
         "_deprecated": false,
         "assertion_id": 378,
         "feature_id": 378,
-        "source_id": 135,
-        "features_endpoint_feature_id": 1003
+        "source_id": 135
     },
     {
         "feature_type": "Somatic Variant",
@@ -14322,8 +13944,7 @@
         "_deprecated": false,
         "assertion_id": 379,
         "feature_id": 379,
-        "source_id": 135,
-        "features_endpoint_feature_id": 1003
+        "source_id": 135
     },
     {
         "feature_type": "Somatic Variant",
@@ -14361,8 +13982,7 @@
         "_deprecated": false,
         "assertion_id": 380,
         "feature_id": 380,
-        "source_id": 136,
-        "features_endpoint_feature_id": 1003
+        "source_id": 136
     },
     {
         "feature_type": "Somatic Variant",
@@ -14400,8 +14020,7 @@
         "_deprecated": false,
         "assertion_id": 381,
         "feature_id": 381,
-        "source_id": 54,
-        "features_endpoint_feature_id": 1003
+        "source_id": 54
     },
     {
         "feature_type": "Somatic Variant",
@@ -14439,8 +14058,7 @@
         "_deprecated": false,
         "assertion_id": 382,
         "feature_id": 382,
-        "source_id": 137,
-        "features_endpoint_feature_id": 1003
+        "source_id": 137
     },
     {
         "feature_type": "Somatic Variant",
@@ -14478,8 +14096,7 @@
         "_deprecated": false,
         "assertion_id": 383,
         "feature_id": 383,
-        "source_id": 137,
-        "features_endpoint_feature_id": 1003
+        "source_id": 137
     },
     {
         "feature_type": "Somatic Variant",
@@ -14517,8 +14134,7 @@
         "_deprecated": false,
         "assertion_id": 384,
         "feature_id": 384,
-        "source_id": 138,
-        "features_endpoint_feature_id": 1003
+        "source_id": 138
     },
     {
         "feature_type": "Somatic Variant",
@@ -14556,8 +14172,7 @@
         "_deprecated": false,
         "assertion_id": 385,
         "feature_id": 385,
-        "source_id": 139,
-        "features_endpoint_feature_id": 1003
+        "source_id": 139
     },
     {
         "feature_type": "Somatic Variant",
@@ -14595,8 +14210,7 @@
         "_deprecated": false,
         "assertion_id": 386,
         "feature_id": 386,
-        "source_id": 71,
-        "features_endpoint_feature_id": 1003
+        "source_id": 71
     },
     {
         "feature_type": "Somatic Variant",
@@ -14634,8 +14248,7 @@
         "_deprecated": false,
         "assertion_id": 387,
         "feature_id": 387,
-        "source_id": 71,
-        "features_endpoint_feature_id": 1003
+        "source_id": 71
     },
     {
         "feature_type": "Somatic Variant",
@@ -14673,8 +14286,7 @@
         "_deprecated": false,
         "assertion_id": 388,
         "feature_id": 388,
-        "source_id": 71,
-        "features_endpoint_feature_id": 1003
+        "source_id": 71
     },
     {
         "feature_type": "Somatic Variant",
@@ -14712,8 +14324,7 @@
         "_deprecated": false,
         "assertion_id": 389,
         "feature_id": 389,
-        "source_id": 140,
-        "features_endpoint_feature_id": 1003
+        "source_id": 140
     },
     {
         "feature_type": "Somatic Variant",
@@ -14751,8 +14362,7 @@
         "_deprecated": false,
         "assertion_id": 390,
         "feature_id": 390,
-        "source_id": 141,
-        "features_endpoint_feature_id": 1003
+        "source_id": 141
     },
     {
         "feature_type": "Somatic Variant",
@@ -14790,8 +14400,7 @@
         "_deprecated": false,
         "assertion_id": 391,
         "feature_id": 391,
-        "source_id": 141,
-        "features_endpoint_feature_id": 1003
+        "source_id": 141
     },
     {
         "feature_type": "Somatic Variant",
@@ -14829,8 +14438,7 @@
         "_deprecated": false,
         "assertion_id": 392,
         "feature_id": 392,
-        "source_id": 142,
-        "features_endpoint_feature_id": 1003
+        "source_id": 142
     },
     {
         "feature_type": "Somatic Variant",
@@ -14868,8 +14476,7 @@
         "_deprecated": false,
         "assertion_id": 393,
         "feature_id": 393,
-        "source_id": 142,
-        "features_endpoint_feature_id": 1003
+        "source_id": 142
     },
     {
         "feature_type": "Somatic Variant",
@@ -14907,8 +14514,7 @@
         "_deprecated": false,
         "assertion_id": 394,
         "feature_id": 394,
-        "source_id": 78,
-        "features_endpoint_feature_id": 1003
+        "source_id": 78
     },
     {
         "feature_type": "Somatic Variant",
@@ -14946,8 +14552,7 @@
         "_deprecated": false,
         "assertion_id": 395,
         "feature_id": 395,
-        "source_id": 143,
-        "features_endpoint_feature_id": 1003
+        "source_id": 143
     },
     {
         "feature_type": "Somatic Variant",
@@ -14985,8 +14590,7 @@
         "_deprecated": false,
         "assertion_id": 396,
         "feature_id": 396,
-        "source_id": 144,
-        "features_endpoint_feature_id": 1003
+        "source_id": 144
     },
     {
         "feature_type": "Somatic Variant",
@@ -15024,8 +14628,7 @@
         "_deprecated": false,
         "assertion_id": 397,
         "feature_id": 397,
-        "source_id": 145,
-        "features_endpoint_feature_id": 1003
+        "source_id": 145
     },
     {
         "feature_type": "Somatic Variant",
@@ -15063,8 +14666,7 @@
         "_deprecated": false,
         "assertion_id": 398,
         "feature_id": 398,
-        "source_id": 11,
-        "features_endpoint_feature_id": 1003
+        "source_id": 11
     },
     {
         "feature_type": "Somatic Variant",
@@ -15102,8 +14704,7 @@
         "_deprecated": false,
         "assertion_id": 399,
         "feature_id": 399,
-        "source_id": 11,
-        "features_endpoint_feature_id": 1003
+        "source_id": 11
     },
     {
         "feature_type": "Somatic Variant",
@@ -15141,8 +14742,7 @@
         "_deprecated": false,
         "assertion_id": 400,
         "feature_id": 400,
-        "source_id": 146,
-        "features_endpoint_feature_id": 1003
+        "source_id": 146
     },
     {
         "feature_type": "Somatic Variant",
@@ -15180,8 +14780,7 @@
         "_deprecated": false,
         "assertion_id": 401,
         "feature_id": 401,
-        "source_id": 146,
-        "features_endpoint_feature_id": 1003
+        "source_id": 146
     },
     {
         "feature_type": "Somatic Variant",
@@ -15219,8 +14818,7 @@
         "_deprecated": false,
         "assertion_id": 402,
         "feature_id": 402,
-        "source_id": 147,
-        "features_endpoint_feature_id": 1003
+        "source_id": 147
     },
     {
         "feature_type": "Somatic Variant",
@@ -15258,8 +14856,7 @@
         "_deprecated": false,
         "assertion_id": 403,
         "feature_id": 403,
-        "source_id": 148,
-        "features_endpoint_feature_id": 1003
+        "source_id": 148
     },
     {
         "feature_type": "Somatic Variant",
@@ -15297,8 +14894,7 @@
         "_deprecated": false,
         "assertion_id": 404,
         "feature_id": 404,
-        "source_id": 147,
-        "features_endpoint_feature_id": 1003
+        "source_id": 147
     },
     {
         "feature_type": "Somatic Variant",
@@ -15336,8 +14932,7 @@
         "_deprecated": false,
         "assertion_id": 405,
         "feature_id": 405,
-        "source_id": 147,
-        "features_endpoint_feature_id": 1003
+        "source_id": 147
     },
     {
         "feature_type": "Somatic Variant",
@@ -15375,8 +14970,7 @@
         "_deprecated": false,
         "assertion_id": 406,
         "feature_id": 406,
-        "source_id": 149,
-        "features_endpoint_feature_id": 1003
+        "source_id": 149
     },
     {
         "feature_type": "Somatic Variant",
@@ -15414,8 +15008,7 @@
         "_deprecated": false,
         "assertion_id": 407,
         "feature_id": 407,
-        "source_id": 147,
-        "features_endpoint_feature_id": 1003
+        "source_id": 147
     },
     {
         "feature_type": "Somatic Variant",
@@ -15453,8 +15046,7 @@
         "_deprecated": false,
         "assertion_id": 408,
         "feature_id": 408,
-        "source_id": 150,
-        "features_endpoint_feature_id": 1003
+        "source_id": 150
     },
     {
         "feature_type": "Somatic Variant",
@@ -15492,8 +15084,7 @@
         "_deprecated": false,
         "assertion_id": 409,
         "feature_id": 409,
-        "source_id": 66,
-        "features_endpoint_feature_id": 1003
+        "source_id": 66
     },
     {
         "feature_type": "Somatic Variant",
@@ -15531,8 +15122,7 @@
         "_deprecated": false,
         "assertion_id": 410,
         "feature_id": 410,
-        "source_id": 66,
-        "features_endpoint_feature_id": 1003
+        "source_id": 66
     },
     {
         "feature_type": "Somatic Variant",
@@ -15570,8 +15160,7 @@
         "_deprecated": false,
         "assertion_id": 411,
         "feature_id": 411,
-        "source_id": 33,
-        "features_endpoint_feature_id": 1003
+        "source_id": 33
     },
     {
         "feature_type": "Somatic Variant",
@@ -15609,8 +15198,7 @@
         "_deprecated": false,
         "assertion_id": 412,
         "feature_id": 412,
-        "source_id": 33,
-        "features_endpoint_feature_id": 1003
+        "source_id": 33
     },
     {
         "feature_type": "Somatic Variant",
@@ -15648,8 +15236,7 @@
         "_deprecated": false,
         "assertion_id": 413,
         "feature_id": 413,
-        "source_id": 33,
-        "features_endpoint_feature_id": 1003
+        "source_id": 33
     },
     {
         "feature_type": "Somatic Variant",
@@ -15687,8 +15274,7 @@
         "_deprecated": false,
         "assertion_id": 414,
         "feature_id": 414,
-        "source_id": 33,
-        "features_endpoint_feature_id": 1003
+        "source_id": 33
     },
     {
         "feature_type": "Somatic Variant",
@@ -15726,8 +15312,7 @@
         "_deprecated": false,
         "assertion_id": 415,
         "feature_id": 415,
-        "source_id": 33,
-        "features_endpoint_feature_id": 1003
+        "source_id": 33
     },
     {
         "feature_type": "Somatic Variant",
@@ -15765,8 +15350,7 @@
         "_deprecated": false,
         "assertion_id": 416,
         "feature_id": 416,
-        "source_id": 33,
-        "features_endpoint_feature_id": 1003
+        "source_id": 33
     },
     {
         "feature_type": "Somatic Variant",
@@ -15804,8 +15388,7 @@
         "_deprecated": false,
         "assertion_id": 417,
         "feature_id": 417,
-        "source_id": 33,
-        "features_endpoint_feature_id": 1003
+        "source_id": 33
     },
     {
         "feature_type": "Somatic Variant",
@@ -15843,8 +15426,7 @@
         "_deprecated": false,
         "assertion_id": 418,
         "feature_id": 418,
-        "source_id": 33,
-        "features_endpoint_feature_id": 1003
+        "source_id": 33
     },
     {
         "feature_type": "Somatic Variant",
@@ -15882,8 +15464,7 @@
         "_deprecated": false,
         "assertion_id": 419,
         "feature_id": 419,
-        "source_id": 33,
-        "features_endpoint_feature_id": 1003
+        "source_id": 33
     },
     {
         "feature_type": "Somatic Variant",
@@ -15921,8 +15502,7 @@
         "_deprecated": false,
         "assertion_id": 420,
         "feature_id": 420,
-        "source_id": 33,
-        "features_endpoint_feature_id": 1003
+        "source_id": 33
     },
     {
         "feature_type": "Somatic Variant",
@@ -15960,8 +15540,7 @@
         "_deprecated": false,
         "assertion_id": 421,
         "feature_id": 421,
-        "source_id": 33,
-        "features_endpoint_feature_id": 1003
+        "source_id": 33
     },
     {
         "feature_type": "Somatic Variant",
@@ -15999,8 +15578,7 @@
         "_deprecated": false,
         "assertion_id": 422,
         "feature_id": 422,
-        "source_id": 33,
-        "features_endpoint_feature_id": 1003
+        "source_id": 33
     },
     {
         "feature_type": "Somatic Variant",
@@ -16038,8 +15616,7 @@
         "_deprecated": false,
         "assertion_id": 423,
         "feature_id": 423,
-        "source_id": 33,
-        "features_endpoint_feature_id": 1003
+        "source_id": 33
     },
     {
         "feature_type": "Somatic Variant",
@@ -16077,8 +15654,7 @@
         "_deprecated": false,
         "assertion_id": 424,
         "feature_id": 424,
-        "source_id": 33,
-        "features_endpoint_feature_id": 1003
+        "source_id": 33
     },
     {
         "feature_type": "Somatic Variant",
@@ -16116,8 +15692,7 @@
         "_deprecated": false,
         "assertion_id": 425,
         "feature_id": 425,
-        "source_id": 151,
-        "features_endpoint_feature_id": 1003
+        "source_id": 151
     },
     {
         "feature_type": "Somatic Variant",
@@ -16155,8 +15730,7 @@
         "_deprecated": false,
         "assertion_id": 426,
         "feature_id": 426,
-        "source_id": 151,
-        "features_endpoint_feature_id": 1003
+        "source_id": 151
     },
     {
         "feature_type": "Somatic Variant",
@@ -16194,8 +15768,7 @@
         "_deprecated": false,
         "assertion_id": 427,
         "feature_id": 427,
-        "source_id": 151,
-        "features_endpoint_feature_id": 1003
+        "source_id": 151
     },
     {
         "feature_type": "Somatic Variant",
@@ -16233,8 +15806,7 @@
         "_deprecated": false,
         "assertion_id": 428,
         "feature_id": 428,
-        "source_id": 151,
-        "features_endpoint_feature_id": 1003
+        "source_id": 151
     },
     {
         "feature_type": "Somatic Variant",
@@ -16272,8 +15844,7 @@
         "_deprecated": false,
         "assertion_id": 429,
         "feature_id": 429,
-        "source_id": 151,
-        "features_endpoint_feature_id": 1003
+        "source_id": 151
     },
     {
         "feature_type": "Somatic Variant",
@@ -16311,8 +15882,7 @@
         "_deprecated": false,
         "assertion_id": 430,
         "feature_id": 430,
-        "source_id": 151,
-        "features_endpoint_feature_id": 1003
+        "source_id": 151
     },
     {
         "feature_type": "Somatic Variant",
@@ -16350,8 +15920,7 @@
         "_deprecated": false,
         "assertion_id": 431,
         "feature_id": 431,
-        "source_id": 151,
-        "features_endpoint_feature_id": 1003
+        "source_id": 151
     },
     {
         "feature_type": "Somatic Variant",
@@ -16389,8 +15958,7 @@
         "_deprecated": false,
         "assertion_id": 432,
         "feature_id": 432,
-        "source_id": 151,
-        "features_endpoint_feature_id": 1003
+        "source_id": 151
     },
     {
         "feature_type": "Somatic Variant",
@@ -16428,8 +15996,7 @@
         "_deprecated": false,
         "assertion_id": 433,
         "feature_id": 433,
-        "source_id": 151,
-        "features_endpoint_feature_id": 1003
+        "source_id": 151
     },
     {
         "feature_type": "Somatic Variant",
@@ -16467,8 +16034,7 @@
         "_deprecated": false,
         "assertion_id": 434,
         "feature_id": 434,
-        "source_id": 151,
-        "features_endpoint_feature_id": 1003
+        "source_id": 151
     },
     {
         "feature_type": "Somatic Variant",
@@ -16506,8 +16072,7 @@
         "_deprecated": false,
         "assertion_id": 435,
         "feature_id": 435,
-        "source_id": 151,
-        "features_endpoint_feature_id": 1003
+        "source_id": 151
     },
     {
         "feature_type": "Somatic Variant",
@@ -16545,8 +16110,7 @@
         "_deprecated": false,
         "assertion_id": 436,
         "feature_id": 436,
-        "source_id": 151,
-        "features_endpoint_feature_id": 1003
+        "source_id": 151
     },
     {
         "feature_type": "Somatic Variant",
@@ -16584,8 +16148,7 @@
         "_deprecated": false,
         "assertion_id": 437,
         "feature_id": 437,
-        "source_id": 151,
-        "features_endpoint_feature_id": 1003
+        "source_id": 151
     },
     {
         "feature_type": "Somatic Variant",
@@ -16623,8 +16186,7 @@
         "_deprecated": false,
         "assertion_id": 438,
         "feature_id": 438,
-        "source_id": 151,
-        "features_endpoint_feature_id": 1003
+        "source_id": 151
     },
     {
         "feature_type": "Somatic Variant",
@@ -16662,8 +16224,7 @@
         "_deprecated": false,
         "assertion_id": 439,
         "feature_id": 439,
-        "source_id": 151,
-        "features_endpoint_feature_id": 1003
+        "source_id": 151
     },
     {
         "feature_type": "Somatic Variant",
@@ -16701,8 +16262,7 @@
         "_deprecated": false,
         "assertion_id": 440,
         "feature_id": 440,
-        "source_id": 152,
-        "features_endpoint_feature_id": 1003
+        "source_id": 152
     },
     {
         "feature_type": "Somatic Variant",
@@ -16740,8 +16300,7 @@
         "_deprecated": false,
         "assertion_id": 441,
         "feature_id": 441,
-        "source_id": 59,
-        "features_endpoint_feature_id": 1003
+        "source_id": 59
     },
     {
         "feature_type": "Somatic Variant",
@@ -16779,8 +16338,7 @@
         "_deprecated": false,
         "assertion_id": 442,
         "feature_id": 442,
-        "source_id": 59,
-        "features_endpoint_feature_id": 1003
+        "source_id": 59
     },
     {
         "feature_type": "Somatic Variant",
@@ -16818,8 +16376,7 @@
         "_deprecated": false,
         "assertion_id": 443,
         "feature_id": 443,
-        "source_id": 59,
-        "features_endpoint_feature_id": 1003
+        "source_id": 59
     },
     {
         "feature_type": "Somatic Variant",
@@ -16857,8 +16414,7 @@
         "_deprecated": false,
         "assertion_id": 444,
         "feature_id": 444,
-        "source_id": 59,
-        "features_endpoint_feature_id": 1003
+        "source_id": 59
     },
     {
         "feature_type": "Somatic Variant",
@@ -16896,8 +16452,7 @@
         "_deprecated": false,
         "assertion_id": 445,
         "feature_id": 445,
-        "source_id": 59,
-        "features_endpoint_feature_id": 1003
+        "source_id": 59
     },
     {
         "feature_type": "Somatic Variant",
@@ -16935,8 +16490,7 @@
         "_deprecated": false,
         "assertion_id": 446,
         "feature_id": 446,
-        "source_id": 59,
-        "features_endpoint_feature_id": 1003
+        "source_id": 59
     },
     {
         "feature_type": "Somatic Variant",
@@ -16974,8 +16528,7 @@
         "_deprecated": false,
         "assertion_id": 447,
         "feature_id": 447,
-        "source_id": 85,
-        "features_endpoint_feature_id": 1003
+        "source_id": 85
     },
     {
         "feature_type": "Somatic Variant",
@@ -17013,8 +16566,7 @@
         "_deprecated": false,
         "assertion_id": 448,
         "feature_id": 448,
-        "source_id": 58,
-        "features_endpoint_feature_id": 1003
+        "source_id": 58
     },
     {
         "feature_type": "Somatic Variant",
@@ -17052,8 +16604,7 @@
         "_deprecated": false,
         "assertion_id": 449,
         "feature_id": 449,
-        "source_id": 153,
-        "features_endpoint_feature_id": 1003
+        "source_id": 153
     },
     {
         "feature_type": "Somatic Variant",
@@ -17091,8 +16642,7 @@
         "_deprecated": false,
         "assertion_id": 450,
         "feature_id": 450,
-        "source_id": 127,
-        "features_endpoint_feature_id": 1003
+        "source_id": 127
     },
     {
         "feature_type": "Somatic Variant",
@@ -17130,8 +16680,7 @@
         "_deprecated": false,
         "assertion_id": 451,
         "feature_id": 451,
-        "source_id": 127,
-        "features_endpoint_feature_id": 1003
+        "source_id": 127
     },
     {
         "feature_type": "Somatic Variant",
@@ -17169,8 +16718,7 @@
         "_deprecated": false,
         "assertion_id": 452,
         "feature_id": 452,
-        "source_id": 129,
-        "features_endpoint_feature_id": 1003
+        "source_id": 129
     },
     {
         "feature_type": "Somatic Variant",
@@ -17208,8 +16756,7 @@
         "_deprecated": false,
         "assertion_id": 453,
         "feature_id": 453,
-        "source_id": 129,
-        "features_endpoint_feature_id": 1003
+        "source_id": 129
     },
     {
         "feature_type": "Somatic Variant",
@@ -17247,8 +16794,7 @@
         "_deprecated": false,
         "assertion_id": 454,
         "feature_id": 454,
-        "source_id": 129,
-        "features_endpoint_feature_id": 1003
+        "source_id": 129
     },
     {
         "feature_type": "Somatic Variant",
@@ -17286,8 +16832,7 @@
         "_deprecated": false,
         "assertion_id": 455,
         "feature_id": 455,
-        "source_id": 153,
-        "features_endpoint_feature_id": 1003
+        "source_id": 153
     },
     {
         "feature_type": "Somatic Variant",
@@ -17325,8 +16870,7 @@
         "_deprecated": false,
         "assertion_id": 456,
         "feature_id": 456,
-        "source_id": 154,
-        "features_endpoint_feature_id": 1003
+        "source_id": 154
     },
     {
         "feature_type": "Somatic Variant",
@@ -17364,8 +16908,7 @@
         "_deprecated": false,
         "assertion_id": 457,
         "feature_id": 457,
-        "source_id": 155,
-        "features_endpoint_feature_id": 1003
+        "source_id": 155
     },
     {
         "feature_type": "Somatic Variant",
@@ -17403,8 +16946,7 @@
         "_deprecated": false,
         "assertion_id": 458,
         "feature_id": 458,
-        "source_id": 44,
-        "features_endpoint_feature_id": 1003
+        "source_id": 44
     },
     {
         "feature_type": "Somatic Variant",
@@ -17442,8 +16984,7 @@
         "_deprecated": false,
         "assertion_id": 459,
         "feature_id": 459,
-        "source_id": 60,
-        "features_endpoint_feature_id": 1003
+        "source_id": 60
     },
     {
         "feature_type": "Somatic Variant",
@@ -17481,8 +17022,7 @@
         "_deprecated": false,
         "assertion_id": 460,
         "feature_id": 460,
-        "source_id": 60,
-        "features_endpoint_feature_id": 1003
+        "source_id": 60
     },
     {
         "feature_type": "Somatic Variant",
@@ -17520,8 +17060,7 @@
         "_deprecated": false,
         "assertion_id": 461,
         "feature_id": 461,
-        "source_id": 60,
-        "features_endpoint_feature_id": 1003
+        "source_id": 60
     },
     {
         "feature_type": "Somatic Variant",
@@ -17559,8 +17098,7 @@
         "_deprecated": false,
         "assertion_id": 462,
         "feature_id": 462,
-        "source_id": 60,
-        "features_endpoint_feature_id": 1003
+        "source_id": 60
     },
     {
         "feature_type": "Somatic Variant",
@@ -17598,8 +17136,7 @@
         "_deprecated": false,
         "assertion_id": 463,
         "feature_id": 463,
-        "source_id": 60,
-        "features_endpoint_feature_id": 1003
+        "source_id": 60
     },
     {
         "feature_type": "Somatic Variant",
@@ -17637,8 +17174,7 @@
         "_deprecated": false,
         "assertion_id": 464,
         "feature_id": 464,
-        "source_id": 60,
-        "features_endpoint_feature_id": 1003
+        "source_id": 60
     },
     {
         "feature_type": "Somatic Variant",
@@ -17676,8 +17212,7 @@
         "_deprecated": false,
         "assertion_id": 465,
         "feature_id": 465,
-        "source_id": 60,
-        "features_endpoint_feature_id": 1003
+        "source_id": 60
     },
     {
         "feature_type": "Somatic Variant",
@@ -17715,8 +17250,7 @@
         "_deprecated": false,
         "assertion_id": 466,
         "feature_id": 466,
-        "source_id": 60,
-        "features_endpoint_feature_id": 1003
+        "source_id": 60
     },
     {
         "feature_type": "Somatic Variant",
@@ -17754,8 +17288,7 @@
         "_deprecated": false,
         "assertion_id": 467,
         "feature_id": 467,
-        "source_id": 60,
-        "features_endpoint_feature_id": 1003
+        "source_id": 60
     },
     {
         "feature_type": "Somatic Variant",
@@ -17793,8 +17326,7 @@
         "_deprecated": false,
         "assertion_id": 468,
         "feature_id": 468,
-        "source_id": 60,
-        "features_endpoint_feature_id": 1003
+        "source_id": 60
     },
     {
         "feature_type": "Somatic Variant",
@@ -17832,8 +17364,7 @@
         "_deprecated": false,
         "assertion_id": 469,
         "feature_id": 469,
-        "source_id": 60,
-        "features_endpoint_feature_id": 1003
+        "source_id": 60
     },
     {
         "feature_type": "Somatic Variant",
@@ -17871,8 +17402,7 @@
         "_deprecated": false,
         "assertion_id": 470,
         "feature_id": 470,
-        "source_id": 60,
-        "features_endpoint_feature_id": 1003
+        "source_id": 60
     },
     {
         "feature_type": "Somatic Variant",
@@ -17910,8 +17440,7 @@
         "_deprecated": false,
         "assertion_id": 471,
         "feature_id": 471,
-        "source_id": 60,
-        "features_endpoint_feature_id": 1003
+        "source_id": 60
     },
     {
         "feature_type": "Somatic Variant",
@@ -17949,8 +17478,7 @@
         "_deprecated": false,
         "assertion_id": 472,
         "feature_id": 472,
-        "source_id": 60,
-        "features_endpoint_feature_id": 1003
+        "source_id": 60
     },
     {
         "feature_type": "Somatic Variant",
@@ -17988,8 +17516,7 @@
         "_deprecated": false,
         "assertion_id": 473,
         "feature_id": 473,
-        "source_id": 60,
-        "features_endpoint_feature_id": 1003
+        "source_id": 60
     },
     {
         "feature_type": "Somatic Variant",
@@ -18027,8 +17554,7 @@
         "_deprecated": false,
         "assertion_id": 474,
         "feature_id": 474,
-        "source_id": 60,
-        "features_endpoint_feature_id": 1003
+        "source_id": 60
     },
     {
         "feature_type": "Somatic Variant",
@@ -18066,8 +17592,7 @@
         "_deprecated": false,
         "assertion_id": 475,
         "feature_id": 475,
-        "source_id": 60,
-        "features_endpoint_feature_id": 1003
+        "source_id": 60
     },
     {
         "feature_type": "Somatic Variant",
@@ -18105,8 +17630,7 @@
         "_deprecated": false,
         "assertion_id": 476,
         "feature_id": 476,
-        "source_id": 60,
-        "features_endpoint_feature_id": 1003
+        "source_id": 60
     },
     {
         "feature_type": "Somatic Variant",
@@ -18144,8 +17668,7 @@
         "_deprecated": false,
         "assertion_id": 477,
         "feature_id": 477,
-        "source_id": 60,
-        "features_endpoint_feature_id": 1003
+        "source_id": 60
     },
     {
         "feature_type": "Somatic Variant",
@@ -18183,8 +17706,7 @@
         "_deprecated": false,
         "assertion_id": 478,
         "feature_id": 478,
-        "source_id": 60,
-        "features_endpoint_feature_id": 1003
+        "source_id": 60
     },
     {
         "feature_type": "Somatic Variant",
@@ -18222,8 +17744,7 @@
         "_deprecated": false,
         "assertion_id": 479,
         "feature_id": 479,
-        "source_id": 156,
-        "features_endpoint_feature_id": 1003
+        "source_id": 156
     },
     {
         "feature_type": "Somatic Variant",
@@ -18261,8 +17782,7 @@
         "_deprecated": false,
         "assertion_id": 480,
         "feature_id": 480,
-        "source_id": 156,
-        "features_endpoint_feature_id": 1003
+        "source_id": 156
     },
     {
         "feature_type": "Somatic Variant",
@@ -18300,8 +17820,7 @@
         "_deprecated": false,
         "assertion_id": 481,
         "feature_id": 481,
-        "source_id": 156,
-        "features_endpoint_feature_id": 1003
+        "source_id": 156
     },
     {
         "feature_type": "Somatic Variant",
@@ -18339,8 +17858,7 @@
         "_deprecated": false,
         "assertion_id": 482,
         "feature_id": 482,
-        "source_id": 156,
-        "features_endpoint_feature_id": 1003
+        "source_id": 156
     },
     {
         "feature_type": "Somatic Variant",
@@ -18378,8 +17896,7 @@
         "_deprecated": false,
         "assertion_id": 483,
         "feature_id": 483,
-        "source_id": 147,
-        "features_endpoint_feature_id": 1003
+        "source_id": 147
     },
     {
         "feature_type": "Somatic Variant",
@@ -18417,8 +17934,7 @@
         "_deprecated": false,
         "assertion_id": 484,
         "feature_id": 484,
-        "source_id": 157,
-        "features_endpoint_feature_id": 1003
+        "source_id": 157
     },
     {
         "feature_type": "Somatic Variant",
@@ -18456,8 +17972,7 @@
         "_deprecated": false,
         "assertion_id": 485,
         "feature_id": 485,
-        "source_id": 157,
-        "features_endpoint_feature_id": 1003
+        "source_id": 157
     },
     {
         "feature_type": "Somatic Variant",
@@ -18495,8 +18010,7 @@
         "_deprecated": false,
         "assertion_id": 486,
         "feature_id": 486,
-        "source_id": 156,
-        "features_endpoint_feature_id": 1003
+        "source_id": 156
     },
     {
         "feature_type": "Somatic Variant",
@@ -18534,8 +18048,7 @@
         "_deprecated": false,
         "assertion_id": 487,
         "feature_id": 487,
-        "source_id": 147,
-        "features_endpoint_feature_id": 1003
+        "source_id": 147
     },
     {
         "feature_type": "Somatic Variant",
@@ -18573,8 +18086,7 @@
         "_deprecated": false,
         "assertion_id": 488,
         "feature_id": 488,
-        "source_id": 157,
-        "features_endpoint_feature_id": 1003
+        "source_id": 157
     },
     {
         "feature_type": "Somatic Variant",
@@ -18612,8 +18124,7 @@
         "_deprecated": false,
         "assertion_id": 489,
         "feature_id": 489,
-        "source_id": 157,
-        "features_endpoint_feature_id": 1003
+        "source_id": 157
     },
     {
         "feature_type": "Somatic Variant",
@@ -18651,8 +18162,7 @@
         "_deprecated": false,
         "assertion_id": 490,
         "feature_id": 490,
-        "source_id": 158,
-        "features_endpoint_feature_id": 1003
+        "source_id": 158
     },
     {
         "feature_type": "Somatic Variant",
@@ -18690,8 +18200,7 @@
         "_deprecated": false,
         "assertion_id": 491,
         "feature_id": 491,
-        "source_id": 158,
-        "features_endpoint_feature_id": 1003
+        "source_id": 158
     },
     {
         "feature_type": "Somatic Variant",
@@ -18729,8 +18238,7 @@
         "_deprecated": false,
         "assertion_id": 492,
         "feature_id": 492,
-        "source_id": 158,
-        "features_endpoint_feature_id": 1003
+        "source_id": 158
     },
     {
         "feature_type": "Somatic Variant",
@@ -18768,8 +18276,7 @@
         "_deprecated": false,
         "assertion_id": 493,
         "feature_id": 493,
-        "source_id": 159,
-        "features_endpoint_feature_id": 1003
+        "source_id": 159
     },
     {
         "feature_type": "Somatic Variant",
@@ -18807,8 +18314,7 @@
         "_deprecated": false,
         "assertion_id": 494,
         "feature_id": 494,
-        "source_id": 159,
-        "features_endpoint_feature_id": 1003
+        "source_id": 159
     },
     {
         "feature_type": "Somatic Variant",
@@ -18846,8 +18352,7 @@
         "_deprecated": false,
         "assertion_id": 495,
         "feature_id": 495,
-        "source_id": 159,
-        "features_endpoint_feature_id": 1003
+        "source_id": 159
     },
     {
         "feature_type": "Somatic Variant",
@@ -18885,8 +18390,7 @@
         "_deprecated": false,
         "assertion_id": 496,
         "feature_id": 496,
-        "source_id": 44,
-        "features_endpoint_feature_id": 1003
+        "source_id": 44
     },
     {
         "feature_type": "Somatic Variant",
@@ -18924,8 +18428,7 @@
         "_deprecated": false,
         "assertion_id": 497,
         "feature_id": 497,
-        "source_id": 160,
-        "features_endpoint_feature_id": 1003
+        "source_id": 160
     },
     {
         "feature_type": "Somatic Variant",
@@ -18963,8 +18466,7 @@
         "_deprecated": false,
         "assertion_id": 498,
         "feature_id": 498,
-        "source_id": 160,
-        "features_endpoint_feature_id": 1003
+        "source_id": 160
     },
     {
         "feature_type": "Somatic Variant",
@@ -19002,8 +18504,7 @@
         "_deprecated": false,
         "assertion_id": 499,
         "feature_id": 499,
-        "source_id": 160,
-        "features_endpoint_feature_id": 1003
+        "source_id": 160
     },
     {
         "feature_type": "Somatic Variant",
@@ -19041,8 +18542,7 @@
         "_deprecated": false,
         "assertion_id": 500,
         "feature_id": 500,
-        "source_id": 160,
-        "features_endpoint_feature_id": 1003
+        "source_id": 160
     },
     {
         "feature_type": "Somatic Variant",
@@ -19080,8 +18580,7 @@
         "_deprecated": false,
         "assertion_id": 501,
         "feature_id": 501,
-        "source_id": 33,
-        "features_endpoint_feature_id": 1003
+        "source_id": 33
     },
     {
         "feature_type": "Somatic Variant",
@@ -19119,8 +18618,7 @@
         "_deprecated": false,
         "assertion_id": 502,
         "feature_id": 502,
-        "source_id": 58,
-        "features_endpoint_feature_id": 1003
+        "source_id": 58
     },
     {
         "feature_type": "Somatic Variant",
@@ -19158,8 +18656,7 @@
         "_deprecated": false,
         "assertion_id": 503,
         "feature_id": 503,
-        "source_id": 59,
-        "features_endpoint_feature_id": 1003
+        "source_id": 59
     },
     {
         "feature_type": "Somatic Variant",
@@ -19197,8 +18694,7 @@
         "_deprecated": false,
         "assertion_id": 504,
         "feature_id": 504,
-        "source_id": 59,
-        "features_endpoint_feature_id": 1003
+        "source_id": 59
     },
     {
         "feature_type": "Somatic Variant",
@@ -19236,8 +18732,7 @@
         "_deprecated": false,
         "assertion_id": 505,
         "feature_id": 505,
-        "source_id": 59,
-        "features_endpoint_feature_id": 1003
+        "source_id": 59
     },
     {
         "feature_type": "Somatic Variant",
@@ -19275,8 +18770,7 @@
         "_deprecated": false,
         "assertion_id": 506,
         "feature_id": 506,
-        "source_id": 59,
-        "features_endpoint_feature_id": 1003
+        "source_id": 59
     },
     {
         "feature_type": "Somatic Variant",
@@ -19314,8 +18808,7 @@
         "_deprecated": false,
         "assertion_id": 507,
         "feature_id": 507,
-        "source_id": 59,
-        "features_endpoint_feature_id": 1003
+        "source_id": 59
     },
     {
         "feature_type": "Somatic Variant",
@@ -19353,8 +18846,7 @@
         "_deprecated": false,
         "assertion_id": 508,
         "feature_id": 508,
-        "source_id": 59,
-        "features_endpoint_feature_id": 1003
+        "source_id": 59
     },
     {
         "feature_type": "Somatic Variant",
@@ -19392,8 +18884,7 @@
         "_deprecated": false,
         "assertion_id": 509,
         "feature_id": 509,
-        "source_id": 58,
-        "features_endpoint_feature_id": 1003
+        "source_id": 58
     },
     {
         "feature_type": "Somatic Variant",
@@ -19431,8 +18922,7 @@
         "_deprecated": false,
         "assertion_id": 510,
         "feature_id": 510,
-        "source_id": 59,
-        "features_endpoint_feature_id": 1003
+        "source_id": 59
     },
     {
         "feature_type": "Somatic Variant",
@@ -19470,8 +18960,7 @@
         "_deprecated": false,
         "assertion_id": 511,
         "feature_id": 511,
-        "source_id": 59,
-        "features_endpoint_feature_id": 1003
+        "source_id": 59
     },
     {
         "feature_type": "Somatic Variant",
@@ -19509,8 +18998,7 @@
         "_deprecated": false,
         "assertion_id": 512,
         "feature_id": 512,
-        "source_id": 59,
-        "features_endpoint_feature_id": 1003
+        "source_id": 59
     },
     {
         "feature_type": "Somatic Variant",
@@ -19548,8 +19036,7 @@
         "_deprecated": false,
         "assertion_id": 513,
         "feature_id": 513,
-        "source_id": 59,
-        "features_endpoint_feature_id": 1003
+        "source_id": 59
     },
     {
         "feature_type": "Somatic Variant",
@@ -19587,8 +19074,7 @@
         "_deprecated": false,
         "assertion_id": 514,
         "feature_id": 514,
-        "source_id": 59,
-        "features_endpoint_feature_id": 1003
+        "source_id": 59
     },
     {
         "feature_type": "Somatic Variant",
@@ -19626,8 +19112,7 @@
         "_deprecated": false,
         "assertion_id": 515,
         "feature_id": 515,
-        "source_id": 59,
-        "features_endpoint_feature_id": 1003
+        "source_id": 59
     },
     {
         "feature_type": "Somatic Variant",
@@ -19665,8 +19150,7 @@
         "_deprecated": false,
         "assertion_id": 516,
         "feature_id": 516,
-        "source_id": 58,
-        "features_endpoint_feature_id": 1003
+        "source_id": 58
     },
     {
         "feature_type": "Somatic Variant",
@@ -19704,8 +19188,7 @@
         "_deprecated": false,
         "assertion_id": 517,
         "feature_id": 517,
-        "source_id": 58,
-        "features_endpoint_feature_id": 1003
+        "source_id": 58
     },
     {
         "feature_type": "Somatic Variant",
@@ -19743,8 +19226,7 @@
         "_deprecated": false,
         "assertion_id": 518,
         "feature_id": 518,
-        "source_id": 54,
-        "features_endpoint_feature_id": 1003
+        "source_id": 54
     },
     {
         "feature_type": "Somatic Variant",
@@ -19782,8 +19264,7 @@
         "_deprecated": false,
         "assertion_id": 519,
         "feature_id": 519,
-        "source_id": 161,
-        "features_endpoint_feature_id": 1003
+        "source_id": 161
     },
     {
         "feature_type": "Somatic Variant",
@@ -19821,8 +19302,7 @@
         "_deprecated": false,
         "assertion_id": 520,
         "feature_id": 520,
-        "source_id": 161,
-        "features_endpoint_feature_id": 1003
+        "source_id": 161
     },
     {
         "feature_type": "Somatic Variant",
@@ -19860,8 +19340,7 @@
         "_deprecated": false,
         "assertion_id": 521,
         "feature_id": 521,
-        "source_id": 162,
-        "features_endpoint_feature_id": 1003
+        "source_id": 162
     },
     {
         "feature_type": "Somatic Variant",
@@ -19899,8 +19378,7 @@
         "_deprecated": false,
         "assertion_id": 522,
         "feature_id": 522,
-        "source_id": 33,
-        "features_endpoint_feature_id": 1003
+        "source_id": 33
     },
     {
         "feature_type": "Somatic Variant",
@@ -19938,8 +19416,7 @@
         "_deprecated": false,
         "assertion_id": 523,
         "feature_id": 523,
-        "source_id": 33,
-        "features_endpoint_feature_id": 1003
+        "source_id": 33
     },
     {
         "feature_type": "Somatic Variant",
@@ -19977,8 +19454,7 @@
         "_deprecated": false,
         "assertion_id": 524,
         "feature_id": 524,
-        "source_id": 33,
-        "features_endpoint_feature_id": 1003
+        "source_id": 33
     },
     {
         "feature_type": "Somatic Variant",
@@ -20016,8 +19492,7 @@
         "_deprecated": false,
         "assertion_id": 525,
         "feature_id": 525,
-        "source_id": 33,
-        "features_endpoint_feature_id": 1003
+        "source_id": 33
     },
     {
         "feature_type": "Somatic Variant",
@@ -20055,8 +19530,7 @@
         "_deprecated": false,
         "assertion_id": 526,
         "feature_id": 526,
-        "source_id": 33,
-        "features_endpoint_feature_id": 1003
+        "source_id": 33
     },
     {
         "feature_type": "Somatic Variant",
@@ -20094,8 +19568,7 @@
         "_deprecated": false,
         "assertion_id": 527,
         "feature_id": 527,
-        "source_id": 33,
-        "features_endpoint_feature_id": 1003
+        "source_id": 33
     },
     {
         "feature_type": "Somatic Variant",
@@ -20133,8 +19606,7 @@
         "_deprecated": false,
         "assertion_id": 528,
         "feature_id": 528,
-        "source_id": 33,
-        "features_endpoint_feature_id": 1003
+        "source_id": 33
     },
     {
         "feature_type": "Somatic Variant",
@@ -20172,8 +19644,7 @@
         "_deprecated": false,
         "assertion_id": 529,
         "feature_id": 529,
-        "source_id": 33,
-        "features_endpoint_feature_id": 1003
+        "source_id": 33
     },
     {
         "feature_type": "Somatic Variant",
@@ -20211,8 +19682,7 @@
         "_deprecated": false,
         "assertion_id": 530,
         "feature_id": 530,
-        "source_id": 33,
-        "features_endpoint_feature_id": 1003
+        "source_id": 33
     },
     {
         "feature_type": "Somatic Variant",
@@ -20250,8 +19720,7 @@
         "_deprecated": false,
         "assertion_id": 531,
         "feature_id": 531,
-        "source_id": 33,
-        "features_endpoint_feature_id": 1003
+        "source_id": 33
     },
     {
         "feature_type": "Somatic Variant",
@@ -20289,8 +19758,7 @@
         "_deprecated": false,
         "assertion_id": 532,
         "feature_id": 532,
-        "source_id": 33,
-        "features_endpoint_feature_id": 1003
+        "source_id": 33
     },
     {
         "feature_type": "Somatic Variant",
@@ -20328,8 +19796,7 @@
         "_deprecated": false,
         "assertion_id": 533,
         "feature_id": 533,
-        "source_id": 33,
-        "features_endpoint_feature_id": 1003
+        "source_id": 33
     },
     {
         "feature_type": "Somatic Variant",
@@ -20367,8 +19834,7 @@
         "_deprecated": false,
         "assertion_id": 534,
         "feature_id": 534,
-        "source_id": 33,
-        "features_endpoint_feature_id": 1003
+        "source_id": 33
     },
     {
         "feature_type": "Somatic Variant",
@@ -20406,8 +19872,7 @@
         "_deprecated": false,
         "assertion_id": 535,
         "feature_id": 535,
-        "source_id": 33,
-        "features_endpoint_feature_id": 1003
+        "source_id": 33
     },
     {
         "feature_type": "Somatic Variant",
@@ -20445,8 +19910,7 @@
         "_deprecated": false,
         "assertion_id": 536,
         "feature_id": 536,
-        "source_id": 33,
-        "features_endpoint_feature_id": 1003
+        "source_id": 33
     },
     {
         "feature_type": "Somatic Variant",
@@ -20484,8 +19948,7 @@
         "_deprecated": false,
         "assertion_id": 537,
         "feature_id": 537,
-        "source_id": 33,
-        "features_endpoint_feature_id": 1003
+        "source_id": 33
     },
     {
         "feature_type": "Somatic Variant",
@@ -20523,8 +19986,7 @@
         "_deprecated": false,
         "assertion_id": 538,
         "feature_id": 538,
-        "source_id": 33,
-        "features_endpoint_feature_id": 1003
+        "source_id": 33
     },
     {
         "feature_type": "Somatic Variant",
@@ -20562,8 +20024,7 @@
         "_deprecated": false,
         "assertion_id": 539,
         "feature_id": 539,
-        "source_id": 33,
-        "features_endpoint_feature_id": 1003
+        "source_id": 33
     },
     {
         "feature_type": "Somatic Variant",
@@ -20601,8 +20062,7 @@
         "_deprecated": false,
         "assertion_id": 540,
         "feature_id": 540,
-        "source_id": 33,
-        "features_endpoint_feature_id": 1003
+        "source_id": 33
     },
     {
         "feature_type": "Somatic Variant",
@@ -20640,8 +20100,7 @@
         "_deprecated": false,
         "assertion_id": 541,
         "feature_id": 541,
-        "source_id": 33,
-        "features_endpoint_feature_id": 1003
+        "source_id": 33
     },
     {
         "feature_type": "Somatic Variant",
@@ -20679,8 +20138,7 @@
         "_deprecated": false,
         "assertion_id": 542,
         "feature_id": 542,
-        "source_id": 33,
-        "features_endpoint_feature_id": 1003
+        "source_id": 33
     },
     {
         "feature_type": "Somatic Variant",
@@ -20718,8 +20176,7 @@
         "_deprecated": false,
         "assertion_id": 543,
         "feature_id": 543,
-        "source_id": 33,
-        "features_endpoint_feature_id": 1003
+        "source_id": 33
     },
     {
         "feature_type": "Somatic Variant",
@@ -20757,8 +20214,7 @@
         "_deprecated": false,
         "assertion_id": 544,
         "feature_id": 544,
-        "source_id": 33,
-        "features_endpoint_feature_id": 1003
+        "source_id": 33
     },
     {
         "feature_type": "Somatic Variant",
@@ -20796,8 +20252,7 @@
         "_deprecated": false,
         "assertion_id": 545,
         "feature_id": 545,
-        "source_id": 33,
-        "features_endpoint_feature_id": 1003
+        "source_id": 33
     },
     {
         "feature_type": "Somatic Variant",
@@ -20835,8 +20290,7 @@
         "_deprecated": false,
         "assertion_id": 546,
         "feature_id": 546,
-        "source_id": 33,
-        "features_endpoint_feature_id": 1003
+        "source_id": 33
     },
     {
         "feature_type": "Somatic Variant",
@@ -20874,8 +20328,7 @@
         "_deprecated": false,
         "assertion_id": 547,
         "feature_id": 547,
-        "source_id": 33,
-        "features_endpoint_feature_id": 1003
+        "source_id": 33
     },
     {
         "feature_type": "Somatic Variant",
@@ -20913,8 +20366,7 @@
         "_deprecated": false,
         "assertion_id": 548,
         "feature_id": 548,
-        "source_id": 33,
-        "features_endpoint_feature_id": 1003
+        "source_id": 33
     },
     {
         "feature_type": "Somatic Variant",
@@ -20952,8 +20404,7 @@
         "_deprecated": false,
         "assertion_id": 549,
         "feature_id": 549,
-        "source_id": 33,
-        "features_endpoint_feature_id": 1003
+        "source_id": 33
     },
     {
         "feature_type": "Somatic Variant",
@@ -20991,8 +20442,7 @@
         "_deprecated": false,
         "assertion_id": 550,
         "feature_id": 550,
-        "source_id": 163,
-        "features_endpoint_feature_id": 1003
+        "source_id": 163
     },
     {
         "feature_type": "Somatic Variant",
@@ -21030,8 +20480,7 @@
         "_deprecated": false,
         "assertion_id": 551,
         "feature_id": 551,
-        "source_id": 163,
-        "features_endpoint_feature_id": 1003
+        "source_id": 163
     },
     {
         "feature_type": "Somatic Variant",
@@ -21069,8 +20518,7 @@
         "_deprecated": false,
         "assertion_id": 552,
         "feature_id": 552,
-        "source_id": 163,
-        "features_endpoint_feature_id": 1003
+        "source_id": 163
     },
     {
         "feature_type": "Somatic Variant",
@@ -21108,8 +20556,7 @@
         "_deprecated": false,
         "assertion_id": 553,
         "feature_id": 553,
-        "source_id": 164,
-        "features_endpoint_feature_id": 1003
+        "source_id": 164
     },
     {
         "feature_type": "Somatic Variant",
@@ -21147,8 +20594,7 @@
         "_deprecated": false,
         "assertion_id": 554,
         "feature_id": 554,
-        "source_id": 165,
-        "features_endpoint_feature_id": 1003
+        "source_id": 165
     },
     {
         "feature_type": "Somatic Variant",
@@ -21186,8 +20632,7 @@
         "_deprecated": false,
         "assertion_id": 555,
         "feature_id": 555,
-        "source_id": 166,
-        "features_endpoint_feature_id": 1003
+        "source_id": 166
     },
     {
         "feature_type": "Somatic Variant",
@@ -21225,8 +20670,7 @@
         "_deprecated": false,
         "assertion_id": 556,
         "feature_id": 556,
-        "source_id": 33,
-        "features_endpoint_feature_id": 1003
+        "source_id": 33
     },
     {
         "feature_type": "Somatic Variant",
@@ -21264,8 +20708,7 @@
         "_deprecated": false,
         "assertion_id": 557,
         "feature_id": 557,
-        "source_id": 33,
-        "features_endpoint_feature_id": 1003
+        "source_id": 33
     },
     {
         "feature_type": "Somatic Variant",
@@ -21303,8 +20746,7 @@
         "_deprecated": false,
         "assertion_id": 558,
         "feature_id": 558,
-        "source_id": 33,
-        "features_endpoint_feature_id": 1003
+        "source_id": 33
     },
     {
         "feature_type": "Somatic Variant",
@@ -21342,8 +20784,7 @@
         "_deprecated": false,
         "assertion_id": 559,
         "feature_id": 559,
-        "source_id": 167,
-        "features_endpoint_feature_id": 1003
+        "source_id": 167
     },
     {
         "feature_type": "Somatic Variant",
@@ -21381,8 +20822,7 @@
         "_deprecated": false,
         "assertion_id": 560,
         "feature_id": 560,
-        "source_id": 33,
-        "features_endpoint_feature_id": 1003
+        "source_id": 33
     },
     {
         "feature_type": "Somatic Variant",
@@ -21420,8 +20860,7 @@
         "_deprecated": false,
         "assertion_id": 561,
         "feature_id": 561,
-        "source_id": 33,
-        "features_endpoint_feature_id": 1003
+        "source_id": 33
     },
     {
         "feature_type": "Somatic Variant",
@@ -21459,8 +20898,7 @@
         "_deprecated": false,
         "assertion_id": 562,
         "feature_id": 562,
-        "source_id": 33,
-        "features_endpoint_feature_id": 1003
+        "source_id": 33
     },
     {
         "feature_type": "Somatic Variant",
@@ -21498,8 +20936,7 @@
         "_deprecated": false,
         "assertion_id": 563,
         "feature_id": 563,
-        "source_id": 33,
-        "features_endpoint_feature_id": 1003
+        "source_id": 33
     },
     {
         "feature_type": "Somatic Variant",
@@ -21537,8 +20974,7 @@
         "_deprecated": false,
         "assertion_id": 564,
         "feature_id": 564,
-        "source_id": 33,
-        "features_endpoint_feature_id": 1003
+        "source_id": 33
     },
     {
         "feature_type": "Somatic Variant",
@@ -21576,8 +21012,7 @@
         "_deprecated": false,
         "assertion_id": 565,
         "feature_id": 565,
-        "source_id": 33,
-        "features_endpoint_feature_id": 1003
+        "source_id": 33
     },
     {
         "feature_type": "Somatic Variant",
@@ -21615,8 +21050,7 @@
         "_deprecated": false,
         "assertion_id": 566,
         "feature_id": 566,
-        "source_id": 33,
-        "features_endpoint_feature_id": 1003
+        "source_id": 33
     },
     {
         "feature_type": "Somatic Variant",
@@ -21654,8 +21088,7 @@
         "_deprecated": false,
         "assertion_id": 567,
         "feature_id": 567,
-        "source_id": 33,
-        "features_endpoint_feature_id": 1003
+        "source_id": 33
     },
     {
         "feature_type": "Somatic Variant",
@@ -21693,8 +21126,7 @@
         "_deprecated": false,
         "assertion_id": 568,
         "feature_id": 568,
-        "source_id": 168,
-        "features_endpoint_feature_id": 1003
+        "source_id": 168
     },
     {
         "feature_type": "Somatic Variant",
@@ -21732,8 +21164,7 @@
         "_deprecated": false,
         "assertion_id": 569,
         "feature_id": 569,
-        "source_id": 44,
-        "features_endpoint_feature_id": 1003
+        "source_id": 44
     },
     {
         "feature_type": "Somatic Variant",
@@ -21771,8 +21202,7 @@
         "_deprecated": false,
         "assertion_id": 570,
         "feature_id": 570,
-        "source_id": 138,
-        "features_endpoint_feature_id": 1003
+        "source_id": 138
     },
     {
         "feature_type": "Somatic Variant",
@@ -21810,8 +21240,7 @@
         "_deprecated": false,
         "assertion_id": 571,
         "feature_id": 571,
-        "source_id": 169,
-        "features_endpoint_feature_id": 1003
+        "source_id": 169
     },
     {
         "feature_type": "Somatic Variant",
@@ -21849,8 +21278,7 @@
         "_deprecated": false,
         "assertion_id": 572,
         "feature_id": 572,
-        "source_id": 110,
-        "features_endpoint_feature_id": 1003
+        "source_id": 110
     },
     {
         "feature_type": "Somatic Variant",
@@ -21888,8 +21316,7 @@
         "_deprecated": false,
         "assertion_id": 573,
         "feature_id": 573,
-        "source_id": 110,
-        "features_endpoint_feature_id": 1003
+        "source_id": 110
     },
     {
         "feature_type": "Somatic Variant",
@@ -21927,8 +21354,7 @@
         "_deprecated": false,
         "assertion_id": 574,
         "feature_id": 574,
-        "source_id": 111,
-        "features_endpoint_feature_id": 1003
+        "source_id": 111
     },
     {
         "feature_type": "Somatic Variant",
@@ -21966,8 +21392,7 @@
         "_deprecated": false,
         "assertion_id": 575,
         "feature_id": 575,
-        "source_id": 111,
-        "features_endpoint_feature_id": 1003
+        "source_id": 111
     },
     {
         "feature_type": "Somatic Variant",
@@ -22005,8 +21430,7 @@
         "_deprecated": false,
         "assertion_id": 576,
         "feature_id": 576,
-        "source_id": 149,
-        "features_endpoint_feature_id": 1003
+        "source_id": 149
     },
     {
         "feature_type": "Somatic Variant",
@@ -22044,8 +21468,7 @@
         "_deprecated": false,
         "assertion_id": 577,
         "feature_id": 577,
-        "source_id": 149,
-        "features_endpoint_feature_id": 1003
+        "source_id": 149
     },
     {
         "feature_type": "Somatic Variant",
@@ -22083,8 +21506,7 @@
         "_deprecated": false,
         "assertion_id": 578,
         "feature_id": 578,
-        "source_id": 169,
-        "features_endpoint_feature_id": 1003
+        "source_id": 169
     },
     {
         "feature_type": "Somatic Variant",
@@ -22122,8 +21544,7 @@
         "_deprecated": false,
         "assertion_id": 579,
         "feature_id": 579,
-        "source_id": 110,
-        "features_endpoint_feature_id": 1003
+        "source_id": 110
     },
     {
         "feature_type": "Somatic Variant",
@@ -22161,8 +21582,7 @@
         "_deprecated": false,
         "assertion_id": 580,
         "feature_id": 580,
-        "source_id": 110,
-        "features_endpoint_feature_id": 1003
+        "source_id": 110
     },
     {
         "feature_type": "Somatic Variant",
@@ -22200,8 +21620,7 @@
         "_deprecated": false,
         "assertion_id": 581,
         "feature_id": 581,
-        "source_id": 111,
-        "features_endpoint_feature_id": 1003
+        "source_id": 111
     },
     {
         "feature_type": "Somatic Variant",
@@ -22239,8 +21658,7 @@
         "_deprecated": false,
         "assertion_id": 582,
         "feature_id": 582,
-        "source_id": 111,
-        "features_endpoint_feature_id": 1003
+        "source_id": 111
     },
     {
         "feature_type": "Somatic Variant",
@@ -22278,8 +21696,7 @@
         "_deprecated": false,
         "assertion_id": 583,
         "feature_id": 583,
-        "source_id": 33,
-        "features_endpoint_feature_id": 1003
+        "source_id": 33
     },
     {
         "feature_type": "Somatic Variant",
@@ -22317,8 +21734,7 @@
         "_deprecated": false,
         "assertion_id": 584,
         "feature_id": 584,
-        "source_id": 33,
-        "features_endpoint_feature_id": 1003
+        "source_id": 33
     },
     {
         "feature_type": "Germline Variant",
@@ -22358,8 +21774,7 @@
         "_deprecated": false,
         "assertion_id": 585,
         "feature_id": 585,
-        "source_id": 170,
-        "features_endpoint_feature_id": 1003
+        "source_id": 170
     },
     {
         "feature_type": "Germline Variant",
@@ -22399,8 +21814,7 @@
         "_deprecated": false,
         "assertion_id": 586,
         "feature_id": 586,
-        "source_id": 171,
-        "features_endpoint_feature_id": 1003
+        "source_id": 171
     },
     {
         "feature_type": "Germline Variant",
@@ -22440,8 +21854,7 @@
         "_deprecated": false,
         "assertion_id": 587,
         "feature_id": 587,
-        "source_id": 57,
-        "features_endpoint_feature_id": 1003
+        "source_id": 57
     },
     {
         "feature_type": "Germline Variant",
@@ -22481,8 +21894,7 @@
         "_deprecated": false,
         "assertion_id": 588,
         "feature_id": 588,
-        "source_id": 59,
-        "features_endpoint_feature_id": 1003
+        "source_id": 59
     },
     {
         "feature_type": "Germline Variant",
@@ -22522,8 +21934,7 @@
         "_deprecated": false,
         "assertion_id": 589,
         "feature_id": 589,
-        "source_id": 59,
-        "features_endpoint_feature_id": 1003
+        "source_id": 59
     },
     {
         "feature_type": "Germline Variant",
@@ -22563,8 +21974,7 @@
         "_deprecated": false,
         "assertion_id": 590,
         "feature_id": 590,
-        "source_id": 59,
-        "features_endpoint_feature_id": 1003
+        "source_id": 59
     },
     {
         "feature_type": "Germline Variant",
@@ -22604,8 +22014,7 @@
         "_deprecated": false,
         "assertion_id": 591,
         "feature_id": 591,
-        "source_id": 59,
-        "features_endpoint_feature_id": 1003
+        "source_id": 59
     },
     {
         "feature_type": "Germline Variant",
@@ -22645,8 +22054,7 @@
         "_deprecated": false,
         "assertion_id": 592,
         "feature_id": 592,
-        "source_id": 59,
-        "features_endpoint_feature_id": 1003
+        "source_id": 59
     },
     {
         "feature_type": "Germline Variant",
@@ -22686,8 +22094,7 @@
         "_deprecated": false,
         "assertion_id": 593,
         "feature_id": 593,
-        "source_id": 59,
-        "features_endpoint_feature_id": 1003
+        "source_id": 59
     },
     {
         "feature_type": "Germline Variant",
@@ -22727,8 +22134,7 @@
         "_deprecated": false,
         "assertion_id": 594,
         "feature_id": 594,
-        "source_id": 86,
-        "features_endpoint_feature_id": 1003
+        "source_id": 86
     },
     {
         "feature_type": "Germline Variant",
@@ -22768,8 +22174,7 @@
         "_deprecated": false,
         "assertion_id": 595,
         "feature_id": 595,
-        "source_id": 86,
-        "features_endpoint_feature_id": 1003
+        "source_id": 86
     },
     {
         "feature_type": "Germline Variant",
@@ -22809,8 +22214,7 @@
         "_deprecated": false,
         "assertion_id": 596,
         "feature_id": 596,
-        "source_id": 86,
-        "features_endpoint_feature_id": 1003
+        "source_id": 86
     },
     {
         "feature_type": "Germline Variant",
@@ -22850,8 +22254,7 @@
         "_deprecated": false,
         "assertion_id": 597,
         "feature_id": 597,
-        "source_id": 172,
-        "features_endpoint_feature_id": 1003
+        "source_id": 172
     },
     {
         "feature_type": "Germline Variant",
@@ -22891,8 +22294,7 @@
         "_deprecated": false,
         "assertion_id": 598,
         "feature_id": 598,
-        "source_id": 81,
-        "features_endpoint_feature_id": 1003
+        "source_id": 81
     },
     {
         "feature_type": "Germline Variant",
@@ -22932,8 +22334,7 @@
         "_deprecated": false,
         "assertion_id": 599,
         "feature_id": 599,
-        "source_id": 81,
-        "features_endpoint_feature_id": 1003
+        "source_id": 81
     },
     {
         "feature_type": "Germline Variant",
@@ -22973,8 +22374,7 @@
         "_deprecated": false,
         "assertion_id": 600,
         "feature_id": 600,
-        "source_id": 81,
-        "features_endpoint_feature_id": 1003
+        "source_id": 81
     },
     {
         "feature_type": "Germline Variant",
@@ -23014,8 +22414,7 @@
         "_deprecated": false,
         "assertion_id": 601,
         "feature_id": 601,
-        "source_id": 173,
-        "features_endpoint_feature_id": 1003
+        "source_id": 173
     },
     {
         "feature_type": "Germline Variant",
@@ -23055,8 +22454,7 @@
         "_deprecated": false,
         "assertion_id": 602,
         "feature_id": 602,
-        "source_id": 85,
-        "features_endpoint_feature_id": 1003
+        "source_id": 85
     },
     {
         "feature_type": "Germline Variant",
@@ -23096,8 +22494,7 @@
         "_deprecated": false,
         "assertion_id": 603,
         "feature_id": 603,
-        "source_id": 174,
-        "features_endpoint_feature_id": 1003
+        "source_id": 174
     },
     {
         "feature_type": "Germline Variant",
@@ -23137,8 +22534,7 @@
         "_deprecated": false,
         "assertion_id": 604,
         "feature_id": 604,
-        "source_id": 174,
-        "features_endpoint_feature_id": 1003
+        "source_id": 174
     },
     {
         "feature_type": "Germline Variant",
@@ -23178,8 +22574,7 @@
         "_deprecated": false,
         "assertion_id": 605,
         "feature_id": 605,
-        "source_id": 174,
-        "features_endpoint_feature_id": 1003
+        "source_id": 174
     },
     {
         "feature_type": "Germline Variant",
@@ -23219,8 +22614,7 @@
         "_deprecated": false,
         "assertion_id": 606,
         "feature_id": 606,
-        "source_id": 174,
-        "features_endpoint_feature_id": 1003
+        "source_id": 174
     },
     {
         "feature_type": "Germline Variant",
@@ -23260,8 +22654,7 @@
         "_deprecated": false,
         "assertion_id": 607,
         "feature_id": 607,
-        "source_id": 175,
-        "features_endpoint_feature_id": 1003
+        "source_id": 175
     },
     {
         "feature_type": "Germline Variant",
@@ -23301,8 +22694,7 @@
         "_deprecated": false,
         "assertion_id": 608,
         "feature_id": 608,
-        "source_id": 86,
-        "features_endpoint_feature_id": 1003
+        "source_id": 86
     },
     {
         "feature_type": "Germline Variant",
@@ -23342,8 +22734,7 @@
         "_deprecated": false,
         "assertion_id": 609,
         "feature_id": 609,
-        "source_id": 86,
-        "features_endpoint_feature_id": 1003
+        "source_id": 86
     },
     {
         "feature_type": "Germline Variant",
@@ -23383,8 +22774,7 @@
         "_deprecated": false,
         "assertion_id": 610,
         "feature_id": 610,
-        "source_id": 86,
-        "features_endpoint_feature_id": 1003
+        "source_id": 86
     },
     {
         "feature_type": "Germline Variant",
@@ -23424,8 +22814,7 @@
         "_deprecated": false,
         "assertion_id": 611,
         "feature_id": 611,
-        "source_id": 58,
-        "features_endpoint_feature_id": 1003
+        "source_id": 58
     },
     {
         "feature_type": "Germline Variant",
@@ -23465,8 +22854,7 @@
         "_deprecated": false,
         "assertion_id": 612,
         "feature_id": 612,
-        "source_id": 174,
-        "features_endpoint_feature_id": 1003
+        "source_id": 174
     },
     {
         "feature_type": "Germline Variant",
@@ -23506,8 +22894,7 @@
         "_deprecated": false,
         "assertion_id": 613,
         "feature_id": 613,
-        "source_id": 174,
-        "features_endpoint_feature_id": 1003
+        "source_id": 174
     },
     {
         "feature_type": "Germline Variant",
@@ -23547,8 +22934,7 @@
         "_deprecated": false,
         "assertion_id": 614,
         "feature_id": 614,
-        "source_id": 174,
-        "features_endpoint_feature_id": 1003
+        "source_id": 174
     },
     {
         "feature_type": "Germline Variant",
@@ -23588,8 +22974,7 @@
         "_deprecated": false,
         "assertion_id": 615,
         "feature_id": 615,
-        "source_id": 174,
-        "features_endpoint_feature_id": 1003
+        "source_id": 174
     },
     {
         "feature_type": "Germline Variant",
@@ -23629,8 +23014,7 @@
         "_deprecated": false,
         "assertion_id": 616,
         "feature_id": 616,
-        "source_id": 176,
-        "features_endpoint_feature_id": 1003
+        "source_id": 176
     },
     {
         "feature_type": "Germline Variant",
@@ -23670,8 +23054,7 @@
         "_deprecated": false,
         "assertion_id": 617,
         "feature_id": 617,
-        "source_id": 172,
-        "features_endpoint_feature_id": 1003
+        "source_id": 172
     },
     {
         "feature_type": "Germline Variant",
@@ -23711,8 +23094,7 @@
         "_deprecated": false,
         "assertion_id": 618,
         "feature_id": 618,
-        "source_id": 86,
-        "features_endpoint_feature_id": 1003
+        "source_id": 86
     },
     {
         "feature_type": "Germline Variant",
@@ -23752,8 +23134,7 @@
         "_deprecated": false,
         "assertion_id": 619,
         "feature_id": 619,
-        "source_id": 86,
-        "features_endpoint_feature_id": 1003
+        "source_id": 86
     },
     {
         "feature_type": "Germline Variant",
@@ -23793,8 +23174,7 @@
         "_deprecated": false,
         "assertion_id": 620,
         "feature_id": 620,
-        "source_id": 86,
-        "features_endpoint_feature_id": 1003
+        "source_id": 86
     },
     {
         "feature_type": "Germline Variant",
@@ -23834,8 +23214,7 @@
         "_deprecated": false,
         "assertion_id": 621,
         "feature_id": 621,
-        "source_id": 177,
-        "features_endpoint_feature_id": 1003
+        "source_id": 177
     },
     {
         "feature_type": "Germline Variant",
@@ -23875,8 +23254,7 @@
         "_deprecated": false,
         "assertion_id": 622,
         "feature_id": 622,
-        "source_id": 177,
-        "features_endpoint_feature_id": 1003
+        "source_id": 177
     },
     {
         "feature_type": "Germline Variant",
@@ -23916,8 +23294,7 @@
         "_deprecated": false,
         "assertion_id": 623,
         "feature_id": 623,
-        "source_id": 177,
-        "features_endpoint_feature_id": 1003
+        "source_id": 177
     },
     {
         "feature_type": "Germline Variant",
@@ -23957,8 +23334,7 @@
         "_deprecated": false,
         "assertion_id": 624,
         "feature_id": 624,
-        "source_id": 173,
-        "features_endpoint_feature_id": 1003
+        "source_id": 173
     },
     {
         "feature_type": "Germline Variant",
@@ -23998,8 +23374,7 @@
         "_deprecated": false,
         "assertion_id": 625,
         "feature_id": 625,
-        "source_id": 88,
-        "features_endpoint_feature_id": 1003
+        "source_id": 88
     },
     {
         "feature_type": "Germline Variant",
@@ -24039,8 +23414,7 @@
         "_deprecated": false,
         "assertion_id": 626,
         "feature_id": 626,
-        "source_id": 85,
-        "features_endpoint_feature_id": 1003
+        "source_id": 85
     },
     {
         "feature_type": "Germline Variant",
@@ -24080,8 +23454,7 @@
         "_deprecated": false,
         "assertion_id": 627,
         "feature_id": 627,
-        "source_id": 58,
-        "features_endpoint_feature_id": 1003
+        "source_id": 58
     },
     {
         "feature_type": "Germline Variant",
@@ -24121,8 +23494,7 @@
         "_deprecated": false,
         "assertion_id": 628,
         "feature_id": 628,
-        "source_id": 59,
-        "features_endpoint_feature_id": 1003
+        "source_id": 59
     },
     {
         "feature_type": "Germline Variant",
@@ -24162,8 +23534,7 @@
         "_deprecated": false,
         "assertion_id": 629,
         "feature_id": 629,
-        "source_id": 59,
-        "features_endpoint_feature_id": 1003
+        "source_id": 59
     },
     {
         "feature_type": "Germline Variant",
@@ -24203,8 +23574,7 @@
         "_deprecated": false,
         "assertion_id": 630,
         "feature_id": 630,
-        "source_id": 59,
-        "features_endpoint_feature_id": 1003
+        "source_id": 59
     },
     {
         "feature_type": "Germline Variant",
@@ -24244,8 +23614,7 @@
         "_deprecated": false,
         "assertion_id": 631,
         "feature_id": 631,
-        "source_id": 59,
-        "features_endpoint_feature_id": 1003
+        "source_id": 59
     },
     {
         "feature_type": "Germline Variant",
@@ -24285,8 +23654,7 @@
         "_deprecated": false,
         "assertion_id": 632,
         "feature_id": 632,
-        "source_id": 59,
-        "features_endpoint_feature_id": 1003
+        "source_id": 59
     },
     {
         "feature_type": "Germline Variant",
@@ -24326,8 +23694,7 @@
         "_deprecated": false,
         "assertion_id": 633,
         "feature_id": 633,
-        "source_id": 59,
-        "features_endpoint_feature_id": 1003
+        "source_id": 59
     },
     {
         "feature_type": "Germline Variant",
@@ -24367,8 +23734,7 @@
         "_deprecated": false,
         "assertion_id": 634,
         "feature_id": 634,
-        "source_id": 59,
-        "features_endpoint_feature_id": 1003
+        "source_id": 59
     },
     {
         "feature_type": "Germline Variant",
@@ -24408,8 +23774,7 @@
         "_deprecated": false,
         "assertion_id": 635,
         "feature_id": 635,
-        "source_id": 59,
-        "features_endpoint_feature_id": 1003
+        "source_id": 59
     },
     {
         "feature_type": "Germline Variant",
@@ -24449,8 +23814,7 @@
         "_deprecated": false,
         "assertion_id": 636,
         "feature_id": 636,
-        "source_id": 59,
-        "features_endpoint_feature_id": 1003
+        "source_id": 59
     },
     {
         "feature_type": "Germline Variant",
@@ -24490,8 +23854,7 @@
         "_deprecated": false,
         "assertion_id": 637,
         "feature_id": 637,
-        "source_id": 59,
-        "features_endpoint_feature_id": 1003
+        "source_id": 59
     },
     {
         "feature_type": "Germline Variant",
@@ -24531,8 +23894,7 @@
         "_deprecated": false,
         "assertion_id": 638,
         "feature_id": 638,
-        "source_id": 59,
-        "features_endpoint_feature_id": 1003
+        "source_id": 59
     },
     {
         "feature_type": "Germline Variant",
@@ -24572,8 +23934,7 @@
         "_deprecated": false,
         "assertion_id": 639,
         "feature_id": 639,
-        "source_id": 59,
-        "features_endpoint_feature_id": 1003
+        "source_id": 59
     },
     {
         "feature_type": "Germline Variant",
@@ -24613,8 +23974,7 @@
         "_deprecated": false,
         "assertion_id": 640,
         "feature_id": 640,
-        "source_id": 178,
-        "features_endpoint_feature_id": 1003
+        "source_id": 178
     },
     {
         "feature_type": "Germline Variant",
@@ -24654,8 +24014,7 @@
         "_deprecated": false,
         "assertion_id": 641,
         "feature_id": 641,
-        "source_id": 80,
-        "features_endpoint_feature_id": 1003
+        "source_id": 80
     },
     {
         "feature_type": "Germline Variant",
@@ -24695,8 +24054,7 @@
         "_deprecated": false,
         "assertion_id": 642,
         "feature_id": 642,
-        "source_id": 179,
-        "features_endpoint_feature_id": 1003
+        "source_id": 179
     },
     {
         "feature_type": "Germline Variant",
@@ -24736,8 +24094,7 @@
         "_deprecated": false,
         "assertion_id": 643,
         "feature_id": 643,
-        "source_id": 179,
-        "features_endpoint_feature_id": 1003
+        "source_id": 179
     },
     {
         "feature_type": "Germline Variant",
@@ -24777,8 +24134,7 @@
         "_deprecated": false,
         "assertion_id": 644,
         "feature_id": 644,
-        "source_id": 179,
-        "features_endpoint_feature_id": 1003
+        "source_id": 179
     },
     {
         "feature_type": "Germline Variant",
@@ -24818,8 +24174,7 @@
         "_deprecated": false,
         "assertion_id": 645,
         "feature_id": 645,
-        "source_id": 179,
-        "features_endpoint_feature_id": 1003
+        "source_id": 179
     },
     {
         "feature_type": "Germline Variant",
@@ -24859,8 +24214,7 @@
         "_deprecated": false,
         "assertion_id": 646,
         "feature_id": 646,
-        "source_id": 179,
-        "features_endpoint_feature_id": 1003
+        "source_id": 179
     },
     {
         "feature_type": "Germline Variant",
@@ -24900,8 +24254,7 @@
         "_deprecated": false,
         "assertion_id": 647,
         "feature_id": 647,
-        "source_id": 80,
-        "features_endpoint_feature_id": 1003
+        "source_id": 80
     },
     {
         "feature_type": "Germline Variant",
@@ -24941,8 +24294,7 @@
         "_deprecated": false,
         "assertion_id": 648,
         "feature_id": 648,
-        "source_id": 147,
-        "features_endpoint_feature_id": 1003
+        "source_id": 147
     },
     {
         "feature_type": "Germline Variant",
@@ -24982,8 +24334,7 @@
         "_deprecated": false,
         "assertion_id": 649,
         "feature_id": 649,
-        "source_id": 179,
-        "features_endpoint_feature_id": 1003
+        "source_id": 179
     },
     {
         "feature_type": "Germline Variant",
@@ -25023,8 +24374,7 @@
         "_deprecated": false,
         "assertion_id": 650,
         "feature_id": 650,
-        "source_id": 179,
-        "features_endpoint_feature_id": 1003
+        "source_id": 179
     },
     {
         "feature_type": "Germline Variant",
@@ -25064,8 +24414,7 @@
         "_deprecated": false,
         "assertion_id": 651,
         "feature_id": 651,
-        "source_id": 179,
-        "features_endpoint_feature_id": 1003
+        "source_id": 179
     },
     {
         "feature_type": "Germline Variant",
@@ -25105,8 +24454,7 @@
         "_deprecated": false,
         "assertion_id": 652,
         "feature_id": 652,
-        "source_id": 80,
-        "features_endpoint_feature_id": 1003
+        "source_id": 80
     },
     {
         "feature_type": "Germline Variant",
@@ -25146,8 +24494,7 @@
         "_deprecated": false,
         "assertion_id": 653,
         "feature_id": 653,
-        "source_id": 147,
-        "features_endpoint_feature_id": 1003
+        "source_id": 147
     },
     {
         "feature_type": "Germline Variant",
@@ -25187,8 +24534,7 @@
         "_deprecated": false,
         "assertion_id": 654,
         "feature_id": 654,
-        "source_id": 80,
-        "features_endpoint_feature_id": 1003
+        "source_id": 80
     },
     {
         "feature_type": "Germline Variant",
@@ -25228,8 +24574,7 @@
         "_deprecated": false,
         "assertion_id": 655,
         "feature_id": 655,
-        "source_id": 147,
-        "features_endpoint_feature_id": 1003
+        "source_id": 147
     },
     {
         "feature_type": "Germline Variant",
@@ -25269,8 +24614,7 @@
         "_deprecated": false,
         "assertion_id": 656,
         "feature_id": 656,
-        "source_id": 180,
-        "features_endpoint_feature_id": 1003
+        "source_id": 180
     },
     {
         "feature_type": "Germline Variant",
@@ -25310,8 +24654,7 @@
         "_deprecated": false,
         "assertion_id": 657,
         "feature_id": 657,
-        "source_id": 59,
-        "features_endpoint_feature_id": 1003
+        "source_id": 59
     },
     {
         "feature_type": "Germline Variant",
@@ -25351,8 +24694,7 @@
         "_deprecated": false,
         "assertion_id": 658,
         "feature_id": 658,
-        "source_id": 59,
-        "features_endpoint_feature_id": 1003
+        "source_id": 59
     },
     {
         "feature_type": "Germline Variant",
@@ -25392,8 +24734,7 @@
         "_deprecated": false,
         "assertion_id": 659,
         "feature_id": 659,
-        "source_id": 59,
-        "features_endpoint_feature_id": 1003
+        "source_id": 59
     },
     {
         "feature_type": "Germline Variant",
@@ -25433,8 +24774,7 @@
         "_deprecated": false,
         "assertion_id": 660,
         "feature_id": 660,
-        "source_id": 59,
-        "features_endpoint_feature_id": 1003
+        "source_id": 59
     },
     {
         "feature_type": "Germline Variant",
@@ -25474,8 +24814,7 @@
         "_deprecated": false,
         "assertion_id": 661,
         "feature_id": 661,
-        "source_id": 59,
-        "features_endpoint_feature_id": 1003
+        "source_id": 59
     },
     {
         "feature_type": "Germline Variant",
@@ -25515,8 +24854,7 @@
         "_deprecated": false,
         "assertion_id": 662,
         "feature_id": 662,
-        "source_id": 59,
-        "features_endpoint_feature_id": 1003
+        "source_id": 59
     },
     {
         "feature_type": "Germline Variant",
@@ -25556,8 +24894,7 @@
         "_deprecated": false,
         "assertion_id": 663,
         "feature_id": 663,
-        "source_id": 85,
-        "features_endpoint_feature_id": 1003
+        "source_id": 85
     },
     {
         "feature_type": "Germline Variant",
@@ -25597,8 +24934,7 @@
         "_deprecated": false,
         "assertion_id": 664,
         "feature_id": 664,
-        "source_id": 171,
-        "features_endpoint_feature_id": 1003
+        "source_id": 171
     },
     {
         "feature_type": "Germline Variant",
@@ -25638,8 +24974,7 @@
         "_deprecated": false,
         "assertion_id": 665,
         "feature_id": 665,
-        "source_id": 80,
-        "features_endpoint_feature_id": 1003
+        "source_id": 80
     },
     {
         "feature_type": "Germline Variant",
@@ -25679,8 +25014,7 @@
         "_deprecated": false,
         "assertion_id": 666,
         "feature_id": 666,
-        "source_id": 179,
-        "features_endpoint_feature_id": 1003
+        "source_id": 179
     },
     {
         "feature_type": "Germline Variant",
@@ -25720,8 +25054,7 @@
         "_deprecated": false,
         "assertion_id": 667,
         "feature_id": 667,
-        "source_id": 179,
-        "features_endpoint_feature_id": 1003
+        "source_id": 179
     },
     {
         "feature_type": "Germline Variant",
@@ -25761,8 +25094,7 @@
         "_deprecated": false,
         "assertion_id": 668,
         "feature_id": 668,
-        "source_id": 179,
-        "features_endpoint_feature_id": 1003
+        "source_id": 179
     },
     {
         "feature_type": "Germline Variant",
@@ -25802,8 +25134,7 @@
         "_deprecated": false,
         "assertion_id": 669,
         "feature_id": 669,
-        "source_id": 179,
-        "features_endpoint_feature_id": 1003
+        "source_id": 179
     },
     {
         "feature_type": "Germline Variant",
@@ -25843,8 +25174,7 @@
         "_deprecated": false,
         "assertion_id": 670,
         "feature_id": 670,
-        "source_id": 59,
-        "features_endpoint_feature_id": 1003
+        "source_id": 59
     },
     {
         "feature_type": "Germline Variant",
@@ -25884,8 +25214,7 @@
         "_deprecated": false,
         "assertion_id": 671,
         "feature_id": 671,
-        "source_id": 59,
-        "features_endpoint_feature_id": 1003
+        "source_id": 59
     },
     {
         "feature_type": "Germline Variant",
@@ -25925,8 +25254,7 @@
         "_deprecated": false,
         "assertion_id": 672,
         "feature_id": 672,
-        "source_id": 59,
-        "features_endpoint_feature_id": 1003
+        "source_id": 59
     },
     {
         "feature_type": "Germline Variant",
@@ -25966,8 +25294,7 @@
         "_deprecated": false,
         "assertion_id": 673,
         "feature_id": 673,
-        "source_id": 59,
-        "features_endpoint_feature_id": 1003
+        "source_id": 59
     },
     {
         "feature_type": "Germline Variant",
@@ -26007,8 +25334,7 @@
         "_deprecated": false,
         "assertion_id": 674,
         "feature_id": 674,
-        "source_id": 59,
-        "features_endpoint_feature_id": 1003
+        "source_id": 59
     },
     {
         "feature_type": "Germline Variant",
@@ -26048,8 +25374,7 @@
         "_deprecated": false,
         "assertion_id": 675,
         "feature_id": 675,
-        "source_id": 59,
-        "features_endpoint_feature_id": 1003
+        "source_id": 59
     },
     {
         "feature_type": "Germline Variant",
@@ -26089,8 +25414,7 @@
         "_deprecated": false,
         "assertion_id": 676,
         "feature_id": 676,
-        "source_id": 59,
-        "features_endpoint_feature_id": 1003
+        "source_id": 59
     },
     {
         "feature_type": "Germline Variant",
@@ -26130,8 +25454,7 @@
         "_deprecated": false,
         "assertion_id": 677,
         "feature_id": 677,
-        "source_id": 59,
-        "features_endpoint_feature_id": 1003
+        "source_id": 59
     },
     {
         "feature_type": "Germline Variant",
@@ -26171,8 +25494,7 @@
         "_deprecated": false,
         "assertion_id": 678,
         "feature_id": 678,
-        "source_id": 59,
-        "features_endpoint_feature_id": 1003
+        "source_id": 59
     },
     {
         "feature_type": "Germline Variant",
@@ -26212,8 +25534,7 @@
         "_deprecated": false,
         "assertion_id": 679,
         "feature_id": 679,
-        "source_id": 59,
-        "features_endpoint_feature_id": 1003
+        "source_id": 59
     },
     {
         "feature_type": "Germline Variant",
@@ -26253,8 +25574,7 @@
         "_deprecated": false,
         "assertion_id": 680,
         "feature_id": 680,
-        "source_id": 59,
-        "features_endpoint_feature_id": 1003
+        "source_id": 59
     },
     {
         "feature_type": "Germline Variant",
@@ -26294,8 +25614,7 @@
         "_deprecated": false,
         "assertion_id": 681,
         "feature_id": 681,
-        "source_id": 59,
-        "features_endpoint_feature_id": 1003
+        "source_id": 59
     },
     {
         "feature_type": "Germline Variant",
@@ -26335,8 +25654,7 @@
         "_deprecated": false,
         "assertion_id": 682,
         "feature_id": 682,
-        "source_id": 180,
-        "features_endpoint_feature_id": 1003
+        "source_id": 180
     },
     {
         "feature_type": "Germline Variant",
@@ -26376,8 +25694,7 @@
         "_deprecated": false,
         "assertion_id": 683,
         "feature_id": 683,
-        "source_id": 180,
-        "features_endpoint_feature_id": 1003
+        "source_id": 180
     },
     {
         "feature_type": "Copy Number",
@@ -26407,8 +25724,7 @@
         "_deprecated": false,
         "assertion_id": 684,
         "feature_id": 684,
-        "source_id": 181,
-        "features_endpoint_feature_id": 1003
+        "source_id": 181
     },
     {
         "feature_type": "Copy Number",
@@ -26438,8 +25754,7 @@
         "_deprecated": false,
         "assertion_id": 685,
         "feature_id": 685,
-        "source_id": 181,
-        "features_endpoint_feature_id": 1003
+        "source_id": 181
     },
     {
         "feature_type": "Copy Number",
@@ -26469,8 +25784,7 @@
         "_deprecated": false,
         "assertion_id": 686,
         "feature_id": 686,
-        "source_id": 181,
-        "features_endpoint_feature_id": 1003
+        "source_id": 181
     },
     {
         "feature_type": "Copy Number",
@@ -26500,8 +25814,7 @@
         "_deprecated": false,
         "assertion_id": 687,
         "feature_id": 687,
-        "source_id": 182,
-        "features_endpoint_feature_id": 1003
+        "source_id": 182
     },
     {
         "feature_type": "Copy Number",
@@ -26531,8 +25844,7 @@
         "_deprecated": false,
         "assertion_id": 688,
         "feature_id": 688,
-        "source_id": 53,
-        "features_endpoint_feature_id": 1003
+        "source_id": 53
     },
     {
         "feature_type": "Copy Number",
@@ -26562,8 +25874,7 @@
         "_deprecated": false,
         "assertion_id": 689,
         "feature_id": 689,
-        "source_id": 183,
-        "features_endpoint_feature_id": 1003
+        "source_id": 183
     },
     {
         "feature_type": "Copy Number",
@@ -26593,8 +25904,7 @@
         "_deprecated": false,
         "assertion_id": 690,
         "feature_id": 690,
-        "source_id": 184,
-        "features_endpoint_feature_id": 1003
+        "source_id": 184
     },
     {
         "feature_type": "Copy Number",
@@ -26624,8 +25934,7 @@
         "_deprecated": false,
         "assertion_id": 691,
         "feature_id": 691,
-        "source_id": 185,
-        "features_endpoint_feature_id": 1003
+        "source_id": 185
     },
     {
         "feature_type": "Copy Number",
@@ -26655,8 +25964,7 @@
         "_deprecated": false,
         "assertion_id": 692,
         "feature_id": 692,
-        "source_id": 186,
-        "features_endpoint_feature_id": 1003
+        "source_id": 186
     },
     {
         "feature_type": "Copy Number",
@@ -26686,8 +25994,7 @@
         "_deprecated": false,
         "assertion_id": 693,
         "feature_id": 693,
-        "source_id": 78,
-        "features_endpoint_feature_id": 1003
+        "source_id": 78
     },
     {
         "feature_type": "Copy Number",
@@ -26717,8 +26024,7 @@
         "_deprecated": false,
         "assertion_id": 694,
         "feature_id": 694,
-        "source_id": 88,
-        "features_endpoint_feature_id": 1003
+        "source_id": 88
     },
     {
         "feature_type": "Copy Number",
@@ -26748,8 +26054,7 @@
         "_deprecated": false,
         "assertion_id": 695,
         "feature_id": 695,
-        "source_id": 187,
-        "features_endpoint_feature_id": 1003
+        "source_id": 187
     },
     {
         "feature_type": "Copy Number",
@@ -26779,8 +26084,7 @@
         "_deprecated": false,
         "assertion_id": 696,
         "feature_id": 696,
-        "source_id": 54,
-        "features_endpoint_feature_id": 1003
+        "source_id": 54
     },
     {
         "feature_type": "Copy Number",
@@ -26810,8 +26114,7 @@
         "_deprecated": false,
         "assertion_id": 697,
         "feature_id": 697,
-        "source_id": 188,
-        "features_endpoint_feature_id": 1003
+        "source_id": 188
     },
     {
         "feature_type": "Copy Number",
@@ -26841,8 +26144,7 @@
         "_deprecated": false,
         "assertion_id": 698,
         "feature_id": 698,
-        "source_id": 189,
-        "features_endpoint_feature_id": 1003
+        "source_id": 189
     },
     {
         "feature_type": "Copy Number",
@@ -26872,8 +26174,7 @@
         "_deprecated": false,
         "assertion_id": 699,
         "feature_id": 699,
-        "source_id": 190,
-        "features_endpoint_feature_id": 1003
+        "source_id": 190
     },
     {
         "feature_type": "Copy Number",
@@ -26903,8 +26204,7 @@
         "_deprecated": false,
         "assertion_id": 700,
         "feature_id": 700,
-        "source_id": 191,
-        "features_endpoint_feature_id": 1003
+        "source_id": 191
     },
     {
         "feature_type": "Copy Number",
@@ -26934,8 +26234,7 @@
         "_deprecated": false,
         "assertion_id": 701,
         "feature_id": 701,
-        "source_id": 192,
-        "features_endpoint_feature_id": 1003
+        "source_id": 192
     },
     {
         "feature_type": "Copy Number",
@@ -26965,8 +26264,7 @@
         "_deprecated": false,
         "assertion_id": 702,
         "feature_id": 702,
-        "source_id": 192,
-        "features_endpoint_feature_id": 1003
+        "source_id": 192
     },
     {
         "feature_type": "Copy Number",
@@ -26996,8 +26294,7 @@
         "_deprecated": false,
         "assertion_id": 703,
         "feature_id": 703,
-        "source_id": 193,
-        "features_endpoint_feature_id": 1003
+        "source_id": 193
     },
     {
         "feature_type": "Copy Number",
@@ -27027,8 +26324,7 @@
         "_deprecated": false,
         "assertion_id": 704,
         "feature_id": 704,
-        "source_id": 194,
-        "features_endpoint_feature_id": 1003
+        "source_id": 194
     },
     {
         "feature_type": "Copy Number",
@@ -27058,8 +26354,7 @@
         "_deprecated": false,
         "assertion_id": 705,
         "feature_id": 705,
-        "source_id": 194,
-        "features_endpoint_feature_id": 1003
+        "source_id": 194
     },
     {
         "feature_type": "Copy Number",
@@ -27089,8 +26384,7 @@
         "_deprecated": false,
         "assertion_id": 706,
         "feature_id": 706,
-        "source_id": 195,
-        "features_endpoint_feature_id": 1003
+        "source_id": 195
     },
     {
         "feature_type": "Copy Number",
@@ -27120,8 +26414,7 @@
         "_deprecated": false,
         "assertion_id": 707,
         "feature_id": 707,
-        "source_id": 54,
-        "features_endpoint_feature_id": 1003
+        "source_id": 54
     },
     {
         "feature_type": "Copy Number",
@@ -27151,8 +26444,7 @@
         "_deprecated": false,
         "assertion_id": 708,
         "feature_id": 708,
-        "source_id": 196,
-        "features_endpoint_feature_id": 1003
+        "source_id": 196
     },
     {
         "feature_type": "Copy Number",
@@ -27182,8 +26474,7 @@
         "_deprecated": false,
         "assertion_id": 709,
         "feature_id": 709,
-        "source_id": 54,
-        "features_endpoint_feature_id": 1003
+        "source_id": 54
     },
     {
         "feature_type": "Copy Number",
@@ -27213,8 +26504,7 @@
         "_deprecated": false,
         "assertion_id": 710,
         "feature_id": 710,
-        "source_id": 197,
-        "features_endpoint_feature_id": 1003
+        "source_id": 197
     },
     {
         "feature_type": "Copy Number",
@@ -27244,8 +26534,7 @@
         "_deprecated": false,
         "assertion_id": 711,
         "feature_id": 711,
-        "source_id": 16,
-        "features_endpoint_feature_id": 1003
+        "source_id": 16
     },
     {
         "feature_type": "Copy Number",
@@ -27275,8 +26564,7 @@
         "_deprecated": false,
         "assertion_id": 712,
         "feature_id": 712,
-        "source_id": 198,
-        "features_endpoint_feature_id": 1003
+        "source_id": 198
     },
     {
         "feature_type": "Copy Number",
@@ -27306,8 +26594,7 @@
         "_deprecated": false,
         "assertion_id": 713,
         "feature_id": 713,
-        "source_id": 96,
-        "features_endpoint_feature_id": 1003
+        "source_id": 96
     },
     {
         "feature_type": "Copy Number",
@@ -27337,8 +26624,7 @@
         "_deprecated": false,
         "assertion_id": 714,
         "feature_id": 714,
-        "source_id": 199,
-        "features_endpoint_feature_id": 1003
+        "source_id": 199
     },
     {
         "feature_type": "Copy Number",
@@ -27368,8 +26654,7 @@
         "_deprecated": false,
         "assertion_id": 715,
         "feature_id": 715,
-        "source_id": 200,
-        "features_endpoint_feature_id": 1003
+        "source_id": 200
     },
     {
         "feature_type": "Copy Number",
@@ -27399,8 +26684,7 @@
         "_deprecated": false,
         "assertion_id": 716,
         "feature_id": 716,
-        "source_id": 201,
-        "features_endpoint_feature_id": 1003
+        "source_id": 201
     },
     {
         "feature_type": "Copy Number",
@@ -27430,8 +26714,7 @@
         "_deprecated": false,
         "assertion_id": 717,
         "feature_id": 717,
-        "source_id": 201,
-        "features_endpoint_feature_id": 1003
+        "source_id": 201
     },
     {
         "feature_type": "Copy Number",
@@ -27461,8 +26744,7 @@
         "_deprecated": false,
         "assertion_id": 718,
         "feature_id": 718,
-        "source_id": 202,
-        "features_endpoint_feature_id": 1003
+        "source_id": 202
     },
     {
         "feature_type": "Copy Number",
@@ -27492,8 +26774,7 @@
         "_deprecated": false,
         "assertion_id": 719,
         "feature_id": 719,
-        "source_id": 203,
-        "features_endpoint_feature_id": 1003
+        "source_id": 203
     },
     {
         "feature_type": "Copy Number",
@@ -27523,8 +26804,7 @@
         "_deprecated": false,
         "assertion_id": 720,
         "feature_id": 720,
-        "source_id": 204,
-        "features_endpoint_feature_id": 1003
+        "source_id": 204
     },
     {
         "feature_type": "Copy Number",
@@ -27554,8 +26834,7 @@
         "_deprecated": false,
         "assertion_id": 721,
         "feature_id": 721,
-        "source_id": 204,
-        "features_endpoint_feature_id": 1003
+        "source_id": 204
     },
     {
         "feature_type": "Copy Number",
@@ -27585,8 +26864,7 @@
         "_deprecated": false,
         "assertion_id": 722,
         "feature_id": 722,
-        "source_id": 204,
-        "features_endpoint_feature_id": 1003
+        "source_id": 204
     },
     {
         "feature_type": "Copy Number",
@@ -27616,8 +26894,7 @@
         "_deprecated": false,
         "assertion_id": 723,
         "feature_id": 723,
-        "source_id": 205,
-        "features_endpoint_feature_id": 1003
+        "source_id": 205
     },
     {
         "feature_type": "Copy Number",
@@ -27647,8 +26924,7 @@
         "_deprecated": false,
         "assertion_id": 724,
         "feature_id": 724,
-        "source_id": 206,
-        "features_endpoint_feature_id": 1003
+        "source_id": 206
     },
     {
         "feature_type": "Copy Number",
@@ -27678,8 +26954,7 @@
         "_deprecated": false,
         "assertion_id": 725,
         "feature_id": 725,
-        "source_id": 207,
-        "features_endpoint_feature_id": 1003
+        "source_id": 207
     },
     {
         "feature_type": "Copy Number",
@@ -27709,8 +26984,7 @@
         "_deprecated": false,
         "assertion_id": 726,
         "feature_id": 726,
-        "source_id": 208,
-        "features_endpoint_feature_id": 1003
+        "source_id": 208
     },
     {
         "feature_type": "Copy Number",
@@ -27740,8 +27014,7 @@
         "_deprecated": false,
         "assertion_id": 727,
         "feature_id": 727,
-        "source_id": 209,
-        "features_endpoint_feature_id": 1003
+        "source_id": 209
     },
     {
         "feature_type": "Copy Number",
@@ -27771,8 +27044,7 @@
         "_deprecated": false,
         "assertion_id": 728,
         "feature_id": 728,
-        "source_id": 209,
-        "features_endpoint_feature_id": 1003
+        "source_id": 209
     },
     {
         "feature_type": "Copy Number",
@@ -27802,8 +27074,7 @@
         "_deprecated": false,
         "assertion_id": 729,
         "feature_id": 729,
-        "source_id": 210,
-        "features_endpoint_feature_id": 1003
+        "source_id": 210
     },
     {
         "feature_type": "Copy Number",
@@ -27833,8 +27104,7 @@
         "_deprecated": false,
         "assertion_id": 730,
         "feature_id": 730,
-        "source_id": 211,
-        "features_endpoint_feature_id": 1003
+        "source_id": 211
     },
     {
         "feature_type": "Copy Number",
@@ -27864,8 +27134,7 @@
         "_deprecated": false,
         "assertion_id": 731,
         "feature_id": 731,
-        "source_id": 211,
-        "features_endpoint_feature_id": 1003
+        "source_id": 211
     },
     {
         "feature_type": "Copy Number",
@@ -27895,8 +27164,7 @@
         "_deprecated": false,
         "assertion_id": 732,
         "feature_id": 732,
-        "source_id": 212,
-        "features_endpoint_feature_id": 1003
+        "source_id": 212
     },
     {
         "feature_type": "Copy Number",
@@ -27926,8 +27194,7 @@
         "_deprecated": false,
         "assertion_id": 733,
         "feature_id": 733,
-        "source_id": 109,
-        "features_endpoint_feature_id": 1003
+        "source_id": 109
     },
     {
         "feature_type": "Copy Number",
@@ -27957,8 +27224,7 @@
         "_deprecated": false,
         "assertion_id": 734,
         "feature_id": 734,
-        "source_id": 213,
-        "features_endpoint_feature_id": 1003
+        "source_id": 213
     },
     {
         "feature_type": "Copy Number",
@@ -27988,8 +27254,7 @@
         "_deprecated": false,
         "assertion_id": 735,
         "feature_id": 735,
-        "source_id": 213,
-        "features_endpoint_feature_id": 1003
+        "source_id": 213
     },
     {
         "feature_type": "Copy Number",
@@ -28019,8 +27284,7 @@
         "_deprecated": false,
         "assertion_id": 736,
         "feature_id": 736,
-        "source_id": 213,
-        "features_endpoint_feature_id": 1003
+        "source_id": 213
     },
     {
         "feature_type": "Copy Number",
@@ -28050,8 +27314,7 @@
         "_deprecated": false,
         "assertion_id": 737,
         "feature_id": 737,
-        "source_id": 213,
-        "features_endpoint_feature_id": 1003
+        "source_id": 213
     },
     {
         "feature_type": "Copy Number",
@@ -28081,8 +27344,7 @@
         "_deprecated": false,
         "assertion_id": 738,
         "feature_id": 738,
-        "source_id": 213,
-        "features_endpoint_feature_id": 1003
+        "source_id": 213
     },
     {
         "feature_type": "Copy Number",
@@ -28112,8 +27374,7 @@
         "_deprecated": false,
         "assertion_id": 739,
         "feature_id": 739,
-        "source_id": 213,
-        "features_endpoint_feature_id": 1003
+        "source_id": 213
     },
     {
         "feature_type": "Copy Number",
@@ -28143,8 +27404,7 @@
         "_deprecated": false,
         "assertion_id": 740,
         "feature_id": 740,
-        "source_id": 213,
-        "features_endpoint_feature_id": 1003
+        "source_id": 213
     },
     {
         "feature_type": "Copy Number",
@@ -28174,8 +27434,7 @@
         "_deprecated": false,
         "assertion_id": 741,
         "feature_id": 741,
-        "source_id": 213,
-        "features_endpoint_feature_id": 1003
+        "source_id": 213
     },
     {
         "feature_type": "Copy Number",
@@ -28205,8 +27464,7 @@
         "_deprecated": false,
         "assertion_id": 742,
         "feature_id": 742,
-        "source_id": 214,
-        "features_endpoint_feature_id": 1003
+        "source_id": 214
     },
     {
         "feature_type": "Copy Number",
@@ -28236,8 +27494,7 @@
         "_deprecated": false,
         "assertion_id": 743,
         "feature_id": 743,
-        "source_id": 215,
-        "features_endpoint_feature_id": 1003
+        "source_id": 215
     },
     {
         "feature_type": "Copy Number",
@@ -28267,8 +27524,7 @@
         "_deprecated": false,
         "assertion_id": 744,
         "feature_id": 744,
-        "source_id": 126,
-        "features_endpoint_feature_id": 1003
+        "source_id": 126
     },
     {
         "feature_type": "Copy Number",
@@ -28298,8 +27554,7 @@
         "_deprecated": false,
         "assertion_id": 745,
         "feature_id": 745,
-        "source_id": 168,
-        "features_endpoint_feature_id": 1003
+        "source_id": 168
     },
     {
         "feature_type": "Copy Number",
@@ -28329,8 +27584,7 @@
         "_deprecated": false,
         "assertion_id": 746,
         "feature_id": 746,
-        "source_id": 11,
-        "features_endpoint_feature_id": 1003
+        "source_id": 11
     },
     {
         "feature_type": "Copy Number",
@@ -28360,8 +27614,7 @@
         "_deprecated": false,
         "assertion_id": 747,
         "feature_id": 747,
-        "source_id": 20,
-        "features_endpoint_feature_id": 1003
+        "source_id": 20
     },
     {
         "feature_type": "Copy Number",
@@ -28391,8 +27644,7 @@
         "_deprecated": false,
         "assertion_id": 748,
         "feature_id": 748,
-        "source_id": 216,
-        "features_endpoint_feature_id": 1003
+        "source_id": 216
     },
     {
         "feature_type": "Copy Number",
@@ -28422,8 +27674,7 @@
         "_deprecated": false,
         "assertion_id": 749,
         "feature_id": 749,
-        "source_id": 217,
-        "features_endpoint_feature_id": 1003
+        "source_id": 217
     },
     {
         "feature_type": "Copy Number",
@@ -28453,8 +27704,7 @@
         "_deprecated": false,
         "assertion_id": 750,
         "feature_id": 750,
-        "source_id": 218,
-        "features_endpoint_feature_id": 1003
+        "source_id": 218
     },
     {
         "feature_type": "Copy Number",
@@ -28484,8 +27734,7 @@
         "_deprecated": false,
         "assertion_id": 751,
         "feature_id": 751,
-        "source_id": 218,
-        "features_endpoint_feature_id": 1003
+        "source_id": 218
     },
     {
         "feature_type": "Copy Number",
@@ -28515,8 +27764,7 @@
         "_deprecated": false,
         "assertion_id": 752,
         "feature_id": 752,
-        "source_id": 219,
-        "features_endpoint_feature_id": 1003
+        "source_id": 219
     },
     {
         "feature_type": "Copy Number",
@@ -28546,8 +27794,7 @@
         "_deprecated": false,
         "assertion_id": 753,
         "feature_id": 753,
-        "source_id": 220,
-        "features_endpoint_feature_id": 1003
+        "source_id": 220
     },
     {
         "feature_type": "Copy Number",
@@ -28577,8 +27824,7 @@
         "_deprecated": false,
         "assertion_id": 754,
         "feature_id": 754,
-        "source_id": 54,
-        "features_endpoint_feature_id": 1003
+        "source_id": 54
     },
     {
         "feature_type": "Copy Number",
@@ -28608,8 +27854,7 @@
         "_deprecated": false,
         "assertion_id": 755,
         "feature_id": 755,
-        "source_id": 187,
-        "features_endpoint_feature_id": 1003
+        "source_id": 187
     },
     {
         "feature_type": "Copy Number",
@@ -28639,8 +27884,7 @@
         "_deprecated": false,
         "assertion_id": 756,
         "feature_id": 756,
-        "source_id": 187,
-        "features_endpoint_feature_id": 1003
+        "source_id": 187
     },
     {
         "feature_type": "Copy Number",
@@ -28670,8 +27914,7 @@
         "_deprecated": false,
         "assertion_id": 757,
         "feature_id": 757,
-        "source_id": 153,
-        "features_endpoint_feature_id": 1003
+        "source_id": 153
     },
     {
         "feature_type": "Copy Number",
@@ -28701,8 +27944,7 @@
         "_deprecated": false,
         "assertion_id": 758,
         "feature_id": 758,
-        "source_id": 221,
-        "features_endpoint_feature_id": 1003
+        "source_id": 221
     },
     {
         "feature_type": "Copy Number",
@@ -28732,8 +27974,7 @@
         "_deprecated": false,
         "assertion_id": 759,
         "feature_id": 759,
-        "source_id": 158,
-        "features_endpoint_feature_id": 1003
+        "source_id": 158
     },
     {
         "feature_type": "Copy Number",
@@ -28763,8 +28004,7 @@
         "_deprecated": false,
         "assertion_id": 760,
         "feature_id": 760,
-        "source_id": 159,
-        "features_endpoint_feature_id": 1003
+        "source_id": 159
     },
     {
         "feature_type": "Copy Number",
@@ -28794,8 +28034,7 @@
         "_deprecated": false,
         "assertion_id": 761,
         "feature_id": 761,
-        "source_id": 222,
-        "features_endpoint_feature_id": 1003
+        "source_id": 222
     },
     {
         "feature_type": "Copy Number",
@@ -28825,8 +28064,7 @@
         "_deprecated": false,
         "assertion_id": 762,
         "feature_id": 762,
-        "source_id": 160,
-        "features_endpoint_feature_id": 1003
+        "source_id": 160
     },
     {
         "feature_type": "Copy Number",
@@ -28856,8 +28094,7 @@
         "_deprecated": false,
         "assertion_id": 763,
         "feature_id": 763,
-        "source_id": 149,
-        "features_endpoint_feature_id": 1003
+        "source_id": 149
     },
     {
         "feature_type": "Copy Number",
@@ -28887,8 +28124,7 @@
         "_deprecated": false,
         "assertion_id": 764,
         "feature_id": 764,
-        "source_id": 149,
-        "features_endpoint_feature_id": 1003
+        "source_id": 149
     },
     {
         "feature_type": "Copy Number",
@@ -28918,8 +28154,7 @@
         "_deprecated": false,
         "assertion_id": 765,
         "feature_id": 765,
-        "source_id": 28,
-        "features_endpoint_feature_id": 1003
+        "source_id": 28
     },
     {
         "feature_type": "Copy Number",
@@ -28949,8 +28184,7 @@
         "_deprecated": false,
         "assertion_id": 766,
         "feature_id": 766,
-        "source_id": 28,
-        "features_endpoint_feature_id": 1003
+        "source_id": 28
     },
     {
         "feature_type": "Copy Number",
@@ -28980,8 +28214,7 @@
         "_deprecated": false,
         "assertion_id": 767,
         "feature_id": 767,
-        "source_id": 184,
-        "features_endpoint_feature_id": 1003
+        "source_id": 184
     },
     {
         "feature_type": "Microsatellite Stability",
@@ -29009,8 +28242,7 @@
         "_deprecated": false,
         "assertion_id": 768,
         "feature_id": 768,
-        "source_id": 223,
-        "features_endpoint_feature_id": 1003
+        "source_id": 223
     },
     {
         "feature_type": "Microsatellite Stability",
@@ -29038,8 +28270,7 @@
         "_deprecated": false,
         "assertion_id": 769,
         "feature_id": 769,
-        "source_id": 223,
-        "features_endpoint_feature_id": 1003
+        "source_id": 223
     },
     {
         "feature_type": "Microsatellite Stability",
@@ -29067,8 +28298,7 @@
         "_deprecated": false,
         "assertion_id": 770,
         "feature_id": 770,
-        "source_id": 80,
-        "features_endpoint_feature_id": 1003
+        "source_id": 80
     },
     {
         "feature_type": "Microsatellite Stability",
@@ -29096,8 +28326,7 @@
         "_deprecated": false,
         "assertion_id": 771,
         "feature_id": 771,
-        "source_id": 80,
-        "features_endpoint_feature_id": 1003
+        "source_id": 80
     },
     {
         "feature_type": "Microsatellite Stability",
@@ -29125,8 +28354,7 @@
         "_deprecated": false,
         "assertion_id": 772,
         "feature_id": 772,
-        "source_id": 80,
-        "features_endpoint_feature_id": 1003
+        "source_id": 80
     },
     {
         "feature_type": "Microsatellite Stability",
@@ -29154,8 +28382,7 @@
         "_deprecated": false,
         "assertion_id": 773,
         "feature_id": 773,
-        "source_id": 147,
-        "features_endpoint_feature_id": 1003
+        "source_id": 147
     },
     {
         "feature_type": "Mutational Signature",
@@ -29183,8 +28410,7 @@
         "_deprecated": false,
         "assertion_id": 774,
         "feature_id": 774,
-        "source_id": 147,
-        "features_endpoint_feature_id": 1003
+        "source_id": 147
     },
     {
         "feature_type": "Mutational Signature",
@@ -29212,8 +28438,7 @@
         "_deprecated": false,
         "assertion_id": 775,
         "feature_id": 775,
-        "source_id": 147,
-        "features_endpoint_feature_id": 1003
+        "source_id": 147
     },
     {
         "feature_type": "Mutational Signature",
@@ -29241,8 +28466,7 @@
         "_deprecated": false,
         "assertion_id": 776,
         "feature_id": 776,
-        "source_id": 157,
-        "features_endpoint_feature_id": 1003
+        "source_id": 157
     },
     {
         "feature_type": "Mutational Signature",
@@ -29270,8 +28494,7 @@
         "_deprecated": false,
         "assertion_id": 777,
         "feature_id": 777,
-        "source_id": 157,
-        "features_endpoint_feature_id": 1003
+        "source_id": 157
     },
     {
         "feature_type": "Mutational Signature",
@@ -29299,8 +28522,7 @@
         "_deprecated": false,
         "assertion_id": 778,
         "feature_id": 778,
-        "source_id": 157,
-        "features_endpoint_feature_id": 1003
+        "source_id": 157
     },
     {
         "feature_type": "Mutational Signature",
@@ -29328,8 +28550,7 @@
         "_deprecated": false,
         "assertion_id": 779,
         "feature_id": 779,
-        "source_id": 157,
-        "features_endpoint_feature_id": 1003
+        "source_id": 157
     },
     {
         "feature_type": "Mutational Signature",
@@ -29357,8 +28578,7 @@
         "_deprecated": false,
         "assertion_id": 780,
         "feature_id": 780,
-        "source_id": 224,
-        "features_endpoint_feature_id": 1003
+        "source_id": 224
     },
     {
         "feature_type": "Mutational Signature",
@@ -29386,8 +28606,7 @@
         "_deprecated": false,
         "assertion_id": 781,
         "feature_id": 781,
-        "source_id": 224,
-        "features_endpoint_feature_id": 1003
+        "source_id": 224
     },
     {
         "feature_type": "Mutational Signature",
@@ -29415,8 +28634,7 @@
         "_deprecated": false,
         "assertion_id": 782,
         "feature_id": 782,
-        "source_id": 225,
-        "features_endpoint_feature_id": 1003
+        "source_id": 225
     },
     {
         "feature_type": "Mutational Signature",
@@ -29444,8 +28662,7 @@
         "_deprecated": false,
         "assertion_id": 783,
         "feature_id": 783,
-        "source_id": 225,
-        "features_endpoint_feature_id": 1003
+        "source_id": 225
     },
     {
         "feature_type": "Mutational Signature",
@@ -29473,8 +28690,7 @@
         "_deprecated": false,
         "assertion_id": 784,
         "feature_id": 784,
-        "source_id": 225,
-        "features_endpoint_feature_id": 1003
+        "source_id": 225
     },
     {
         "feature_type": "Mutational Signature",
@@ -29502,8 +28718,7 @@
         "_deprecated": false,
         "assertion_id": 785,
         "feature_id": 785,
-        "source_id": 225,
-        "features_endpoint_feature_id": 1003
+        "source_id": 225
     },
     {
         "feature_type": "Mutational Signature",
@@ -29531,8 +28746,7 @@
         "_deprecated": false,
         "assertion_id": 786,
         "feature_id": 786,
-        "source_id": 225,
-        "features_endpoint_feature_id": 1003
+        "source_id": 225
     },
     {
         "feature_type": "Mutational Signature",
@@ -29560,8 +28774,7 @@
         "_deprecated": false,
         "assertion_id": 787,
         "feature_id": 787,
-        "source_id": 85,
-        "features_endpoint_feature_id": 1003
+        "source_id": 85
     },
     {
         "feature_type": "Mutational Signature",
@@ -29589,8 +28802,7 @@
         "_deprecated": false,
         "assertion_id": 788,
         "feature_id": 788,
-        "source_id": 136,
-        "features_endpoint_feature_id": 1003
+        "source_id": 136
     },
     {
         "feature_type": "Mutational Signature",
@@ -29618,8 +28830,7 @@
         "_deprecated": false,
         "assertion_id": 789,
         "feature_id": 789,
-        "source_id": 136,
-        "features_endpoint_feature_id": 1003
+        "source_id": 136
     },
     {
         "feature_type": "Mutational Signature",
@@ -29647,8 +28858,7 @@
         "_deprecated": false,
         "assertion_id": 790,
         "feature_id": 790,
-        "source_id": 226,
-        "features_endpoint_feature_id": 1003
+        "source_id": 226
     },
     {
         "feature_type": "Mutational Signature",
@@ -29676,8 +28886,7 @@
         "_deprecated": false,
         "assertion_id": 791,
         "feature_id": 791,
-        "source_id": 87,
-        "features_endpoint_feature_id": 1003
+        "source_id": 87
     },
     {
         "feature_type": "Mutational Signature",
@@ -29705,8 +28914,7 @@
         "_deprecated": false,
         "assertion_id": 792,
         "feature_id": 792,
-        "source_id": 87,
-        "features_endpoint_feature_id": 1003
+        "source_id": 87
     },
     {
         "feature_type": "Mutational Signature",
@@ -29734,8 +28942,7 @@
         "_deprecated": false,
         "assertion_id": 793,
         "feature_id": 793,
-        "source_id": 87,
-        "features_endpoint_feature_id": 1003
+        "source_id": 87
     },
     {
         "feature_type": "Mutational Burden",
@@ -29765,8 +28972,7 @@
         "_deprecated": false,
         "assertion_id": 794,
         "feature_id": 794,
-        "source_id": 11,
-        "features_endpoint_feature_id": 1003
+        "source_id": 11
     },
     {
         "feature_type": "Mutational Burden",
@@ -29796,8 +29002,7 @@
         "_deprecated": false,
         "assertion_id": 795,
         "feature_id": 795,
-        "source_id": 11,
-        "features_endpoint_feature_id": 1003
+        "source_id": 11
     },
     {
         "feature_type": "Mutational Burden",
@@ -29827,8 +29032,7 @@
         "_deprecated": false,
         "assertion_id": 796,
         "feature_id": 796,
-        "source_id": 136,
-        "features_endpoint_feature_id": 1003
+        "source_id": 136
     },
     {
         "feature_type": "Mutational Burden",
@@ -29858,8 +29062,7 @@
         "_deprecated": false,
         "assertion_id": 797,
         "feature_id": 797,
-        "source_id": 227,
-        "features_endpoint_feature_id": 1003
+        "source_id": 227
     },
     {
         "feature_type": "Mutational Burden",
@@ -29889,8 +29092,7 @@
         "_deprecated": false,
         "assertion_id": 798,
         "feature_id": 798,
-        "source_id": 228,
-        "features_endpoint_feature_id": 1003
+        "source_id": 228
     },
     {
         "feature_type": "Mutational Burden",
@@ -29920,8 +29122,7 @@
         "_deprecated": false,
         "assertion_id": 799,
         "feature_id": 799,
-        "source_id": 223,
-        "features_endpoint_feature_id": 1003
+        "source_id": 223
     },
     {
         "feature_type": "Knockdown",
@@ -29950,8 +29151,7 @@
         "_deprecated": false,
         "assertion_id": 800,
         "feature_id": 800,
-        "source_id": 57,
-        "features_endpoint_feature_id": 1003
+        "source_id": 57
     },
     {
         "feature_type": "Knockdown",
@@ -29980,8 +29180,7 @@
         "_deprecated": false,
         "assertion_id": 801,
         "feature_id": 801,
-        "source_id": 229,
-        "features_endpoint_feature_id": 1003
+        "source_id": 229
     },
     {
         "feature_type": "Knockdown",
@@ -30010,8 +29209,7 @@
         "_deprecated": false,
         "assertion_id": 802,
         "feature_id": 802,
-        "source_id": 230,
-        "features_endpoint_feature_id": 1003
+        "source_id": 230
     },
     {
         "feature_type": "Knockdown",
@@ -30040,8 +29238,7 @@
         "_deprecated": false,
         "assertion_id": 803,
         "feature_id": 803,
-        "source_id": 231,
-        "features_endpoint_feature_id": 1003
+        "source_id": 231
     },
     {
         "feature_type": "Knockdown",
@@ -30070,8 +29267,7 @@
         "_deprecated": false,
         "assertion_id": 804,
         "feature_id": 804,
-        "source_id": 232,
-        "features_endpoint_feature_id": 1003
+        "source_id": 232
     },
     {
         "feature_type": "Knockdown",
@@ -30100,8 +29296,7 @@
         "_deprecated": false,
         "assertion_id": 805,
         "feature_id": 805,
-        "source_id": 233,
-        "features_endpoint_feature_id": 1003
+        "source_id": 233
     },
     {
         "feature_type": "Knockdown",
@@ -30130,8 +29325,7 @@
         "_deprecated": false,
         "assertion_id": 806,
         "feature_id": 806,
-        "source_id": 233,
-        "features_endpoint_feature_id": 1003
+        "source_id": 233
     },
     {
         "feature_type": "Knockdown",
@@ -30160,8 +29354,7 @@
         "_deprecated": false,
         "assertion_id": 807,
         "feature_id": 807,
-        "source_id": 233,
-        "features_endpoint_feature_id": 1003
+        "source_id": 233
     },
     {
         "feature_type": "Knockdown",
@@ -30190,8 +29383,7 @@
         "_deprecated": false,
         "assertion_id": 808,
         "feature_id": 808,
-        "source_id": 229,
-        "features_endpoint_feature_id": 1003
+        "source_id": 229
     },
     {
         "feature_type": "Knockdown",
@@ -30220,8 +29412,7 @@
         "_deprecated": false,
         "assertion_id": 809,
         "feature_id": 809,
-        "source_id": 234,
-        "features_endpoint_feature_id": 1003
+        "source_id": 234
     },
     {
         "feature_type": "Aneuploidy",
@@ -30249,8 +29440,7 @@
         "_deprecated": false,
         "assertion_id": 810,
         "feature_id": 810,
-        "source_id": 235,
-        "features_endpoint_feature_id": 1003
+        "source_id": 235
     },
     {
         "feature_type": "Somatic Variant",
@@ -30288,8 +29478,7 @@
         "_deprecated": false,
         "assertion_id": 811,
         "feature_id": 811,
-        "source_id": 236,
-        "features_endpoint_feature_id": 1003
+        "source_id": 236
     },
     {
         "feature_type": "Somatic Variant",
@@ -30327,8 +29516,7 @@
         "_deprecated": false,
         "assertion_id": 812,
         "feature_id": 812,
-        "source_id": 237,
-        "features_endpoint_feature_id": 1003
+        "source_id": 237
     },
     {
         "feature_type": "Somatic Variant",
@@ -30366,8 +29554,7 @@
         "_deprecated": false,
         "assertion_id": 813,
         "feature_id": 813,
-        "source_id": 237,
-        "features_endpoint_feature_id": 1003
+        "source_id": 237
     },
     {
         "feature_type": "Somatic Variant",
@@ -30405,8 +29592,7 @@
         "_deprecated": false,
         "assertion_id": 814,
         "feature_id": 814,
-        "source_id": 237,
-        "features_endpoint_feature_id": 1003
+        "source_id": 237
     },
     {
         "feature_type": "Somatic Variant",
@@ -30444,8 +29630,7 @@
         "_deprecated": false,
         "assertion_id": 815,
         "feature_id": 815,
-        "source_id": 237,
-        "features_endpoint_feature_id": 1003
+        "source_id": 237
     },
     {
         "feature_type": "Microsatellite Stability",
@@ -30473,8 +29658,7 @@
         "_deprecated": false,
         "assertion_id": 816,
         "feature_id": 816,
-        "source_id": 147,
-        "features_endpoint_feature_id": 1003
+        "source_id": 147
     },
     {
         "feature_type": "Microsatellite Stability",
@@ -30502,8 +29686,7 @@
         "_deprecated": false,
         "assertion_id": 817,
         "feature_id": 817,
-        "source_id": 238,
-        "features_endpoint_feature_id": 1003
+        "source_id": 238
     },
     {
         "feature_type": "Germline Variant",
@@ -30543,8 +29726,7 @@
         "_deprecated": false,
         "assertion_id": 818,
         "feature_id": 818,
-        "source_id": 239,
-        "features_endpoint_feature_id": 1003
+        "source_id": 239
     },
     {
         "feature_type": "Germline Variant",
@@ -30584,8 +29766,7 @@
         "_deprecated": false,
         "assertion_id": 819,
         "feature_id": 819,
-        "source_id": 239,
-        "features_endpoint_feature_id": 1003
+        "source_id": 239
     },
     {
         "feature_type": "Germline Variant",
@@ -30625,8 +29806,7 @@
         "_deprecated": false,
         "assertion_id": 820,
         "feature_id": 820,
-        "source_id": 239,
-        "features_endpoint_feature_id": 1003
+        "source_id": 239
     },
     {
         "feature_type": "Germline Variant",
@@ -30666,8 +29846,7 @@
         "_deprecated": false,
         "assertion_id": 821,
         "feature_id": 821,
-        "source_id": 239,
-        "features_endpoint_feature_id": 1003
+        "source_id": 239
     },
     {
         "feature_type": "Germline Variant",
@@ -30707,8 +29886,7 @@
         "_deprecated": false,
         "assertion_id": 822,
         "feature_id": 822,
-        "source_id": 239,
-        "features_endpoint_feature_id": 1003
+        "source_id": 239
     },
     {
         "feature_type": "Germline Variant",
@@ -30748,8 +29926,7 @@
         "_deprecated": false,
         "assertion_id": 823,
         "feature_id": 823,
-        "source_id": 239,
-        "features_endpoint_feature_id": 1003
+        "source_id": 239
     },
     {
         "feature_type": "Knockdown",
@@ -30778,8 +29955,7 @@
         "_deprecated": false,
         "assertion_id": 824,
         "feature_id": 824,
-        "source_id": 240,
-        "features_endpoint_feature_id": 1003
+        "source_id": 240
     },
     {
         "feature_type": "Knockdown",
@@ -30808,8 +29984,7 @@
         "_deprecated": false,
         "assertion_id": 825,
         "feature_id": 825,
-        "source_id": 241,
-        "features_endpoint_feature_id": 1003
+        "source_id": 241
     },
     {
         "feature_type": "Rearrangement",
@@ -30840,8 +30015,7 @@
         "_deprecated": false,
         "assertion_id": 826,
         "feature_id": 826,
-        "source_id": 242,
-        "features_endpoint_feature_id": 1003
+        "source_id": 242
     },
     {
         "feature_type": "Somatic Variant",
@@ -30879,8 +30053,7 @@
         "_deprecated": false,
         "assertion_id": 827,
         "feature_id": 827,
-        "source_id": 243,
-        "features_endpoint_feature_id": 1003
+        "source_id": 243
     },
     {
         "feature_type": "Somatic Variant",
@@ -30918,8 +30091,7 @@
         "_deprecated": false,
         "assertion_id": 828,
         "feature_id": 828,
-        "source_id": 243,
-        "features_endpoint_feature_id": 1003
+        "source_id": 243
     },
     {
         "feature_type": "Somatic Variant",
@@ -30957,8 +30129,7 @@
         "_deprecated": false,
         "assertion_id": 829,
         "feature_id": 829,
-        "source_id": 243,
-        "features_endpoint_feature_id": 1003
+        "source_id": 243
     },
     {
         "feature_type": "Somatic Variant",
@@ -30996,8 +30167,7 @@
         "_deprecated": false,
         "assertion_id": 830,
         "feature_id": 830,
-        "source_id": 243,
-        "features_endpoint_feature_id": 1003
+        "source_id": 243
     },
     {
         "feature_type": "Somatic Variant",
@@ -31035,8 +30205,7 @@
         "_deprecated": false,
         "assertion_id": 831,
         "feature_id": 831,
-        "source_id": 243,
-        "features_endpoint_feature_id": 1003
+        "source_id": 243
     },
     {
         "feature_type": "Somatic Variant",
@@ -31074,8 +30243,7 @@
         "_deprecated": false,
         "assertion_id": 832,
         "feature_id": 832,
-        "source_id": 243,
-        "features_endpoint_feature_id": 1003
+        "source_id": 243
     },
     {
         "feature_type": "Somatic Variant",
@@ -31113,8 +30281,7 @@
         "_deprecated": false,
         "assertion_id": 833,
         "feature_id": 833,
-        "source_id": 243,
-        "features_endpoint_feature_id": 1003
+        "source_id": 243
     },
     {
         "feature_type": "Somatic Variant",
@@ -31152,8 +30319,7 @@
         "_deprecated": false,
         "assertion_id": 834,
         "feature_id": 834,
-        "source_id": 243,
-        "features_endpoint_feature_id": 1003
+        "source_id": 243
     },
     {
         "feature_type": "Somatic Variant",
@@ -31191,8 +30357,7 @@
         "_deprecated": false,
         "assertion_id": 835,
         "feature_id": 835,
-        "source_id": 244,
-        "features_endpoint_feature_id": 1003
+        "source_id": 244
     },
     {
         "feature_type": "Somatic Variant",
@@ -31230,8 +30395,7 @@
         "_deprecated": false,
         "assertion_id": 836,
         "feature_id": 836,
-        "source_id": 244,
-        "features_endpoint_feature_id": 1003
+        "source_id": 244
     },
     {
         "feature_type": "Somatic Variant",
@@ -31269,8 +30433,7 @@
         "_deprecated": false,
         "assertion_id": 837,
         "feature_id": 837,
-        "source_id": 240,
-        "features_endpoint_feature_id": 1003
+        "source_id": 240
     },
     {
         "feature_type": "Somatic Variant",
@@ -31308,8 +30471,7 @@
         "_deprecated": false,
         "assertion_id": 838,
         "feature_id": 838,
-        "source_id": 240,
-        "features_endpoint_feature_id": 1003
+        "source_id": 240
     },
     {
         "feature_type": "Copy Number",
@@ -31340,8 +30502,7 @@
         "_deprecated": false,
         "assertion_id": 839,
         "feature_id": 839,
-        "source_id": 245,
-        "features_endpoint_feature_id": 1003
+        "source_id": 245
     },
     {
         "feature_type": "Copy Number",
@@ -31372,8 +30533,7 @@
         "_deprecated": false,
         "assertion_id": 840,
         "feature_id": 840,
-        "source_id": 243,
-        "features_endpoint_feature_id": 1003
+        "source_id": 243
     },
     {
         "feature_type": "Copy Number",
@@ -31404,8 +30564,7 @@
         "_deprecated": false,
         "assertion_id": 841,
         "feature_id": 841,
-        "source_id": 243,
-        "features_endpoint_feature_id": 1003
+        "source_id": 243
     },
     {
         "feature_type": "Copy Number",
@@ -31436,8 +30595,7 @@
         "_deprecated": false,
         "assertion_id": 842,
         "feature_id": 842,
-        "source_id": 244,
-        "features_endpoint_feature_id": 1003
+        "source_id": 244
     },
     {
         "feature_type": "Copy Number",
@@ -31468,8 +30626,7 @@
         "_deprecated": false,
         "assertion_id": 843,
         "feature_id": 843,
-        "source_id": 246,
-        "features_endpoint_feature_id": 1003
+        "source_id": 246
     },
     {
         "feature_type": "Copy Number",
@@ -31500,8 +30657,7 @@
         "_deprecated": false,
         "assertion_id": 844,
         "feature_id": 844,
-        "source_id": 247,
-        "features_endpoint_feature_id": 1003
+        "source_id": 247
     },
     {
         "feature_type": "Copy Number",
@@ -31532,8 +30688,7 @@
         "_deprecated": false,
         "assertion_id": 845,
         "feature_id": 845,
-        "source_id": 248,
-        "features_endpoint_feature_id": 1003
+        "source_id": 248
     },
     {
         "feature_type": "Copy Number",
@@ -31564,8 +30719,7 @@
         "_deprecated": false,
         "assertion_id": 846,
         "feature_id": 846,
-        "source_id": 248,
-        "features_endpoint_feature_id": 1003
+        "source_id": 248
     },
     {
         "feature_type": "Copy Number",
@@ -31596,8 +30750,7 @@
         "_deprecated": false,
         "assertion_id": 847,
         "feature_id": 847,
-        "source_id": 248,
-        "features_endpoint_feature_id": 1003
+        "source_id": 248
     },
     {
         "feature_type": "Copy Number",
@@ -31628,8 +30781,7 @@
         "_deprecated": false,
         "assertion_id": 848,
         "feature_id": 848,
-        "source_id": 248,
-        "features_endpoint_feature_id": 1003
+        "source_id": 248
     },
     {
         "feature_type": "Copy Number",
@@ -31660,8 +30812,7 @@
         "_deprecated": false,
         "assertion_id": 849,
         "feature_id": 849,
-        "source_id": 249,
-        "features_endpoint_feature_id": 1003
+        "source_id": 249
     },
     {
         "feature_type": "Copy Number",
@@ -31692,8 +30843,7 @@
         "_deprecated": false,
         "assertion_id": 850,
         "feature_id": 850,
-        "source_id": 250,
-        "features_endpoint_feature_id": 1003
+        "source_id": 250
     },
     {
         "feature_type": "Copy Number",
@@ -31724,8 +30874,7 @@
         "_deprecated": false,
         "assertion_id": 851,
         "feature_id": 851,
-        "source_id": 251,
-        "features_endpoint_feature_id": 1003
+        "source_id": 251
     },
     {
         "feature_type": "Copy Number",
@@ -31756,8 +30905,7 @@
         "_deprecated": false,
         "assertion_id": 852,
         "feature_id": 852,
-        "source_id": 251,
-        "features_endpoint_feature_id": 1003
+        "source_id": 251
     },
     {
         "feature_type": "Copy Number",
@@ -31788,8 +30936,7 @@
         "_deprecated": false,
         "assertion_id": 853,
         "feature_id": 853,
-        "source_id": 240,
-        "features_endpoint_feature_id": 1003
+        "source_id": 240
     },
     {
         "feature_type": "Rearrangement",
@@ -31820,8 +30967,7 @@
         "_deprecated": false,
         "assertion_id": 854,
         "feature_id": 854,
-        "source_id": 252,
-        "features_endpoint_feature_id": 1003
+        "source_id": 252
     },
     {
         "feature_type": "Rearrangement",
@@ -31852,8 +30998,7 @@
         "_deprecated": false,
         "assertion_id": 855,
         "feature_id": 855,
-        "source_id": 253,
-        "features_endpoint_feature_id": 1003
+        "source_id": 253
     },
     {
         "feature_type": "Rearrangement",
@@ -31884,8 +31029,7 @@
         "_deprecated": false,
         "assertion_id": 856,
         "feature_id": 856,
-        "source_id": 254,
-        "features_endpoint_feature_id": 1003
+        "source_id": 254
     },
     {
         "feature_type": "Somatic Variant",
@@ -31923,8 +31067,7 @@
         "_deprecated": false,
         "assertion_id": 857,
         "feature_id": 857,
-        "source_id": 255,
-        "features_endpoint_feature_id": 1003
+        "source_id": 255
     },
     {
         "feature_type": "Somatic Variant",
@@ -31962,8 +31105,7 @@
         "_deprecated": false,
         "assertion_id": 858,
         "feature_id": 858,
-        "source_id": 255,
-        "features_endpoint_feature_id": 1003
+        "source_id": 255
     },
     {
         "feature_type": "Somatic Variant",
@@ -32001,8 +31143,7 @@
         "_deprecated": false,
         "assertion_id": 859,
         "feature_id": 859,
-        "source_id": 255,
-        "features_endpoint_feature_id": 1003
+        "source_id": 255
     },
     {
         "feature_type": "Somatic Variant",
@@ -32040,8 +31181,7 @@
         "_deprecated": false,
         "assertion_id": 860,
         "feature_id": 860,
-        "source_id": 255,
-        "features_endpoint_feature_id": 1003
+        "source_id": 255
     },
     {
         "feature_type": "Somatic Variant",
@@ -32079,8 +31219,7 @@
         "_deprecated": false,
         "assertion_id": 861,
         "feature_id": 861,
-        "source_id": 255,
-        "features_endpoint_feature_id": 1003
+        "source_id": 255
     },
     {
         "feature_type": "Somatic Variant",
@@ -32118,8 +31257,7 @@
         "_deprecated": false,
         "assertion_id": 862,
         "feature_id": 862,
-        "source_id": 256,
-        "features_endpoint_feature_id": 1003
+        "source_id": 256
     },
     {
         "feature_type": "Copy Number",
@@ -32149,8 +31287,7 @@
         "_deprecated": false,
         "assertion_id": 863,
         "feature_id": 863,
-        "source_id": 257,
-        "features_endpoint_feature_id": 1003
+        "source_id": 257
     },
     {
         "feature_type": "Somatic Variant",
@@ -32188,8 +31325,7 @@
         "_deprecated": false,
         "assertion_id": 864,
         "feature_id": 864,
-        "source_id": 258,
-        "features_endpoint_feature_id": 1003
+        "source_id": 258
     },
     {
         "feature_type": "Somatic Variant",
@@ -32227,8 +31363,7 @@
         "_deprecated": false,
         "assertion_id": 865,
         "feature_id": 865,
-        "source_id": 259,
-        "features_endpoint_feature_id": 1003
+        "source_id": 259
     },
     {
         "feature_type": "Somatic Variant",
@@ -32266,8 +31401,7 @@
         "_deprecated": false,
         "assertion_id": 866,
         "feature_id": 866,
-        "source_id": 172,
-        "features_endpoint_feature_id": 1003
+        "source_id": 172
     },
     {
         "feature_type": "Somatic Variant",
@@ -32305,8 +31439,7 @@
         "_deprecated": false,
         "assertion_id": 867,
         "feature_id": 867,
-        "source_id": 172,
-        "features_endpoint_feature_id": 1003
+        "source_id": 172
     },
     {
         "feature_type": "Germline Variant",
@@ -32345,8 +31478,7 @@
         "_deprecated": false,
         "assertion_id": 868,
         "feature_id": 868,
-        "source_id": 172,
-        "features_endpoint_feature_id": 1003
+        "source_id": 172
     },
     {
         "feature_type": "Germline Variant",
@@ -32385,8 +31517,7 @@
         "_deprecated": false,
         "assertion_id": 869,
         "feature_id": 869,
-        "source_id": 172,
-        "features_endpoint_feature_id": 1003
+        "source_id": 172
     },
     {
         "feature_type": "Germline Variant",
@@ -32425,8 +31556,7 @@
         "_deprecated": false,
         "assertion_id": 870,
         "feature_id": 870,
-        "source_id": 172,
-        "features_endpoint_feature_id": 1003
+        "source_id": 172
     },
     {
         "feature_type": "Germline Variant",
@@ -32465,8 +31595,7 @@
         "_deprecated": false,
         "assertion_id": 871,
         "feature_id": 871,
-        "source_id": 172,
-        "features_endpoint_feature_id": 1003
+        "source_id": 172
     },
     {
         "feature_type": "Germline Variant",
@@ -32506,8 +31635,7 @@
         "_deprecated": false,
         "assertion_id": 872,
         "feature_id": 872,
-        "source_id": 172,
-        "features_endpoint_feature_id": 1003
+        "source_id": 172
     },
     {
         "feature_type": "Germline Variant",
@@ -32547,8 +31675,7 @@
         "_deprecated": false,
         "assertion_id": 873,
         "feature_id": 873,
-        "source_id": 172,
-        "features_endpoint_feature_id": 1003
+        "source_id": 172
     },
     {
         "feature_type": "Somatic Variant",
@@ -32587,8 +31714,7 @@
         "_deprecated": false,
         "assertion_id": 874,
         "feature_id": 874,
-        "source_id": 260,
-        "features_endpoint_feature_id": 1003
+        "source_id": 260
     },
     {
         "feature_type": "Somatic Variant",
@@ -32627,8 +31753,7 @@
         "_deprecated": false,
         "assertion_id": 875,
         "feature_id": 875,
-        "source_id": 260,
-        "features_endpoint_feature_id": 1003
+        "source_id": 260
     },
     {
         "feature_type": "Somatic Variant",
@@ -32667,8 +31792,7 @@
         "_deprecated": false,
         "assertion_id": 876,
         "feature_id": 876,
-        "source_id": 260,
-        "features_endpoint_feature_id": 1003
+        "source_id": 260
     },
     {
         "feature_type": "Somatic Variant",
@@ -32707,8 +31831,7 @@
         "_deprecated": false,
         "assertion_id": 877,
         "feature_id": 877,
-        "source_id": 260,
-        "features_endpoint_feature_id": 1003
+        "source_id": 260
     },
     {
         "feature_type": "Somatic Variant",
@@ -32747,8 +31870,7 @@
         "_deprecated": false,
         "assertion_id": 878,
         "feature_id": 878,
-        "source_id": 260,
-        "features_endpoint_feature_id": 1003
+        "source_id": 260
     },
     {
         "feature_type": "Somatic Variant",
@@ -32787,8 +31909,7 @@
         "_deprecated": false,
         "assertion_id": 879,
         "feature_id": 879,
-        "source_id": 260,
-        "features_endpoint_feature_id": 1003
+        "source_id": 260
     },
     {
         "feature_type": "Somatic Variant",
@@ -32827,8 +31948,7 @@
         "_deprecated": false,
         "assertion_id": 880,
         "feature_id": 880,
-        "source_id": 260,
-        "features_endpoint_feature_id": 1003
+        "source_id": 260
     },
     {
         "feature_type": "Somatic Variant",
@@ -32867,8 +31987,7 @@
         "_deprecated": false,
         "assertion_id": 881,
         "feature_id": 881,
-        "source_id": 260,
-        "features_endpoint_feature_id": 1003
+        "source_id": 260
     },
     {
         "feature_type": "Somatic Variant",
@@ -32907,8 +32026,7 @@
         "_deprecated": true,
         "assertion_id": 882,
         "feature_id": 882,
-        "source_id": 260,
-        "features_endpoint_feature_id": 1003
+        "source_id": 260
     },
     {
         "feature_type": "Somatic Variant",
@@ -32947,8 +32065,7 @@
         "_deprecated": false,
         "assertion_id": 883,
         "feature_id": 883,
-        "source_id": 260,
-        "features_endpoint_feature_id": 1003
+        "source_id": 260
     },
     {
         "feature_type": "Somatic Variant",
@@ -32987,8 +32104,7 @@
         "_deprecated": false,
         "assertion_id": 884,
         "feature_id": 884,
-        "source_id": 260,
-        "features_endpoint_feature_id": 1003
+        "source_id": 260
     },
     {
         "feature_type": "Somatic Variant",
@@ -33027,8 +32143,7 @@
         "_deprecated": false,
         "assertion_id": 885,
         "feature_id": 885,
-        "source_id": 260,
-        "features_endpoint_feature_id": 1003
+        "source_id": 260
     },
     {
         "feature_type": "Germline Variant",
@@ -33068,8 +32183,7 @@
         "_deprecated": false,
         "assertion_id": 886,
         "feature_id": 886,
-        "source_id": 261,
-        "features_endpoint_feature_id": 1003
+        "source_id": 261
     },
     {
         "feature_type": "Somatic Variant",
@@ -33108,8 +32222,7 @@
         "_deprecated": false,
         "assertion_id": 887,
         "feature_id": 887,
-        "source_id": 261,
-        "features_endpoint_feature_id": 1003
+        "source_id": 261
     },
     {
         "feature_type": "Germline Variant",
@@ -33149,8 +32262,7 @@
         "_deprecated": false,
         "assertion_id": 888,
         "feature_id": 888,
-        "source_id": 261,
-        "features_endpoint_feature_id": 1003
+        "source_id": 261
     },
     {
         "feature_type": "Somatic Variant",
@@ -33189,8 +32301,7 @@
         "_deprecated": false,
         "assertion_id": 889,
         "feature_id": 889,
-        "source_id": 261,
-        "features_endpoint_feature_id": 1003
+        "source_id": 261
     },
     {
         "feature_type": "Microsatellite Stability",
@@ -33218,8 +32329,7 @@
         "_deprecated": false,
         "assertion_id": 890,
         "feature_id": 890,
-        "source_id": 262,
-        "features_endpoint_feature_id": 1003
+        "source_id": 262
     },
     {
         "feature_type": "Somatic Variant",
@@ -33258,8 +32368,7 @@
         "_deprecated": false,
         "assertion_id": 891,
         "feature_id": 891,
-        "source_id": 263,
-        "features_endpoint_feature_id": 1003
+        "source_id": 263
     },
     {
         "feature_type": "Somatic Variant",
@@ -33298,8 +32407,7 @@
         "_deprecated": false,
         "assertion_id": 892,
         "feature_id": 892,
-        "source_id": 264,
-        "features_endpoint_feature_id": 1003
+        "source_id": 264
     },
     {
         "feature_type": "Copy Number",
@@ -33330,8 +32438,7 @@
         "_deprecated": false,
         "assertion_id": 893,
         "feature_id": 893,
-        "source_id": 264,
-        "features_endpoint_feature_id": 1003
+        "source_id": 264
     },
     {
         "feature_type": "Copy Number",
@@ -33362,8 +32469,7 @@
         "_deprecated": false,
         "assertion_id": 894,
         "feature_id": 894,
-        "source_id": 264,
-        "features_endpoint_feature_id": 1003
+        "source_id": 264
     },
     {
         "feature_type": "Somatic Variant",
@@ -33402,8 +32508,7 @@
         "_deprecated": false,
         "assertion_id": 895,
         "feature_id": 895,
-        "source_id": 265,
-        "features_endpoint_feature_id": 1003
+        "source_id": 265
     },
     {
         "feature_type": "Copy Number",
@@ -33434,8 +32539,7 @@
         "_deprecated": false,
         "assertion_id": 896,
         "feature_id": 896,
-        "source_id": 266,
-        "features_endpoint_feature_id": 1003
+        "source_id": 266
     },
     {
         "feature_type": "Copy Number",
@@ -33466,8 +32570,7 @@
         "_deprecated": false,
         "assertion_id": 897,
         "feature_id": 897,
-        "source_id": 266,
-        "features_endpoint_feature_id": 1003
+        "source_id": 266
     },
     {
         "feature_type": "Copy Number",
@@ -33498,8 +32601,7 @@
         "_deprecated": false,
         "assertion_id": 898,
         "feature_id": 898,
-        "source_id": 266,
-        "features_endpoint_feature_id": 1003
+        "source_id": 266
     },
     {
         "feature_type": "Copy Number",
@@ -33530,8 +32632,7 @@
         "_deprecated": false,
         "assertion_id": 899,
         "feature_id": 899,
-        "source_id": 266,
-        "features_endpoint_feature_id": 1003
+        "source_id": 266
     },
     {
         "feature_type": "Copy Number",
@@ -33562,8 +32663,7 @@
         "_deprecated": false,
         "assertion_id": 900,
         "feature_id": 900,
-        "source_id": 266,
-        "features_endpoint_feature_id": 1003
+        "source_id": 266
     },
     {
         "feature_type": "Copy Number",
@@ -33594,8 +32694,7 @@
         "_deprecated": false,
         "assertion_id": 901,
         "feature_id": 901,
-        "source_id": 267,
-        "features_endpoint_feature_id": 1003
+        "source_id": 267
     },
     {
         "feature_type": "Copy Number",
@@ -33626,8 +32725,7 @@
         "_deprecated": false,
         "assertion_id": 902,
         "feature_id": 902,
-        "source_id": 267,
-        "features_endpoint_feature_id": 1003
+        "source_id": 267
     },
     {
         "feature_type": "Copy Number",
@@ -33658,8 +32756,7 @@
         "_deprecated": false,
         "assertion_id": 903,
         "feature_id": 903,
-        "source_id": 267,
-        "features_endpoint_feature_id": 1003
+        "source_id": 267
     },
     {
         "feature_type": "Copy Number",
@@ -33690,8 +32787,7 @@
         "_deprecated": false,
         "assertion_id": 904,
         "feature_id": 904,
-        "source_id": 267,
-        "features_endpoint_feature_id": 1003
+        "source_id": 267
     },
     {
         "feature_type": "Copy Number",
@@ -33722,8 +32818,7 @@
         "_deprecated": false,
         "assertion_id": 905,
         "feature_id": 905,
-        "source_id": 267,
-        "features_endpoint_feature_id": 1003
+        "source_id": 267
     },
     {
         "feature_type": "Copy Number",
@@ -33754,8 +32849,7 @@
         "_deprecated": false,
         "assertion_id": 906,
         "feature_id": 906,
-        "source_id": 267,
-        "features_endpoint_feature_id": 1003
+        "source_id": 267
     },
     {
         "feature_type": "Rearrangement",
@@ -33787,8 +32881,7 @@
         "_deprecated": false,
         "assertion_id": 907,
         "feature_id": 907,
-        "source_id": 268,
-        "features_endpoint_feature_id": 1003
+        "source_id": 268
     },
     {
         "feature_type": "Somatic Variant",
@@ -33826,8 +32919,7 @@
         "_deprecated": false,
         "assertion_id": 908,
         "feature_id": 908,
-        "source_id": 269,
-        "features_endpoint_feature_id": 1003
+        "source_id": 269
     },
     {
         "feature_type": "Somatic Variant",
@@ -33865,8 +32957,7 @@
         "_deprecated": false,
         "assertion_id": 909,
         "feature_id": 909,
-        "source_id": 269,
-        "features_endpoint_feature_id": 1003
+        "source_id": 269
     },
     {
         "feature_type": "Somatic Variant",
@@ -33904,8 +32995,7 @@
         "_deprecated": false,
         "assertion_id": 910,
         "feature_id": 910,
-        "source_id": 269,
-        "features_endpoint_feature_id": 1003
+        "source_id": 269
     },
     {
         "feature_type": "Somatic Variant",
@@ -33943,8 +33033,7 @@
         "_deprecated": false,
         "assertion_id": 911,
         "feature_id": 911,
-        "source_id": 270,
-        "features_endpoint_feature_id": 1003
+        "source_id": 270
     },
     {
         "feature_type": "Somatic Variant",
@@ -33982,8 +33071,7 @@
         "_deprecated": false,
         "assertion_id": 912,
         "feature_id": 912,
-        "source_id": 33,
-        "features_endpoint_feature_id": 1003
+        "source_id": 33
     },
     {
         "feature_type": "Somatic Variant",
@@ -34021,8 +33109,7 @@
         "_deprecated": false,
         "assertion_id": 913,
         "feature_id": 913,
-        "source_id": 33,
-        "features_endpoint_feature_id": 1003
+        "source_id": 33
     },
     {
         "feature_type": "Somatic Variant",
@@ -34060,8 +33147,7 @@
         "_deprecated": false,
         "assertion_id": 914,
         "feature_id": 914,
-        "source_id": 33,
-        "features_endpoint_feature_id": 1003
+        "source_id": 33
     },
     {
         "feature_type": "Somatic Variant",
@@ -34099,8 +33185,7 @@
         "_deprecated": false,
         "assertion_id": 915,
         "feature_id": 915,
-        "source_id": 33,
-        "features_endpoint_feature_id": 1003
+        "source_id": 33
     },
     {
         "feature_type": "Somatic Variant",
@@ -34138,8 +33223,7 @@
         "_deprecated": false,
         "assertion_id": 916,
         "feature_id": 916,
-        "source_id": 33,
-        "features_endpoint_feature_id": 1003
+        "source_id": 33
     },
     {
         "feature_type": "Somatic Variant",
@@ -34177,8 +33261,7 @@
         "_deprecated": false,
         "assertion_id": 917,
         "feature_id": 917,
-        "source_id": 33,
-        "features_endpoint_feature_id": 1003
+        "source_id": 33
     },
     {
         "feature_type": "Somatic Variant",
@@ -34216,8 +33299,7 @@
         "_deprecated": false,
         "assertion_id": 918,
         "feature_id": 918,
-        "source_id": 33,
-        "features_endpoint_feature_id": 1003
+        "source_id": 33
     },
     {
         "feature_type": "Somatic Variant",
@@ -34255,8 +33337,7 @@
         "_deprecated": false,
         "assertion_id": 919,
         "feature_id": 919,
-        "source_id": 33,
-        "features_endpoint_feature_id": 1003
+        "source_id": 33
     },
     {
         "feature_type": "Somatic Variant",
@@ -34294,8 +33375,7 @@
         "_deprecated": false,
         "assertion_id": 920,
         "feature_id": 920,
-        "source_id": 33,
-        "features_endpoint_feature_id": 1003
+        "source_id": 33
     },
     {
         "feature_type": "Somatic Variant",
@@ -34333,8 +33413,7 @@
         "_deprecated": false,
         "assertion_id": 921,
         "feature_id": 921,
-        "source_id": 33,
-        "features_endpoint_feature_id": 1003
+        "source_id": 33
     },
     {
         "feature_type": "Somatic Variant",
@@ -34372,8 +33451,7 @@
         "_deprecated": false,
         "assertion_id": 922,
         "feature_id": 922,
-        "source_id": 33,
-        "features_endpoint_feature_id": 1003
+        "source_id": 33
     },
     {
         "feature_type": "Somatic Variant",
@@ -34411,8 +33489,7 @@
         "_deprecated": false,
         "assertion_id": 923,
         "feature_id": 923,
-        "source_id": 33,
-        "features_endpoint_feature_id": 1003
+        "source_id": 33
     },
     {
         "feature_type": "Somatic Variant",
@@ -34450,8 +33527,7 @@
         "_deprecated": false,
         "assertion_id": 924,
         "feature_id": 924,
-        "source_id": 33,
-        "features_endpoint_feature_id": 1003
+        "source_id": 33
     },
     {
         "feature_type": "Somatic Variant",
@@ -34489,8 +33565,7 @@
         "_deprecated": false,
         "assertion_id": 925,
         "feature_id": 925,
-        "source_id": 33,
-        "features_endpoint_feature_id": 1003
+        "source_id": 33
     },
     {
         "feature_type": "Somatic Variant",
@@ -34528,8 +33603,7 @@
         "_deprecated": false,
         "assertion_id": 926,
         "feature_id": 926,
-        "source_id": 33,
-        "features_endpoint_feature_id": 1003
+        "source_id": 33
     },
     {
         "feature_type": "Somatic Variant",
@@ -34567,8 +33641,7 @@
         "_deprecated": false,
         "assertion_id": 927,
         "feature_id": 927,
-        "source_id": 33,
-        "features_endpoint_feature_id": 1003
+        "source_id": 33
     },
     {
         "feature_type": "Somatic Variant",
@@ -34606,8 +33679,7 @@
         "_deprecated": false,
         "assertion_id": 928,
         "feature_id": 928,
-        "source_id": 33,
-        "features_endpoint_feature_id": 1003
+        "source_id": 33
     },
     {
         "feature_type": "Somatic Variant",
@@ -34645,8 +33717,7 @@
         "_deprecated": false,
         "assertion_id": 929,
         "feature_id": 929,
-        "source_id": 33,
-        "features_endpoint_feature_id": 1003
+        "source_id": 33
     },
     {
         "feature_type": "Somatic Variant",
@@ -34684,8 +33755,7 @@
         "_deprecated": false,
         "assertion_id": 930,
         "feature_id": 930,
-        "source_id": 33,
-        "features_endpoint_feature_id": 1003
+        "source_id": 33
     },
     {
         "feature_type": "Somatic Variant",
@@ -34723,8 +33793,7 @@
         "_deprecated": false,
         "assertion_id": 931,
         "feature_id": 931,
-        "source_id": 33,
-        "features_endpoint_feature_id": 1003
+        "source_id": 33
     },
     {
         "feature_type": "Somatic Variant",
@@ -34762,8 +33831,7 @@
         "_deprecated": false,
         "assertion_id": 932,
         "feature_id": 932,
-        "source_id": 33,
-        "features_endpoint_feature_id": 1003
+        "source_id": 33
     },
     {
         "feature_type": "Somatic Variant",
@@ -34801,8 +33869,7 @@
         "_deprecated": false,
         "assertion_id": 933,
         "feature_id": 933,
-        "source_id": 33,
-        "features_endpoint_feature_id": 1003
+        "source_id": 33
     },
     {
         "feature_type": "Somatic Variant",
@@ -34840,8 +33907,7 @@
         "_deprecated": false,
         "assertion_id": 934,
         "feature_id": 934,
-        "source_id": 33,
-        "features_endpoint_feature_id": 1003
+        "source_id": 33
     },
     {
         "feature_type": "Somatic Variant",
@@ -34879,8 +33945,7 @@
         "_deprecated": false,
         "assertion_id": 935,
         "feature_id": 935,
-        "source_id": 33,
-        "features_endpoint_feature_id": 1003
+        "source_id": 33
     },
     {
         "feature_type": "Rearrangement",
@@ -34911,8 +33976,7 @@
         "_deprecated": true,
         "assertion_id": 936,
         "feature_id": 936,
-        "source_id": 271,
-        "features_endpoint_feature_id": 1003
+        "source_id": 271
     },
     {
         "feature_type": "Somatic Variant",
@@ -34950,8 +34014,7 @@
         "_deprecated": false,
         "assertion_id": 937,
         "feature_id": 937,
-        "source_id": 272,
-        "features_endpoint_feature_id": 1003
+        "source_id": 272
     },
     {
         "feature_type": "Somatic Variant",
@@ -34989,8 +34052,7 @@
         "_deprecated": false,
         "assertion_id": 938,
         "feature_id": 938,
-        "source_id": 272,
-        "features_endpoint_feature_id": 1003
+        "source_id": 272
     },
     {
         "feature_type": "Somatic Variant",
@@ -35028,8 +34090,7 @@
         "_deprecated": false,
         "assertion_id": 939,
         "feature_id": 939,
-        "source_id": 272,
-        "features_endpoint_feature_id": 1003
+        "source_id": 272
     },
     {
         "feature_type": "Somatic Variant",
@@ -35067,8 +34128,7 @@
         "_deprecated": false,
         "assertion_id": 940,
         "feature_id": 940,
-        "source_id": 272,
-        "features_endpoint_feature_id": 1003
+        "source_id": 272
     },
     {
         "feature_type": "Somatic Variant",
@@ -35106,8 +34166,7 @@
         "_deprecated": false,
         "assertion_id": 941,
         "feature_id": 941,
-        "source_id": 272,
-        "features_endpoint_feature_id": 1003
+        "source_id": 272
     },
     {
         "feature_type": "Copy Number",
@@ -35137,8 +34196,7 @@
         "_deprecated": false,
         "assertion_id": 942,
         "feature_id": 942,
-        "source_id": 272,
-        "features_endpoint_feature_id": 1003
+        "source_id": 272
     },
     {
         "feature_type": "Copy Number",
@@ -35168,8 +34226,7 @@
         "_deprecated": false,
         "assertion_id": 943,
         "feature_id": 943,
-        "source_id": 202,
-        "features_endpoint_feature_id": 1003
+        "source_id": 202
     },
     {
         "feature_type": "Somatic Variant",
@@ -35207,8 +34264,7 @@
         "_deprecated": false,
         "assertion_id": 944,
         "feature_id": 944,
-        "source_id": 273,
-        "features_endpoint_feature_id": 1003
+        "source_id": 273
     },
     {
         "feature_type": "Somatic Variant",
@@ -35246,8 +34302,7 @@
         "_deprecated": false,
         "assertion_id": 945,
         "feature_id": 945,
-        "source_id": 273,
-        "features_endpoint_feature_id": 1003
+        "source_id": 273
     },
     {
         "feature_type": "Somatic Variant",
@@ -35285,8 +34340,7 @@
         "_deprecated": false,
         "assertion_id": 946,
         "feature_id": 946,
-        "source_id": 274,
-        "features_endpoint_feature_id": 1003
+        "source_id": 274
     },
     {
         "feature_type": "Somatic Variant",
@@ -35324,8 +34378,7 @@
         "_deprecated": false,
         "assertion_id": 947,
         "feature_id": 947,
-        "source_id": 275,
-        "features_endpoint_feature_id": 1003
+        "source_id": 275
     },
     {
         "feature_type": "Somatic Variant",
@@ -35363,8 +34416,7 @@
         "_deprecated": false,
         "assertion_id": 948,
         "feature_id": 948,
-        "source_id": 275,
-        "features_endpoint_feature_id": 1003
+        "source_id": 275
     },
     {
         "feature_type": "Somatic Variant",
@@ -35402,8 +34454,7 @@
         "_deprecated": false,
         "assertion_id": 949,
         "feature_id": 949,
-        "source_id": 276,
-        "features_endpoint_feature_id": 1003
+        "source_id": 276
     },
     {
         "feature_type": "Somatic Variant",
@@ -35441,8 +34492,7 @@
         "_deprecated": false,
         "assertion_id": 950,
         "feature_id": 950,
-        "source_id": 276,
-        "features_endpoint_feature_id": 1003
+        "source_id": 276
     },
     {
         "feature_type": "Somatic Variant",
@@ -35480,8 +34530,7 @@
         "_deprecated": false,
         "assertion_id": 951,
         "feature_id": 951,
-        "source_id": 277,
-        "features_endpoint_feature_id": 1003
+        "source_id": 277
     },
     {
         "feature_type": "Somatic Variant",
@@ -35519,8 +34568,7 @@
         "_deprecated": false,
         "assertion_id": 952,
         "feature_id": 952,
-        "source_id": 277,
-        "features_endpoint_feature_id": 1003
+        "source_id": 277
     },
     {
         "feature_type": "Rearrangement",
@@ -35551,8 +34599,7 @@
         "_deprecated": false,
         "assertion_id": 953,
         "feature_id": 953,
-        "source_id": 278,
-        "features_endpoint_feature_id": 1003
+        "source_id": 278
     },
     {
         "feature_type": "Rearrangement",
@@ -35583,8 +34630,7 @@
         "_deprecated": false,
         "assertion_id": 954,
         "feature_id": 954,
-        "source_id": 40,
-        "features_endpoint_feature_id": 1003
+        "source_id": 40
     },
     {
         "feature_type": "Rearrangement",
@@ -35615,8 +34661,7 @@
         "_deprecated": false,
         "assertion_id": 955,
         "feature_id": 955,
-        "source_id": 271,
-        "features_endpoint_feature_id": 1003
+        "source_id": 271
     },
     {
         "feature_type": "Somatic Variant",
@@ -35655,8 +34700,7 @@
         "_deprecated": false,
         "assertion_id": 956,
         "feature_id": 956,
-        "source_id": 260,
-        "features_endpoint_feature_id": 1003
+        "source_id": 260
     },
     {
         "feature_type": "Rearrangement",
@@ -35688,8 +34732,7 @@
         "_deprecated": false,
         "assertion_id": 957,
         "feature_id": 957,
-        "source_id": 279,
-        "features_endpoint_feature_id": 1003
+        "source_id": 279
     },
     {
         "feature_type": "Rearrangement",
@@ -35721,8 +34764,7 @@
         "_deprecated": false,
         "assertion_id": 958,
         "feature_id": 958,
-        "source_id": 280,
-        "features_endpoint_feature_id": 1003
+        "source_id": 280
     },
     {
         "feature_type": "Rearrangement",
@@ -35754,8 +34796,7 @@
         "_deprecated": false,
         "assertion_id": 959,
         "feature_id": 959,
-        "source_id": 280,
-        "features_endpoint_feature_id": 1003
+        "source_id": 280
     },
     {
         "feature_type": "Somatic Variant",
@@ -35794,8 +34835,7 @@
         "_deprecated": false,
         "assertion_id": 960,
         "feature_id": 960,
-        "source_id": 280,
-        "features_endpoint_feature_id": 1003
+        "source_id": 280
     },
     {
         "feature_type": "Somatic Variant",
@@ -35834,8 +34874,7 @@
         "_deprecated": false,
         "assertion_id": 961,
         "feature_id": 961,
-        "source_id": 280,
-        "features_endpoint_feature_id": 1003
+        "source_id": 280
     },
     {
         "feature_type": "Rearrangement",
@@ -35866,8 +34905,7 @@
         "_deprecated": false,
         "assertion_id": 962,
         "feature_id": 962,
-        "source_id": 281,
-        "features_endpoint_feature_id": 1003
+        "source_id": 281
     },
     {
         "feature_type": "Somatic Variant",
@@ -35905,8 +34943,7 @@
         "_deprecated": false,
         "assertion_id": 963,
         "feature_id": 963,
-        "source_id": 282,
-        "features_endpoint_feature_id": 1003
+        "source_id": 282
     },
     {
         "feature_type": "Rearrangement",
@@ -35937,8 +34974,7 @@
         "_deprecated": false,
         "assertion_id": 964,
         "feature_id": 964,
-        "source_id": 282,
-        "features_endpoint_feature_id": 1003
+        "source_id": 282
     },
     {
         "feature_type": "Rearrangement",
@@ -35969,8 +35005,7 @@
         "_deprecated": false,
         "assertion_id": 965,
         "feature_id": 965,
-        "source_id": 282,
-        "features_endpoint_feature_id": 1003
+        "source_id": 282
     },
     {
         "feature_type": "Somatic Variant",
@@ -36008,8 +35043,7 @@
         "_deprecated": false,
         "assertion_id": 966,
         "feature_id": 966,
-        "source_id": 283,
-        "features_endpoint_feature_id": 1003
+        "source_id": 283
     },
     {
         "feature_type": "Somatic Variant",
@@ -36047,8 +35081,7 @@
         "_deprecated": false,
         "assertion_id": 967,
         "feature_id": 967,
-        "source_id": 283,
-        "features_endpoint_feature_id": 1003
+        "source_id": 283
     },
     {
         "feature_type": "Somatic Variant",
@@ -36086,8 +35119,7 @@
         "_deprecated": false,
         "assertion_id": 968,
         "feature_id": 968,
-        "source_id": 284,
-        "features_endpoint_feature_id": 1003
+        "source_id": 284
     },
     {
         "feature_type": "Somatic Variant",
@@ -36125,8 +35157,7 @@
         "_deprecated": false,
         "assertion_id": 969,
         "feature_id": 969,
-        "source_id": 284,
-        "features_endpoint_feature_id": 1003
+        "source_id": 284
     },
     {
         "feature_type": "Rearrangement",
@@ -36157,8 +35188,7 @@
         "_deprecated": false,
         "assertion_id": 970,
         "feature_id": 970,
-        "source_id": 285,
-        "features_endpoint_feature_id": 1003
+        "source_id": 285
     },
     {
         "feature_type": "Rearrangement",
@@ -36189,8 +35219,7 @@
         "_deprecated": false,
         "assertion_id": 971,
         "feature_id": 971,
-        "source_id": 285,
-        "features_endpoint_feature_id": 1003
+        "source_id": 285
     },
     {
         "feature_type": "Rearrangement",
@@ -36221,8 +35250,7 @@
         "_deprecated": false,
         "assertion_id": 972,
         "feature_id": 972,
-        "source_id": 285,
-        "features_endpoint_feature_id": 1003
+        "source_id": 285
     },
     {
         "feature_type": "Somatic Variant",
@@ -36260,8 +35288,7 @@
         "_deprecated": false,
         "assertion_id": 973,
         "feature_id": 973,
-        "source_id": 286,
-        "features_endpoint_feature_id": 1003
+        "source_id": 286
     },
     {
         "feature_type": "Somatic Variant",
@@ -36299,8 +35326,7 @@
         "_deprecated": false,
         "assertion_id": 974,
         "feature_id": 974,
-        "source_id": 287,
-        "features_endpoint_feature_id": 1003
+        "source_id": 287
     },
     {
         "feature_type": "Somatic Variant",
@@ -36338,8 +35364,7 @@
         "_deprecated": false,
         "assertion_id": 975,
         "feature_id": 975,
-        "source_id": 287,
-        "features_endpoint_feature_id": 1003
+        "source_id": 287
     },
     {
         "feature_type": "Somatic Variant",
@@ -36377,8 +35402,7 @@
         "_deprecated": false,
         "assertion_id": 976,
         "feature_id": 976,
-        "source_id": 287,
-        "features_endpoint_feature_id": 1003
+        "source_id": 287
     },
     {
         "feature_type": "Somatic Variant",
@@ -36416,8 +35440,7 @@
         "_deprecated": false,
         "assertion_id": 977,
         "feature_id": 977,
-        "source_id": 287,
-        "features_endpoint_feature_id": 1003
+        "source_id": 287
     },
     {
         "feature_type": "Somatic Variant",
@@ -36455,8 +35478,7 @@
         "_deprecated": false,
         "assertion_id": 978,
         "feature_id": 978,
-        "source_id": 287,
-        "features_endpoint_feature_id": 1003
+        "source_id": 287
     },
     {
         "feature_type": "Somatic Variant",
@@ -36494,8 +35516,7 @@
         "_deprecated": false,
         "assertion_id": 979,
         "feature_id": 979,
-        "source_id": 287,
-        "features_endpoint_feature_id": 1003
+        "source_id": 287
     },
     {
         "feature_type": "Somatic Variant",
@@ -36533,8 +35554,7 @@
         "_deprecated": false,
         "assertion_id": 980,
         "feature_id": 980,
-        "source_id": 287,
-        "features_endpoint_feature_id": 1003
+        "source_id": 287
     },
     {
         "feature_type": "Somatic Variant",
@@ -36572,8 +35592,7 @@
         "_deprecated": false,
         "assertion_id": 981,
         "feature_id": 981,
-        "source_id": 287,
-        "features_endpoint_feature_id": 1003
+        "source_id": 287
     },
     {
         "feature_type": "Somatic Variant",
@@ -36611,8 +35630,7 @@
         "_deprecated": false,
         "assertion_id": 982,
         "feature_id": 982,
-        "source_id": 287,
-        "features_endpoint_feature_id": 1003
+        "source_id": 287
     },
     {
         "feature_type": "Somatic Variant",
@@ -36650,8 +35668,7 @@
         "_deprecated": false,
         "assertion_id": 983,
         "feature_id": 983,
-        "source_id": 287,
-        "features_endpoint_feature_id": 1003
+        "source_id": 287
     },
     {
         "feature_type": "Somatic Variant",
@@ -36689,8 +35706,7 @@
         "_deprecated": false,
         "assertion_id": 984,
         "feature_id": 984,
-        "source_id": 287,
-        "features_endpoint_feature_id": 1003
+        "source_id": 287
     },
     {
         "feature_type": "Somatic Variant",
@@ -36728,8 +35744,7 @@
         "_deprecated": false,
         "assertion_id": 985,
         "feature_id": 985,
-        "source_id": 287,
-        "features_endpoint_feature_id": 1003
+        "source_id": 287
     },
     {
         "feature_type": "Somatic Variant",
@@ -36767,8 +35782,7 @@
         "_deprecated": false,
         "assertion_id": 986,
         "feature_id": 986,
-        "source_id": 287,
-        "features_endpoint_feature_id": 1003
+        "source_id": 287
     },
     {
         "feature_type": "Somatic Variant",
@@ -36806,8 +35820,7 @@
         "_deprecated": false,
         "assertion_id": 987,
         "feature_id": 987,
-        "source_id": 287,
-        "features_endpoint_feature_id": 1003
+        "source_id": 287
     },
     {
         "feature_type": "Somatic Variant",
@@ -36845,8 +35858,7 @@
         "_deprecated": false,
         "assertion_id": 988,
         "feature_id": 988,
-        "source_id": 287,
-        "features_endpoint_feature_id": 1003
+        "source_id": 287
     },
     {
         "feature_type": "Somatic Variant",
@@ -36884,8 +35896,7 @@
         "_deprecated": false,
         "assertion_id": 989,
         "feature_id": 989,
-        "source_id": 287,
-        "features_endpoint_feature_id": 1003
+        "source_id": 287
     },
     {
         "feature_type": "Somatic Variant",
@@ -36923,8 +35934,7 @@
         "_deprecated": false,
         "assertion_id": 990,
         "feature_id": 990,
-        "source_id": 287,
-        "features_endpoint_feature_id": 1003
+        "source_id": 287
     },
     {
         "feature_type": "Somatic Variant",
@@ -36962,8 +35972,7 @@
         "_deprecated": false,
         "assertion_id": 991,
         "feature_id": 991,
-        "source_id": 288,
-        "features_endpoint_feature_id": 1003
+        "source_id": 288
     },
     {
         "feature_type": "Somatic Variant",
@@ -37001,8 +36010,7 @@
         "_deprecated": false,
         "assertion_id": 992,
         "feature_id": 992,
-        "source_id": 288,
-        "features_endpoint_feature_id": 1003
+        "source_id": 288
     },
     {
         "feature_type": "Somatic Variant",
@@ -37040,8 +36048,7 @@
         "_deprecated": false,
         "assertion_id": 993,
         "feature_id": 993,
-        "source_id": 289,
-        "features_endpoint_feature_id": 1003
+        "source_id": 289
     },
     {
         "feature_type": "Somatic Variant",
@@ -37079,8 +36086,7 @@
         "_deprecated": false,
         "assertion_id": 994,
         "feature_id": 994,
-        "source_id": 289,
-        "features_endpoint_feature_id": 1003
+        "source_id": 289
     },
     {
         "feature_type": "Somatic Variant",
@@ -37118,8 +36124,7 @@
         "_deprecated": false,
         "assertion_id": 995,
         "feature_id": 995,
-        "source_id": 290,
-        "features_endpoint_feature_id": 1003
+        "source_id": 290
     },
     {
         "feature_type": "Somatic Variant",
@@ -37157,8 +36162,7 @@
         "_deprecated": false,
         "assertion_id": 996,
         "feature_id": 996,
-        "source_id": 290,
-        "features_endpoint_feature_id": 1003
+        "source_id": 290
     },
     {
         "feature_type": "Rearrangement",
@@ -37189,8 +36193,7 @@
         "_deprecated": false,
         "assertion_id": 997,
         "feature_id": 997,
-        "source_id": 6,
-        "features_endpoint_feature_id": 1003
+        "source_id": 6
     },
     {
         "feature_type": "Rearrangement",
@@ -37221,8 +36224,7 @@
         "_deprecated": false,
         "assertion_id": 998,
         "feature_id": 998,
-        "source_id": 6,
-        "features_endpoint_feature_id": 1003
+        "source_id": 6
     },
     {
         "feature_type": "Somatic Variant",
@@ -37260,8 +36262,7 @@
         "_deprecated": false,
         "assertion_id": 999,
         "feature_id": 999,
-        "source_id": 6,
-        "features_endpoint_feature_id": 1003
+        "source_id": 6
     },
     {
         "feature_type": "Somatic Variant",
@@ -37299,8 +36300,7 @@
         "_deprecated": false,
         "assertion_id": 1000,
         "feature_id": 1000,
-        "source_id": 291,
-        "features_endpoint_feature_id": 1003
+        "source_id": 291
     },
     {
         "feature_type": "Rearrangement",
@@ -37331,8 +36331,7 @@
         "_deprecated": false,
         "assertion_id": 1001,
         "feature_id": 1001,
-        "source_id": 292,
-        "features_endpoint_feature_id": 1003
+        "source_id": 292
     },
     {
         "feature_type": "Rearrangement",
@@ -37363,8 +36362,7 @@
         "_deprecated": false,
         "assertion_id": 1002,
         "feature_id": 1002,
-        "source_id": 292,
-        "features_endpoint_feature_id": 1003
+        "source_id": 292
     },
     {
         "feature_type": "Rearrangement",
@@ -37395,8 +36393,7 @@
         "_deprecated": false,
         "assertion_id": 1003,
         "feature_id": 1003,
-        "source_id": 293,
-        "features_endpoint_feature_id": 1003
+        "source_id": 293
     },
     {
         "feature_type": "Rearrangement",
@@ -37427,7 +36424,6 @@
         "_deprecated": false,
         "assertion_id": 1004,
         "feature_id": 1004,
-        "source_id": 293,
-        "features_endpoint_feature_id": 1003
+        "source_id": 293
     }
 ]


### PR DESCRIPTION
Several ids are added to records when the database is the [current browser](https://github.com/vanallenlab/moalmanac-browser) and thus API. Here, we add `assertion_id`, `feature_id`, and `source_id`, as they appear in the [[/api/assertions](https://www.moalmanac.org/api/assertions)](https://www.moalmanac.org/api/assertions) endpoint, to all records in `molecular-oncology-almanac.json`. The `assertion_id` and `feature_id` values are simply the index value for each record in the database. 

The [https://www.moalmanac.org/api/features](https://www.moalmanac.org/api/features) endpoint lists the unique features when _not_ considering the `feature_id` key, and thus it returns a list of dictionaries containing the first instance of each genomic feature. This will be added at a later date to each record in `molecular-oncology-almanac.json` under the key `features_endpoint_feature_id`. 