### PR TITLE
Normalize therapy names

### DIFF
--- a/docs/sop.md
+++ b/docs/sop.md
@@ -340,5 +340,10 @@ The assertion of a relationship describes the claim made by a source and connect
 - `therapy_sensitivity` (optional, integer), `1` if the relationship asserts sensitive to a therapy, `0` if the relationship asserts not sensitive to a therapy, and blank otherwise.
 - `therapy_resistance` (optional, integer), `1` if the relationship asserts resistance to a therapy, `0` if the relationship asserts not resistive to a therapy, and blank otherwise.
 - `favorable_prognosis` (optional, integer), `1` if the relationship asserts a disease prognosis that is favorable, `0` if the relationship asserts a disease prognosis that is not favorable, and blank otherwise
+- `_deprecated` (optional, boolean), `false` is the relationship is still active within the database, `true` if the relationship has been deprecated and will thus not show up on [https://moalmanac.org](https://moalmanac.org) or through the API.
+- `assertion_id` (required, integer), integer value corresponding to the `assertion_id` from the `assertions` endpoint at [https://moalmanac.org/api/assertions](https://moalmanac.org/api/assertions).
+- `feature_id` (required, integer), integer value corresponding to the `feature_id` from the `assertions` endpoint at [https://moalmanac.org/api/assertions](https://moalmanac.org/api/assertions).
+- `source_id` (required, integer), integer value corresponding to the `source_id` from the `assertions` endpoint at [https://moalmanac.org/api/assertions](https://moalmanac.org/api/assertions).
+- `therapy_name_mappings` (optional, list), mappings for `therapy_name` to the [NCI thesaurus](https://evsexplore.semantics.cancer.gov/evsexplore/), if possible. This field is _not_ included in the API or [https://moalmanac.org](https://moalmanac.org). Represented as a [ConceptMapping](https://va-ga4gh.readthedocs.io/en/latest/core-information-model/data-types.html#conceptmapping) from [GA4GH's Variant Annotation Specification](https://github.com/ga4gh/va-spec).
 
 [Return to Table of Contents](#table-of-contents)

--- a/molecular-oncology-almanac.json
+++ b/molecular-oncology-almanac.json
@@ -28,7 +28,19 @@
         "_deprecated": false,
         "assertion_id": 1,
         "feature_id": 1,
-        "source_id": 1
+        "source_id": 1,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C60809",
+                    "code": "C60809",
+                    "name": "Bosutinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Rearrangement",
@@ -59,7 +71,19 @@
         "_deprecated": false,
         "assertion_id": 2,
         "feature_id": 2,
-        "source_id": 2
+        "source_id": 2,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C38713",
+                    "code": "C38713",
+                    "name": "Dasatinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Rearrangement",
@@ -90,7 +114,19 @@
         "_deprecated": false,
         "assertion_id": 3,
         "feature_id": 3,
-        "source_id": 2
+        "source_id": 2,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C38713",
+                    "code": "C38713",
+                    "name": "Dasatinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Rearrangement",
@@ -121,7 +157,19 @@
         "_deprecated": false,
         "assertion_id": 4,
         "feature_id": 4,
-        "source_id": 3
+        "source_id": 3,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C62035",
+                    "code": "C62035",
+                    "name": "Imatinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Rearrangement",
@@ -152,7 +200,19 @@
         "_deprecated": false,
         "assertion_id": 5,
         "feature_id": 5,
-        "source_id": 3
+        "source_id": 3,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C62035",
+                    "code": "C62035",
+                    "name": "Imatinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Rearrangement",
@@ -183,7 +243,19 @@
         "_deprecated": false,
         "assertion_id": 6,
         "feature_id": 6,
-        "source_id": 4
+        "source_id": 4,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C38713",
+                    "code": "C38713",
+                    "name": "Dasatinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Rearrangement",
@@ -214,7 +286,19 @@
         "_deprecated": false,
         "assertion_id": 7,
         "feature_id": 7,
-        "source_id": 5
+        "source_id": 5,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C48375",
+                    "code": "C48375",
+                    "name": "Nilotinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Rearrangement",
@@ -245,7 +329,19 @@
         "_deprecated": false,
         "assertion_id": 8,
         "feature_id": 8,
-        "source_id": 6
+        "source_id": 6,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C114494",
+                    "code": "C114494",
+                    "name": "Asciminib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Rearrangement",
@@ -276,7 +372,19 @@
         "_deprecated": false,
         "assertion_id": 9,
         "feature_id": 9,
-        "source_id": 7
+        "source_id": 7,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C101790",
+                    "code": "C101790",
+                    "name": "Alectinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Rearrangement",
@@ -307,7 +415,19 @@
         "_deprecated": false,
         "assertion_id": 10,
         "feature_id": 10,
-        "source_id": 8
+        "source_id": 8,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C74061",
+                    "code": "C74061",
+                    "name": "Crizotinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Rearrangement",
@@ -338,7 +458,19 @@
         "_deprecated": false,
         "assertion_id": 11,
         "feature_id": 11,
-        "source_id": 9
+        "source_id": 9,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C113655",
+                    "code": "C113655",
+                    "name": "Lorlatinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Rearrangement",
@@ -369,7 +501,19 @@
         "_deprecated": false,
         "assertion_id": 12,
         "feature_id": 12,
-        "source_id": 10
+        "source_id": 10,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C115112",
+                    "code": "C115112",
+                    "name": "Ceritinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Rearrangement",
@@ -400,7 +544,19 @@
         "_deprecated": false,
         "assertion_id": 13,
         "feature_id": 13,
-        "source_id": 11
+        "source_id": 11,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C101790",
+                    "code": "C101790",
+                    "name": "Alectinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Rearrangement",
@@ -431,7 +587,19 @@
         "_deprecated": false,
         "assertion_id": 14,
         "feature_id": 14,
-        "source_id": 12
+        "source_id": 12,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C115112",
+                    "code": "C115112",
+                    "name": "Ceritinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Rearrangement",
@@ -462,7 +630,19 @@
         "_deprecated": false,
         "assertion_id": 15,
         "feature_id": 15,
-        "source_id": 13
+        "source_id": 13,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C74061",
+                    "code": "C74061",
+                    "name": "Crizotinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Rearrangement",
@@ -493,7 +673,19 @@
         "_deprecated": false,
         "assertion_id": 16,
         "feature_id": 16,
-        "source_id": 13
+        "source_id": 13,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C115112",
+                    "code": "C115112",
+                    "name": "Ceritinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Rearrangement",
@@ -524,7 +716,19 @@
         "_deprecated": false,
         "assertion_id": 17,
         "feature_id": 17,
-        "source_id": 14
+        "source_id": 14,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C74061",
+                    "code": "C74061",
+                    "name": "Crizotinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Rearrangement",
@@ -555,7 +759,8 @@
         "_deprecated": false,
         "assertion_id": 18,
         "feature_id": 18,
-        "source_id": 15
+        "source_id": 15,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Rearrangement",
@@ -586,7 +791,19 @@
         "_deprecated": false,
         "assertion_id": 19,
         "feature_id": 19,
-        "source_id": 16
+        "source_id": 16,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C49176",
+                    "code": "C49176",
+                    "name": "Palbociclib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Rearrangement",
@@ -617,7 +834,8 @@
         "_deprecated": false,
         "assertion_id": 20,
         "feature_id": 20,
-        "source_id": 17
+        "source_id": 17,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Rearrangement",
@@ -648,7 +866,19 @@
         "_deprecated": false,
         "assertion_id": 21,
         "feature_id": 21,
-        "source_id": 16
+        "source_id": 16,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C49176",
+                    "code": "C49176",
+                    "name": "Palbociclib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Rearrangement",
@@ -679,7 +909,19 @@
         "_deprecated": false,
         "assertion_id": 22,
         "feature_id": 22,
-        "source_id": 18
+        "source_id": 18,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C62035",
+                    "code": "C62035",
+                    "name": "Imatinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Rearrangement",
@@ -710,7 +952,19 @@
         "_deprecated": false,
         "assertion_id": 23,
         "feature_id": 23,
-        "source_id": 19
+        "source_id": 19,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C15382",
+                    "code": "C15382",
+                    "name": "Gamma knife",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Rearrangement",
@@ -741,7 +995,19 @@
         "_deprecated": false,
         "assertion_id": 24,
         "feature_id": 24,
-        "source_id": 20
+        "source_id": 20,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C74061",
+                    "code": "C74061",
+                    "name": "Crizotinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Rearrangement",
@@ -772,7 +1038,19 @@
         "_deprecated": false,
         "assertion_id": 25,
         "feature_id": 25,
-        "source_id": 21
+        "source_id": 21,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C61948",
+                    "code": "C61948",
+                    "name": "Sorafenib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Rearrangement",
@@ -803,7 +1081,8 @@
         "_deprecated": false,
         "assertion_id": 26,
         "feature_id": 26,
-        "source_id": 21
+        "source_id": 21,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Rearrangement",
@@ -834,7 +1113,8 @@
         "_deprecated": false,
         "assertion_id": 27,
         "feature_id": 27,
-        "source_id": 22
+        "source_id": 22,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Rearrangement",
@@ -865,7 +1145,19 @@
         "_deprecated": false,
         "assertion_id": 28,
         "feature_id": 28,
-        "source_id": 23
+        "source_id": 23,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C95777",
+                    "code": "C95777",
+                    "name": "Ponatinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Rearrangement",
@@ -896,7 +1188,19 @@
         "_deprecated": false,
         "assertion_id": 29,
         "feature_id": 29,
-        "source_id": 24
+        "source_id": 24,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C121553",
+                    "code": "C121553",
+                    "name": "Pemigatinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Rearrangement",
@@ -927,7 +1231,19 @@
         "_deprecated": false,
         "assertion_id": 30,
         "feature_id": 30,
-        "source_id": 24
+        "source_id": 24,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C121553",
+                    "code": "C121553",
+                    "name": "Pemigatinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Rearrangement",
@@ -958,7 +1274,19 @@
         "_deprecated": false,
         "assertion_id": 31,
         "feature_id": 31,
-        "source_id": 25
+        "source_id": 25,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C88302",
+                    "code": "C88302",
+                    "name": "Infigratinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Rearrangement",
@@ -989,7 +1317,19 @@
         "_deprecated": false,
         "assertion_id": 32,
         "feature_id": 32,
-        "source_id": 26
+        "source_id": 26,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C103273",
+                    "code": "C103273",
+                    "name": "Erdafitinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Rearrangement",
@@ -1020,7 +1360,19 @@
         "_deprecated": false,
         "assertion_id": 33,
         "feature_id": 33,
-        "source_id": 27
+        "source_id": 27,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C1851",
+                    "code": "C1851",
+                    "name": "Bortezomib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Rearrangement",
@@ -1051,7 +1403,8 @@
         "_deprecated": false,
         "assertion_id": 34,
         "feature_id": 34,
-        "source_id": 28
+        "source_id": 28,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Rearrangement",
@@ -1082,7 +1435,8 @@
         "_deprecated": false,
         "assertion_id": 35,
         "feature_id": 35,
-        "source_id": 28
+        "source_id": 28,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Rearrangement",
@@ -1113,7 +1467,19 @@
         "_deprecated": false,
         "assertion_id": 36,
         "feature_id": 36,
-        "source_id": 29
+        "source_id": 29,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C115977",
+                    "code": "C115977",
+                    "name": "Larotrectinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Rearrangement",
@@ -1144,7 +1510,19 @@
         "_deprecated": false,
         "assertion_id": 37,
         "feature_id": 37,
-        "source_id": 30
+        "source_id": 30,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C114984",
+                    "code": "C114984",
+                    "name": "Entrectinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Rearrangement",
@@ -1175,7 +1553,19 @@
         "_deprecated": false,
         "assertion_id": 38,
         "feature_id": 38,
-        "source_id": 31
+        "source_id": 31,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C114984",
+                    "code": "C114984",
+                    "name": "Entrectinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Rearrangement",
@@ -1206,7 +1596,19 @@
         "_deprecated": false,
         "assertion_id": 39,
         "feature_id": 39,
-        "source_id": 29
+        "source_id": 29,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C115977",
+                    "code": "C115977",
+                    "name": "Larotrectinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Rearrangement",
@@ -1237,7 +1639,19 @@
         "_deprecated": false,
         "assertion_id": 40,
         "feature_id": 40,
-        "source_id": 30
+        "source_id": 30,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C114984",
+                    "code": "C114984",
+                    "name": "Entrectinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Rearrangement",
@@ -1268,7 +1682,19 @@
         "_deprecated": false,
         "assertion_id": 41,
         "feature_id": 41,
-        "source_id": 31
+        "source_id": 31,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C114984",
+                    "code": "C114984",
+                    "name": "Entrectinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Rearrangement",
@@ -1299,7 +1725,19 @@
         "_deprecated": false,
         "assertion_id": 42,
         "feature_id": 42,
-        "source_id": 29
+        "source_id": 29,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C115977",
+                    "code": "C115977",
+                    "name": "Larotrectinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Rearrangement",
@@ -1330,7 +1768,19 @@
         "_deprecated": false,
         "assertion_id": 43,
         "feature_id": 43,
-        "source_id": 30
+        "source_id": 30,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C114984",
+                    "code": "C114984",
+                    "name": "Entrectinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Rearrangement",
@@ -1361,7 +1811,19 @@
         "_deprecated": false,
         "assertion_id": 44,
         "feature_id": 44,
-        "source_id": 31
+        "source_id": 31,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C114984",
+                    "code": "C114984",
+                    "name": "Entrectinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Rearrangement",
@@ -1392,7 +1854,19 @@
         "_deprecated": false,
         "assertion_id": 45,
         "feature_id": 45,
-        "source_id": 3
+        "source_id": 3,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C62035",
+                    "code": "C62035",
+                    "name": "Imatinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Rearrangement",
@@ -1423,7 +1897,19 @@
         "_deprecated": false,
         "assertion_id": 46,
         "feature_id": 46,
-        "source_id": 3
+        "source_id": 3,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C62035",
+                    "code": "C62035",
+                    "name": "Imatinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Rearrangement",
@@ -1454,7 +1940,19 @@
         "_deprecated": false,
         "assertion_id": 47,
         "feature_id": 47,
-        "source_id": 32
+        "source_id": 32,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C62035",
+                    "code": "C62035",
+                    "name": "Imatinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Rearrangement",
@@ -1485,7 +1983,19 @@
         "_deprecated": false,
         "assertion_id": 48,
         "feature_id": 48,
-        "source_id": 3
+        "source_id": 3,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C62035",
+                    "code": "C62035",
+                    "name": "Imatinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Rearrangement",
@@ -1516,7 +2026,19 @@
         "_deprecated": false,
         "assertion_id": 49,
         "feature_id": 49,
-        "source_id": 33
+        "source_id": 33,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C62035",
+                    "code": "C62035",
+                    "name": "Imatinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Rearrangement",
@@ -1547,7 +2069,19 @@
         "_deprecated": false,
         "assertion_id": 50,
         "feature_id": 50,
-        "source_id": 11
+        "source_id": 11,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C52200",
+                    "code": "C52200",
+                    "name": "Cabozantinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Rearrangement",
@@ -1578,7 +2112,19 @@
         "_deprecated": false,
         "assertion_id": 51,
         "feature_id": 51,
-        "source_id": 11
+        "source_id": 11,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C2737",
+                    "code": "C2737",
+                    "name": "Vandetanib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Rearrangement",
@@ -1609,7 +2155,19 @@
         "_deprecated": false,
         "assertion_id": 52,
         "feature_id": 52,
-        "source_id": 34
+        "source_id": 34,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C52200",
+                    "code": "C52200",
+                    "name": "Cabozantinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Rearrangement",
@@ -1640,7 +2198,19 @@
         "_deprecated": false,
         "assertion_id": 53,
         "feature_id": 53,
-        "source_id": 35
+        "source_id": 35,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C134987",
+                    "code": "C134987",
+                    "name": "Selpercatinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Rearrangement",
@@ -1671,7 +2241,19 @@
         "_deprecated": false,
         "assertion_id": 54,
         "feature_id": 54,
-        "source_id": 36
+        "source_id": 36,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C134987",
+                    "code": "C134987",
+                    "name": "Selpercatinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Rearrangement",
@@ -1702,7 +2284,19 @@
         "_deprecated": false,
         "assertion_id": 55,
         "feature_id": 55,
-        "source_id": 37
+        "source_id": 37,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C132295",
+                    "code": "C132295",
+                    "name": "Pralsetinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Rearrangement",
@@ -1733,7 +2327,19 @@
         "_deprecated": false,
         "assertion_id": 56,
         "feature_id": 56,
-        "source_id": 38
+        "source_id": 38,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C132295",
+                    "code": "C132295",
+                    "name": "Pralsetinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Rearrangement",
@@ -1764,7 +2370,19 @@
         "_deprecated": false,
         "assertion_id": 57,
         "feature_id": 57,
-        "source_id": 39
+        "source_id": 39,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C74061",
+                    "code": "C74061",
+                    "name": "Crizotinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Rearrangement",
@@ -1795,7 +2413,19 @@
         "_deprecated": true,
         "assertion_id": 58,
         "feature_id": 58,
-        "source_id": 40
+        "source_id": 40,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C114984",
+                    "code": "C114984",
+                    "name": "Entrectinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Rearrangement",
@@ -1826,7 +2456,29 @@
         "_deprecated": false,
         "assertion_id": 59,
         "feature_id": 59,
-        "source_id": 41
+        "source_id": 41,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C288",
+                    "code": "C288",
+                    "name": "Azacitidine",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C66948",
+                    "code": "C66948",
+                    "name": "Panobinostat",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Rearrangement",
@@ -1857,7 +2509,19 @@
         "_deprecated": false,
         "assertion_id": 60,
         "feature_id": 60,
-        "source_id": 21
+        "source_id": 21,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C61948",
+                    "code": "C61948",
+                    "name": "Sorafenib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Rearrangement",
@@ -1888,7 +2552,8 @@
         "_deprecated": false,
         "assertion_id": 61,
         "feature_id": 61,
-        "source_id": 21
+        "source_id": 21,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Rearrangement",
@@ -1919,7 +2584,19 @@
         "_deprecated": false,
         "assertion_id": 62,
         "feature_id": 62,
-        "source_id": 42
+        "source_id": 42,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C137800",
+                    "code": "C137800",
+                    "name": "Rucaparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Rearrangement",
@@ -1950,7 +2627,8 @@
         "_deprecated": false,
         "assertion_id": 63,
         "feature_id": 63,
-        "source_id": 43
+        "source_id": 43,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Rearrangement",
@@ -1981,7 +2659,19 @@
         "_deprecated": false,
         "assertion_id": 64,
         "feature_id": 64,
-        "source_id": 44
+        "source_id": 44,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C77333",
+                    "code": "C77333",
+                    "name": "Abiraterone",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Rearrangement",
@@ -2012,7 +2702,19 @@
         "_deprecated": false,
         "assertion_id": 65,
         "feature_id": 65,
-        "source_id": 44
+        "source_id": 44,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C60768",
+                    "code": "C60768",
+                    "name": "Veliparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -2050,7 +2752,19 @@
         "_deprecated": false,
         "assertion_id": 66,
         "feature_id": 66,
-        "source_id": 45
+        "source_id": 45,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C62035",
+                    "code": "C62035",
+                    "name": "Imatinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -2088,7 +2802,19 @@
         "_deprecated": false,
         "assertion_id": 67,
         "feature_id": 67,
-        "source_id": 46
+        "source_id": 46,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C38713",
+                    "code": "C38713",
+                    "name": "Dasatinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -2126,7 +2852,19 @@
         "_deprecated": false,
         "assertion_id": 68,
         "feature_id": 68,
-        "source_id": 46
+        "source_id": 46,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C38713",
+                    "code": "C38713",
+                    "name": "Dasatinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -2164,7 +2902,19 @@
         "_deprecated": false,
         "assertion_id": 69,
         "feature_id": 69,
-        "source_id": 46
+        "source_id": 46,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C38713",
+                    "code": "C38713",
+                    "name": "Dasatinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -2202,7 +2952,19 @@
         "_deprecated": false,
         "assertion_id": 70,
         "feature_id": 70,
-        "source_id": 46
+        "source_id": 46,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C38713",
+                    "code": "C38713",
+                    "name": "Dasatinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -2240,7 +3002,19 @@
         "_deprecated": false,
         "assertion_id": 71,
         "feature_id": 71,
-        "source_id": 46
+        "source_id": 46,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C38713",
+                    "code": "C38713",
+                    "name": "Dasatinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -2278,7 +3052,19 @@
         "_deprecated": false,
         "assertion_id": 72,
         "feature_id": 72,
-        "source_id": 46
+        "source_id": 46,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C38713",
+                    "code": "C38713",
+                    "name": "Dasatinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -2316,7 +3102,19 @@
         "_deprecated": false,
         "assertion_id": 73,
         "feature_id": 73,
-        "source_id": 46
+        "source_id": 46,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C38713",
+                    "code": "C38713",
+                    "name": "Dasatinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -2354,7 +3152,19 @@
         "_deprecated": false,
         "assertion_id": 74,
         "feature_id": 74,
-        "source_id": 46
+        "source_id": 46,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C62035",
+                    "code": "C62035",
+                    "name": "Imatinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -2392,7 +3202,19 @@
         "_deprecated": false,
         "assertion_id": 75,
         "feature_id": 75,
-        "source_id": 46
+        "source_id": 46,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C48375",
+                    "code": "C48375",
+                    "name": "Nilotinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -2430,7 +3252,19 @@
         "_deprecated": false,
         "assertion_id": 76,
         "feature_id": 76,
-        "source_id": 46
+        "source_id": 46,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C48375",
+                    "code": "C48375",
+                    "name": "Nilotinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -2468,7 +3302,19 @@
         "_deprecated": false,
         "assertion_id": 77,
         "feature_id": 77,
-        "source_id": 46
+        "source_id": 46,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C48375",
+                    "code": "C48375",
+                    "name": "Nilotinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -2506,7 +3352,19 @@
         "_deprecated": false,
         "assertion_id": 78,
         "feature_id": 78,
-        "source_id": 46
+        "source_id": 46,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C48375",
+                    "code": "C48375",
+                    "name": "Nilotinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -2544,7 +3402,19 @@
         "_deprecated": false,
         "assertion_id": 79,
         "feature_id": 79,
-        "source_id": 46
+        "source_id": 46,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C48375",
+                    "code": "C48375",
+                    "name": "Nilotinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -2582,7 +3452,19 @@
         "_deprecated": false,
         "assertion_id": 80,
         "feature_id": 80,
-        "source_id": 46
+        "source_id": 46,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C48375",
+                    "code": "C48375",
+                    "name": "Nilotinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -2620,7 +3502,19 @@
         "_deprecated": false,
         "assertion_id": 81,
         "feature_id": 81,
-        "source_id": 47
+        "source_id": 47,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C38713",
+                    "code": "C38713",
+                    "name": "Dasatinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -2658,7 +3552,19 @@
         "_deprecated": false,
         "assertion_id": 82,
         "feature_id": 82,
-        "source_id": 47
+        "source_id": 47,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C38713",
+                    "code": "C38713",
+                    "name": "Dasatinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -2696,7 +3602,19 @@
         "_deprecated": false,
         "assertion_id": 83,
         "feature_id": 83,
-        "source_id": 47
+        "source_id": 47,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C38713",
+                    "code": "C38713",
+                    "name": "Dasatinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -2734,7 +3652,19 @@
         "_deprecated": false,
         "assertion_id": 84,
         "feature_id": 84,
-        "source_id": 47
+        "source_id": 47,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C38713",
+                    "code": "C38713",
+                    "name": "Dasatinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -2772,7 +3702,19 @@
         "_deprecated": false,
         "assertion_id": 85,
         "feature_id": 85,
-        "source_id": 47
+        "source_id": 47,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C38713",
+                    "code": "C38713",
+                    "name": "Dasatinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -2810,7 +3752,19 @@
         "_deprecated": false,
         "assertion_id": 86,
         "feature_id": 86,
-        "source_id": 47
+        "source_id": 47,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C38713",
+                    "code": "C38713",
+                    "name": "Dasatinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -2848,7 +3802,19 @@
         "_deprecated": false,
         "assertion_id": 87,
         "feature_id": 87,
-        "source_id": 47
+        "source_id": 47,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C48375",
+                    "code": "C48375",
+                    "name": "Nilotinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -2886,7 +3852,19 @@
         "_deprecated": false,
         "assertion_id": 88,
         "feature_id": 88,
-        "source_id": 47
+        "source_id": 47,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C48375",
+                    "code": "C48375",
+                    "name": "Nilotinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -2924,7 +3902,19 @@
         "_deprecated": false,
         "assertion_id": 89,
         "feature_id": 89,
-        "source_id": 47
+        "source_id": 47,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C48375",
+                    "code": "C48375",
+                    "name": "Nilotinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -2962,7 +3952,19 @@
         "_deprecated": false,
         "assertion_id": 90,
         "feature_id": 90,
-        "source_id": 47
+        "source_id": 47,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C48375",
+                    "code": "C48375",
+                    "name": "Nilotinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -3000,7 +4002,19 @@
         "_deprecated": false,
         "assertion_id": 91,
         "feature_id": 91,
-        "source_id": 47
+        "source_id": 47,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C48375",
+                    "code": "C48375",
+                    "name": "Nilotinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -3038,7 +4052,19 @@
         "_deprecated": false,
         "assertion_id": 92,
         "feature_id": 92,
-        "source_id": 47
+        "source_id": 47,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C48375",
+                    "code": "C48375",
+                    "name": "Nilotinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -3076,7 +4102,19 @@
         "_deprecated": false,
         "assertion_id": 93,
         "feature_id": 93,
-        "source_id": 47
+        "source_id": 47,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C60809",
+                    "code": "C60809",
+                    "name": "Bosutinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -3114,7 +4152,19 @@
         "_deprecated": false,
         "assertion_id": 94,
         "feature_id": 94,
-        "source_id": 47
+        "source_id": 47,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C60809",
+                    "code": "C60809",
+                    "name": "Bosutinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -3152,7 +4202,19 @@
         "_deprecated": false,
         "assertion_id": 95,
         "feature_id": 95,
-        "source_id": 47
+        "source_id": 47,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C60809",
+                    "code": "C60809",
+                    "name": "Bosutinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -3190,7 +4252,19 @@
         "_deprecated": false,
         "assertion_id": 96,
         "feature_id": 96,
-        "source_id": 47
+        "source_id": 47,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C60809",
+                    "code": "C60809",
+                    "name": "Bosutinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -3228,7 +4302,19 @@
         "_deprecated": false,
         "assertion_id": 97,
         "feature_id": 97,
-        "source_id": 47
+        "source_id": 47,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C60809",
+                    "code": "C60809",
+                    "name": "Bosutinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -3266,7 +4352,19 @@
         "_deprecated": false,
         "assertion_id": 98,
         "feature_id": 98,
-        "source_id": 47
+        "source_id": 47,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C60809",
+                    "code": "C60809",
+                    "name": "Bosutinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -3304,7 +4402,19 @@
         "_deprecated": false,
         "assertion_id": 99,
         "feature_id": 99,
-        "source_id": 47
+        "source_id": 47,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C60809",
+                    "code": "C60809",
+                    "name": "Bosutinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -3342,7 +4452,19 @@
         "_deprecated": false,
         "assertion_id": 100,
         "feature_id": 100,
-        "source_id": 47
+        "source_id": 47,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C60809",
+                    "code": "C60809",
+                    "name": "Bosutinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -3380,7 +4502,19 @@
         "_deprecated": false,
         "assertion_id": 101,
         "feature_id": 101,
-        "source_id": 47
+        "source_id": 47,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C60809",
+                    "code": "C60809",
+                    "name": "Bosutinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -3418,7 +4552,19 @@
         "_deprecated": false,
         "assertion_id": 102,
         "feature_id": 102,
-        "source_id": 47
+        "source_id": 47,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C60809",
+                    "code": "C60809",
+                    "name": "Bosutinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -3456,7 +4602,19 @@
         "_deprecated": false,
         "assertion_id": 103,
         "feature_id": 103,
-        "source_id": 47
+        "source_id": 47,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C95777",
+                    "code": "C95777",
+                    "name": "Ponatinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -3494,7 +4652,19 @@
         "_deprecated": false,
         "assertion_id": 104,
         "feature_id": 104,
-        "source_id": 47
+        "source_id": 47,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C179199",
+                    "code": "C179199",
+                    "name": "Omacetaxine",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -3532,7 +4702,19 @@
         "_deprecated": false,
         "assertion_id": 105,
         "feature_id": 105,
-        "source_id": 47
+        "source_id": 47,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C38713",
+                    "code": "C38713",
+                    "name": "Dasatinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -3551,7 +4733,7 @@
         "context": "",
         "oncotree_term": "Invasive Breast Carcinoma",
         "oncotree_code": "BRCA",
-        "therapy_name": "MK-2206",
+        "therapy_name": "Akt Inhibitor MK2206",
         "therapy_strategy": "PI3K/AKT/mTOR inhibition",
         "therapy_type": "Targeted therapy",
         "therapy_sensitivity": 1,
@@ -3570,7 +4752,19 @@
         "_deprecated": false,
         "assertion_id": 106,
         "feature_id": 106,
-        "source_id": 48
+        "source_id": 48,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C90581",
+                    "code": "C90581",
+                    "name": "Akt Inhibitor MK2206",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -3589,7 +4783,7 @@
         "context": "",
         "oncotree_term": "Invasive Breast Carcinoma",
         "oncotree_code": "BRCA",
-        "therapy_name": "MK-2206",
+        "therapy_name": "Akt Inhibitor MK2206",
         "therapy_strategy": "PI3K/AKT/mTOR inhibition",
         "therapy_type": "Targeted therapy",
         "therapy_sensitivity": 1,
@@ -3608,7 +4802,19 @@
         "_deprecated": false,
         "assertion_id": 107,
         "feature_id": 107,
-        "source_id": 48
+        "source_id": 48,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C90581",
+                    "code": "C90581",
+                    "name": "Akt Inhibitor MK2206",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -3627,7 +4833,7 @@
         "context": "",
         "oncotree_term": "",
         "oncotree_code": "",
-        "therapy_name": "MK-2206",
+        "therapy_name": "Akt Inhibitor MK2206",
         "therapy_strategy": "PI3K/AKT/mTOR inhibition",
         "therapy_type": "Targeted therapy",
         "therapy_sensitivity": 1,
@@ -3646,7 +4852,19 @@
         "_deprecated": false,
         "assertion_id": 108,
         "feature_id": 108,
-        "source_id": 49
+        "source_id": 49,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C90581",
+                    "code": "C90581",
+                    "name": "Akt Inhibitor MK2206",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -3665,7 +4883,7 @@
         "context": "",
         "oncotree_term": "",
         "oncotree_code": "",
-        "therapy_name": "MK-2206",
+        "therapy_name": "Akt Inhibitor MK2206",
         "therapy_strategy": "PI3K/AKT/mTOR inhibition",
         "therapy_type": "Targeted therapy",
         "therapy_sensitivity": 1,
@@ -3684,7 +4902,19 @@
         "_deprecated": false,
         "assertion_id": 109,
         "feature_id": 109,
-        "source_id": 49
+        "source_id": 49,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C90581",
+                    "code": "C90581",
+                    "name": "Akt Inhibitor MK2206",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -3722,7 +4952,19 @@
         "_deprecated": false,
         "assertion_id": 110,
         "feature_id": 110,
-        "source_id": 50
+        "source_id": 50,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C115112",
+                    "code": "C115112",
+                    "name": "Ceritinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -3760,7 +5002,19 @@
         "_deprecated": false,
         "assertion_id": 111,
         "feature_id": 111,
-        "source_id": 50
+        "source_id": 50,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C115112",
+                    "code": "C115112",
+                    "name": "Ceritinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -3798,7 +5052,19 @@
         "_deprecated": false,
         "assertion_id": 112,
         "feature_id": 112,
-        "source_id": 50
+        "source_id": 50,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C115112",
+                    "code": "C115112",
+                    "name": "Ceritinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -3836,7 +5102,19 @@
         "_deprecated": false,
         "assertion_id": 113,
         "feature_id": 113,
-        "source_id": 50
+        "source_id": 50,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C115112",
+                    "code": "C115112",
+                    "name": "Ceritinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -3874,7 +5152,19 @@
         "_deprecated": false,
         "assertion_id": 114,
         "feature_id": 114,
-        "source_id": 50
+        "source_id": 50,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C115112",
+                    "code": "C115112",
+                    "name": "Ceritinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -3912,7 +5202,19 @@
         "_deprecated": false,
         "assertion_id": 115,
         "feature_id": 115,
-        "source_id": 51
+        "source_id": 51,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C77333",
+                    "code": "C77333",
+                    "name": "Abiraterone",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -3950,7 +5252,19 @@
         "_deprecated": false,
         "assertion_id": 116,
         "feature_id": 116,
-        "source_id": 51
+        "source_id": 51,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C77333",
+                    "code": "C77333",
+                    "name": "Abiraterone",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -3988,7 +5302,19 @@
         "_deprecated": false,
         "assertion_id": 117,
         "feature_id": 117,
-        "source_id": 52
+        "source_id": 52,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C61948",
+                    "code": "C61948",
+                    "name": "Sorafenib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -4026,7 +5352,19 @@
         "_deprecated": false,
         "assertion_id": 118,
         "feature_id": 118,
-        "source_id": 53
+        "source_id": 53,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C103194",
+                    "code": "C103194",
+                    "name": "Durvalumab",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -4064,7 +5402,19 @@
         "_deprecated": false,
         "assertion_id": 119,
         "feature_id": 119,
-        "source_id": 53
+        "source_id": 53,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C103194",
+                    "code": "C103194",
+                    "name": "Durvalumab",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -4102,7 +5452,8 @@
         "_deprecated": false,
         "assertion_id": 120,
         "feature_id": 120,
-        "source_id": 54
+        "source_id": 54,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -4140,7 +5491,8 @@
         "_deprecated": false,
         "assertion_id": 121,
         "feature_id": 121,
-        "source_id": 33
+        "source_id": 33,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -4178,7 +5530,8 @@
         "_deprecated": false,
         "assertion_id": 122,
         "feature_id": 122,
-        "source_id": 33
+        "source_id": 33,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -4197,7 +5550,7 @@
         "context": "Advanced or metastatic",
         "oncotree_term": "Any solid tumor",
         "oncotree_code": "",
-        "therapy_name": "BAY 1895344",
+        "therapy_name": "Elimusertib",
         "therapy_strategy": "ATR inhibition",
         "therapy_type": "Targeted therapy",
         "therapy_sensitivity": 1,
@@ -4216,7 +5569,19 @@
         "_deprecated": false,
         "assertion_id": 123,
         "feature_id": 123,
-        "source_id": 55
+        "source_id": 55,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C146807",
+                    "code": "C146807",
+                    "name": "Elimusertib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -4235,7 +5600,7 @@
         "context": "Advanced or metastatic",
         "oncotree_term": "Any solid tumor",
         "oncotree_code": "",
-        "therapy_name": "BAY 1895344",
+        "therapy_name": "Elimusertib",
         "therapy_strategy": "ATR inhibition",
         "therapy_type": "Targeted therapy",
         "therapy_sensitivity": 1,
@@ -4254,7 +5619,19 @@
         "_deprecated": false,
         "assertion_id": 124,
         "feature_id": 124,
-        "source_id": 55
+        "source_id": 55,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C146807",
+                    "code": "C146807",
+                    "name": "Elimusertib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -4273,7 +5650,7 @@
         "context": "Advanced or metastatic",
         "oncotree_term": "Any solid tumor",
         "oncotree_code": "",
-        "therapy_name": "BAY 1895344",
+        "therapy_name": "Elimusertib",
         "therapy_strategy": "ATR inhibition",
         "therapy_type": "Targeted therapy",
         "therapy_sensitivity": 1,
@@ -4292,7 +5669,19 @@
         "_deprecated": false,
         "assertion_id": 125,
         "feature_id": 125,
-        "source_id": 55
+        "source_id": 55,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C146807",
+                    "code": "C146807",
+                    "name": "Elimusertib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -4311,7 +5700,7 @@
         "context": "",
         "oncotree_term": "Any solid tumor",
         "oncotree_code": "",
-        "therapy_name": "Radiation therapy",
+        "therapy_name": "Radiation Therapy",
         "therapy_strategy": "Radiation",
         "therapy_type": "Radiation therapy",
         "therapy_sensitivity": 1,
@@ -4330,7 +5719,19 @@
         "_deprecated": false,
         "assertion_id": 126,
         "feature_id": 126,
-        "source_id": 56
+        "source_id": 56,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C15313",
+                    "code": "C15313",
+                    "name": "Radiation Therapy",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -4349,7 +5750,7 @@
         "context": "",
         "oncotree_term": "Any solid tumor",
         "oncotree_code": "",
-        "therapy_name": "Radiation therapy",
+        "therapy_name": "Radiation Therapy",
         "therapy_strategy": "Radiation",
         "therapy_type": "Radiation therapy",
         "therapy_sensitivity": 1,
@@ -4368,7 +5769,19 @@
         "_deprecated": false,
         "assertion_id": 127,
         "feature_id": 127,
-        "source_id": 56
+        "source_id": 56,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C15313",
+                    "code": "C15313",
+                    "name": "Radiation Therapy",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -4387,7 +5800,7 @@
         "context": "",
         "oncotree_term": "Any solid tumor",
         "oncotree_code": "",
-        "therapy_name": "Radiation therapy",
+        "therapy_name": "Radiation Therapy",
         "therapy_strategy": "Radiation",
         "therapy_type": "Radiation therapy",
         "therapy_sensitivity": 1,
@@ -4406,7 +5819,19 @@
         "_deprecated": false,
         "assertion_id": 128,
         "feature_id": 128,
-        "source_id": 56
+        "source_id": 56,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C15313",
+                    "code": "C15313",
+                    "name": "Radiation Therapy",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -4444,7 +5869,19 @@
         "_deprecated": false,
         "assertion_id": 129,
         "feature_id": 129,
-        "source_id": 57
+        "source_id": 57,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C71721",
+                    "code": "C71721",
+                    "name": "Olaparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -4482,7 +5919,19 @@
         "_deprecated": false,
         "assertion_id": 130,
         "feature_id": 130,
-        "source_id": 58
+        "source_id": 58,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C71721",
+                    "code": "C71721",
+                    "name": "Olaparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -4520,7 +5969,8 @@
         "_deprecated": false,
         "assertion_id": 131,
         "feature_id": 131,
-        "source_id": 59
+        "source_id": 59,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -4558,7 +6008,8 @@
         "_deprecated": false,
         "assertion_id": 132,
         "feature_id": 132,
-        "source_id": 59
+        "source_id": 59,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -4596,7 +6047,8 @@
         "_deprecated": false,
         "assertion_id": 133,
         "feature_id": 133,
-        "source_id": 59
+        "source_id": 59,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -4615,7 +6067,7 @@
         "context": "Primary",
         "oncotree_term": "Ovarian Cancer, Other",
         "oncotree_code": "OOVC",
-        "therapy_name": "Platinum",
+        "therapy_name": "Platinum Compound",
         "therapy_strategy": "Platinum-based chemotherapy",
         "therapy_type": "Chemotherapy",
         "therapy_sensitivity": 1,
@@ -4634,7 +6086,19 @@
         "_deprecated": false,
         "assertion_id": 134,
         "feature_id": 134,
-        "source_id": 59
+        "source_id": 59,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C1450",
+                    "code": "C1450",
+                    "name": "Platinum Compound",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -4653,7 +6117,7 @@
         "context": "Primary",
         "oncotree_term": "Peritoneal Mesothelioma",
         "oncotree_code": "PEMESO",
-        "therapy_name": "Platinum",
+        "therapy_name": "Platinum Compound",
         "therapy_strategy": "Platinum-based chemotherapy",
         "therapy_type": "Chemotherapy",
         "therapy_sensitivity": 1,
@@ -4672,7 +6136,19 @@
         "_deprecated": false,
         "assertion_id": 135,
         "feature_id": 135,
-        "source_id": 59
+        "source_id": 59,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C1450",
+                    "code": "C1450",
+                    "name": "Platinum Compound",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -4691,7 +6167,7 @@
         "context": "Primary",
         "oncotree_term": "Serous Ovarian Cancer",
         "oncotree_code": "SOC",
-        "therapy_name": "Platinum",
+        "therapy_name": "Platinum Compound",
         "therapy_strategy": "Platinum-based chemotherapy",
         "therapy_type": "Chemotherapy",
         "therapy_sensitivity": 1,
@@ -4710,7 +6186,19 @@
         "_deprecated": false,
         "assertion_id": 136,
         "feature_id": 136,
-        "source_id": 59
+        "source_id": 59,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C1450",
+                    "code": "C1450",
+                    "name": "Platinum Compound",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -4748,7 +6236,19 @@
         "_deprecated": false,
         "assertion_id": 137,
         "feature_id": 137,
-        "source_id": 58
+        "source_id": 58,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C71721",
+                    "code": "C71721",
+                    "name": "Olaparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -4786,7 +6286,8 @@
         "_deprecated": false,
         "assertion_id": 138,
         "feature_id": 138,
-        "source_id": 33
+        "source_id": 33,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -4824,7 +6325,8 @@
         "_deprecated": false,
         "assertion_id": 139,
         "feature_id": 139,
-        "source_id": 33
+        "source_id": 33,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -4862,7 +6364,8 @@
         "_deprecated": false,
         "assertion_id": 140,
         "feature_id": 140,
-        "source_id": 33
+        "source_id": 33,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -4900,7 +6403,8 @@
         "_deprecated": false,
         "assertion_id": 141,
         "feature_id": 141,
-        "source_id": 60
+        "source_id": 60,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -4938,7 +6442,19 @@
         "_deprecated": false,
         "assertion_id": 142,
         "feature_id": 142,
-        "source_id": 46
+        "source_id": 46,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C62035",
+                    "code": "C62035",
+                    "name": "Imatinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -4976,7 +6492,8 @@
         "_deprecated": false,
         "assertion_id": 143,
         "feature_id": 143,
-        "source_id": 61
+        "source_id": 61,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -5014,7 +6531,19 @@
         "_deprecated": false,
         "assertion_id": 144,
         "feature_id": 144,
-        "source_id": 62
+        "source_id": 62,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C82386",
+                    "code": "C82386",
+                    "name": "Dabrafenib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -5052,7 +6581,29 @@
         "_deprecated": false,
         "assertion_id": 145,
         "feature_id": 145,
-        "source_id": 62
+        "source_id": 62,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C82386",
+                    "code": "C82386",
+                    "name": "Dabrafenib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C77908",
+                    "code": "C77908",
+                    "name": "Trametinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -5090,7 +6641,29 @@
         "_deprecated": false,
         "assertion_id": 146,
         "feature_id": 146,
-        "source_id": 62
+        "source_id": 62,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C82386",
+                    "code": "C82386",
+                    "name": "Dabrafenib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C77908",
+                    "code": "C77908",
+                    "name": "Trametinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -5128,7 +6701,29 @@
         "_deprecated": false,
         "assertion_id": 147,
         "feature_id": 147,
-        "source_id": 62
+        "source_id": 62,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C82386",
+                    "code": "C82386",
+                    "name": "Dabrafenib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C77908",
+                    "code": "C77908",
+                    "name": "Trametinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -5166,7 +6761,29 @@
         "_deprecated": false,
         "assertion_id": 148,
         "feature_id": 148,
-        "source_id": 62
+        "source_id": 62,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C82386",
+                    "code": "C82386",
+                    "name": "Dabrafenib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C77908",
+                    "code": "C77908",
+                    "name": "Trametinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -5204,7 +6821,29 @@
         "_deprecated": false,
         "assertion_id": 149,
         "feature_id": 149,
-        "source_id": 62
+        "source_id": 62,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C82386",
+                    "code": "C82386",
+                    "name": "Dabrafenib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C77908",
+                    "code": "C77908",
+                    "name": "Trametinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -5242,7 +6881,19 @@
         "_deprecated": false,
         "assertion_id": 150,
         "feature_id": 150,
-        "source_id": 63
+        "source_id": 63,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C77908",
+                    "code": "C77908",
+                    "name": "Trametinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -5280,7 +6931,19 @@
         "_deprecated": false,
         "assertion_id": 151,
         "feature_id": 151,
-        "source_id": 63
+        "source_id": 63,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C77908",
+                    "code": "C77908",
+                    "name": "Trametinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -5318,7 +6981,19 @@
         "_deprecated": false,
         "assertion_id": 152,
         "feature_id": 152,
-        "source_id": 64
+        "source_id": 64,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C98283",
+                    "code": "C98283",
+                    "name": "Encorafenib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -5356,7 +7031,19 @@
         "_deprecated": false,
         "assertion_id": 153,
         "feature_id": 153,
-        "source_id": 64
+        "source_id": 64,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C98283",
+                    "code": "C98283",
+                    "name": "Encorafenib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -5394,7 +7081,29 @@
         "_deprecated": false,
         "assertion_id": 154,
         "feature_id": 154,
-        "source_id": 64
+        "source_id": 64,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C1723",
+                    "code": "C1723",
+                    "name": "Cetuximab",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C98283",
+                    "code": "C98283",
+                    "name": "Encorafenib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -5432,7 +7141,19 @@
         "_deprecated": false,
         "assertion_id": 155,
         "feature_id": 155,
-        "source_id": 65
+        "source_id": 65,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C64768",
+                    "code": "C64768",
+                    "name": "Vemurafenib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -5470,7 +7191,19 @@
         "_deprecated": false,
         "assertion_id": 156,
         "feature_id": 156,
-        "source_id": 66
+        "source_id": 66,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C1857",
+                    "code": "C1857",
+                    "name": "Panitumumab",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -5508,7 +7241,8 @@
         "_deprecated": false,
         "assertion_id": 157,
         "feature_id": 157,
-        "source_id": 67
+        "source_id": 67,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -5546,7 +7280,19 @@
         "_deprecated": false,
         "assertion_id": 158,
         "feature_id": 158,
-        "source_id": 68
+        "source_id": 68,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C64768",
+                    "code": "C64768",
+                    "name": "Vemurafenib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -5584,7 +7330,19 @@
         "_deprecated": false,
         "assertion_id": 159,
         "feature_id": 159,
-        "source_id": 68
+        "source_id": 68,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C82386",
+                    "code": "C82386",
+                    "name": "Dabrafenib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -5622,7 +7380,29 @@
         "_deprecated": false,
         "assertion_id": 160,
         "feature_id": 160,
-        "source_id": 68
+        "source_id": 68,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C68923",
+                    "code": "C68923",
+                    "name": "Cobimetinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C64768",
+                    "code": "C64768",
+                    "name": "Vemurafenib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -5660,7 +7440,29 @@
         "_deprecated": false,
         "assertion_id": 161,
         "feature_id": 161,
-        "source_id": 68
+        "source_id": 68,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C82386",
+                    "code": "C82386",
+                    "name": "Dabrafenib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C77908",
+                    "code": "C77908",
+                    "name": "Trametinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -5698,7 +7500,29 @@
         "_deprecated": false,
         "assertion_id": 162,
         "feature_id": 162,
-        "source_id": 69
+        "source_id": 69,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C2654",
+                    "code": "C2654",
+                    "name": "Ipilimumab",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C64768",
+                    "code": "C64768",
+                    "name": "Vemurafenib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -5736,7 +7560,29 @@
         "_deprecated": false,
         "assertion_id": 163,
         "feature_id": 163,
-        "source_id": 69
+        "source_id": 69,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C2654",
+                    "code": "C2654",
+                    "name": "Ipilimumab",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C64768",
+                    "code": "C64768",
+                    "name": "Vemurafenib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -5755,7 +7601,7 @@
         "context": "Resistance to BRAFi monotherapy",
         "oncotree_term": "Melanoma",
         "oncotree_code": "MEL",
-        "therapy_name": "Dabrafenib + Bevacizumab",
+        "therapy_name": "Bevacizumab + Dabrafenib",
         "therapy_strategy": "B-RAF inhibition + VEGF/VEGFR inhibition",
         "therapy_type": "Targeted therapy",
         "therapy_sensitivity": 1,
@@ -5774,7 +7620,29 @@
         "_deprecated": false,
         "assertion_id": 164,
         "feature_id": 164,
-        "source_id": 70
+        "source_id": 70,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C82386",
+                    "code": "C82386",
+                    "name": "Dabrafenib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C2039",
+                    "code": "C2039",
+                    "name": "Bevacizumab",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -5812,7 +7680,29 @@
         "_deprecated": false,
         "assertion_id": 165,
         "feature_id": 165,
-        "source_id": 70
+        "source_id": 70,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C82386",
+                    "code": "C82386",
+                    "name": "Dabrafenib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C88270",
+                    "code": "C88270",
+                    "name": "Omipalisib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -5850,7 +7740,29 @@
         "_deprecated": false,
         "assertion_id": 166,
         "feature_id": 166,
-        "source_id": 71
+        "source_id": 71,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C66939",
+                    "code": "C66939",
+                    "name": "Selumetinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C64768",
+                    "code": "C64768",
+                    "name": "Vemurafenib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -5888,7 +7800,19 @@
         "_deprecated": false,
         "assertion_id": 167,
         "feature_id": 167,
-        "source_id": 72
+        "source_id": 72,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C313",
+                    "code": "C313",
+                    "name": "Bleomycin",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -5926,7 +7850,8 @@
         "_deprecated": false,
         "assertion_id": 168,
         "feature_id": 168,
-        "source_id": 73
+        "source_id": 73,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -5964,7 +7889,19 @@
         "_deprecated": false,
         "assertion_id": 169,
         "feature_id": 169,
-        "source_id": 74
+        "source_id": 74,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C64768",
+                    "code": "C64768",
+                    "name": "Vemurafenib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -6002,7 +7939,19 @@
         "_deprecated": false,
         "assertion_id": 170,
         "feature_id": 170,
-        "source_id": 74
+        "source_id": 74,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C64768",
+                    "code": "C64768",
+                    "name": "Vemurafenib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -6040,7 +7989,19 @@
         "_deprecated": false,
         "assertion_id": 171,
         "feature_id": 171,
-        "source_id": 74
+        "source_id": 74,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C64768",
+                    "code": "C64768",
+                    "name": "Vemurafenib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -6078,7 +8039,19 @@
         "_deprecated": false,
         "assertion_id": 172,
         "feature_id": 172,
-        "source_id": 75
+        "source_id": 75,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C77908",
+                    "code": "C77908",
+                    "name": "Trametinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -6116,7 +8089,29 @@
         "_deprecated": false,
         "assertion_id": 173,
         "feature_id": 173,
-        "source_id": 76
+        "source_id": 76,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C82386",
+                    "code": "C82386",
+                    "name": "Dabrafenib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C77908",
+                    "code": "C77908",
+                    "name": "Trametinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -6154,7 +8149,29 @@
         "_deprecated": false,
         "assertion_id": 174,
         "feature_id": 174,
-        "source_id": 76
+        "source_id": 76,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C77908",
+                    "code": "C77908",
+                    "name": "Trametinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C64768",
+                    "code": "C64768",
+                    "name": "Vemurafenib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -6173,7 +8190,7 @@
         "context": "",
         "oncotree_term": "Melanoma",
         "oncotree_code": "MEL",
-        "therapy_name": "Interferon-alpha + Ixazomib",
+        "therapy_name": "Interferon Alpha + Ixazomib",
         "therapy_strategy": "Interferon-alpha + Proteasome inhibition",
         "therapy_type": "Targeted therapy",
         "therapy_sensitivity": 1,
@@ -6192,7 +8209,29 @@
         "_deprecated": false,
         "assertion_id": 175,
         "feature_id": 175,
-        "source_id": 77
+        "source_id": 77,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C20494",
+                    "code": "C20494",
+                    "name": "Interferon Alpha",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C97940",
+                    "code": "C97940",
+                    "name": "Ixazomib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -6230,7 +8269,19 @@
         "_deprecated": false,
         "assertion_id": 176,
         "feature_id": 176,
-        "source_id": 78
+        "source_id": 78,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C82386",
+                    "code": "C82386",
+                    "name": "Dabrafenib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -6268,7 +8319,19 @@
         "_deprecated": false,
         "assertion_id": 177,
         "feature_id": 177,
-        "source_id": 78
+        "source_id": 78,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C64768",
+                    "code": "C64768",
+                    "name": "Vemurafenib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -6306,7 +8369,29 @@
         "_deprecated": false,
         "assertion_id": 178,
         "feature_id": 178,
-        "source_id": 78
+        "source_id": 78,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C82386",
+                    "code": "C82386",
+                    "name": "Dabrafenib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C77908",
+                    "code": "C77908",
+                    "name": "Trametinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -6344,7 +8429,19 @@
         "_deprecated": false,
         "assertion_id": 179,
         "feature_id": 179,
-        "source_id": 78
+        "source_id": 78,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C77908",
+                    "code": "C77908",
+                    "name": "Trametinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -6382,7 +8479,19 @@
         "_deprecated": false,
         "assertion_id": 180,
         "feature_id": 180,
-        "source_id": 54
+        "source_id": 54,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C64768",
+                    "code": "C64768",
+                    "name": "Vemurafenib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -6420,7 +8529,29 @@
         "_deprecated": false,
         "assertion_id": 181,
         "feature_id": 181,
-        "source_id": 79
+        "source_id": 79,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C49094",
+                    "code": "C49094",
+                    "name": "Neratinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C64768",
+                    "code": "C64768",
+                    "name": "Vemurafenib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -6458,7 +8589,19 @@
         "_deprecated": false,
         "assertion_id": 182,
         "feature_id": 182,
-        "source_id": 66
+        "source_id": 66,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C1723",
+                    "code": "C1723",
+                    "name": "Cetuximab",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -6496,7 +8639,8 @@
         "_deprecated": false,
         "assertion_id": 183,
         "feature_id": 183,
-        "source_id": 80
+        "source_id": 80,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -6534,7 +8678,29 @@
         "_deprecated": false,
         "assertion_id": 184,
         "feature_id": 184,
-        "source_id": 74
+        "source_id": 74,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C1723",
+                    "code": "C1723",
+                    "name": "Cetuximab",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C64768",
+                    "code": "C64768",
+                    "name": "Vemurafenib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -6572,7 +8738,19 @@
         "_deprecated": false,
         "assertion_id": 185,
         "feature_id": 185,
-        "source_id": 81
+        "source_id": 81,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C71721",
+                    "code": "C71721",
+                    "name": "Olaparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -6610,7 +8788,19 @@
         "_deprecated": false,
         "assertion_id": 186,
         "feature_id": 186,
-        "source_id": 81
+        "source_id": 81,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C71721",
+                    "code": "C71721",
+                    "name": "Olaparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -6648,7 +8838,19 @@
         "_deprecated": false,
         "assertion_id": 187,
         "feature_id": 187,
-        "source_id": 81
+        "source_id": 81,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C71721",
+                    "code": "C71721",
+                    "name": "Olaparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -6686,7 +8888,19 @@
         "_deprecated": false,
         "assertion_id": 188,
         "feature_id": 188,
-        "source_id": 82
+        "source_id": 82,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C137800",
+                    "code": "C137800",
+                    "name": "Rucaparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -6724,7 +8938,19 @@
         "_deprecated": false,
         "assertion_id": 189,
         "feature_id": 189,
-        "source_id": 82
+        "source_id": 82,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C137800",
+                    "code": "C137800",
+                    "name": "Rucaparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -6762,7 +8988,19 @@
         "_deprecated": false,
         "assertion_id": 190,
         "feature_id": 190,
-        "source_id": 82
+        "source_id": 82,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C137800",
+                    "code": "C137800",
+                    "name": "Rucaparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -6800,7 +9038,19 @@
         "_deprecated": false,
         "assertion_id": 191,
         "feature_id": 191,
-        "source_id": 83
+        "source_id": 83,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C71721",
+                    "code": "C71721",
+                    "name": "Olaparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -6838,7 +9088,19 @@
         "_deprecated": false,
         "assertion_id": 192,
         "feature_id": 192,
-        "source_id": 84
+        "source_id": 84,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C71721",
+                    "code": "C71721",
+                    "name": "Olaparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -6857,7 +9119,7 @@
         "context": "",
         "oncotree_term": "Pancreatic Adenocarcinoma",
         "oncotree_code": "PAAD",
-        "therapy_name": "Platinum",
+        "therapy_name": "Platinum Compound",
         "therapy_strategy": "Platinum-based chemotherapy",
         "therapy_type": "Chemotherapy",
         "therapy_sensitivity": 1,
@@ -6876,7 +9138,19 @@
         "_deprecated": false,
         "assertion_id": 193,
         "feature_id": 193,
-        "source_id": 85
+        "source_id": 85,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C1450",
+                    "code": "C1450",
+                    "name": "Platinum Compound",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -6914,7 +9188,19 @@
         "_deprecated": false,
         "assertion_id": 194,
         "feature_id": 194,
-        "source_id": 86
+        "source_id": 86,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C80059",
+                    "code": "C80059",
+                    "name": "Niraparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -6952,7 +9238,19 @@
         "_deprecated": false,
         "assertion_id": 195,
         "feature_id": 195,
-        "source_id": 86
+        "source_id": 86,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C80059",
+                    "code": "C80059",
+                    "name": "Niraparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -6990,7 +9288,19 @@
         "_deprecated": false,
         "assertion_id": 196,
         "feature_id": 196,
-        "source_id": 86
+        "source_id": 86,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C80059",
+                    "code": "C80059",
+                    "name": "Niraparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -7028,7 +9338,19 @@
         "_deprecated": false,
         "assertion_id": 197,
         "feature_id": 197,
-        "source_id": 58
+        "source_id": 58,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C71721",
+                    "code": "C71721",
+                    "name": "Olaparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -7066,7 +9388,29 @@
         "_deprecated": false,
         "assertion_id": 198,
         "feature_id": 198,
-        "source_id": 87
+        "source_id": 87,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C2039",
+                    "code": "C2039",
+                    "name": "Bevacizumab",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C71721",
+                    "code": "C71721",
+                    "name": "Olaparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -7104,7 +9448,29 @@
         "_deprecated": false,
         "assertion_id": 199,
         "feature_id": 199,
-        "source_id": 87
+        "source_id": 87,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C2039",
+                    "code": "C2039",
+                    "name": "Bevacizumab",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C71721",
+                    "code": "C71721",
+                    "name": "Olaparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -7142,7 +9508,29 @@
         "_deprecated": false,
         "assertion_id": 200,
         "feature_id": 200,
-        "source_id": 87
+        "source_id": 87,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C2039",
+                    "code": "C2039",
+                    "name": "Bevacizumab",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C71721",
+                    "code": "C71721",
+                    "name": "Olaparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -7180,7 +9568,19 @@
         "_deprecated": false,
         "assertion_id": 201,
         "feature_id": 201,
-        "source_id": 86
+        "source_id": 86,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C80059",
+                    "code": "C80059",
+                    "name": "Niraparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -7218,7 +9618,19 @@
         "_deprecated": false,
         "assertion_id": 202,
         "feature_id": 202,
-        "source_id": 86
+        "source_id": 86,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C80059",
+                    "code": "C80059",
+                    "name": "Niraparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -7256,7 +9668,19 @@
         "_deprecated": false,
         "assertion_id": 203,
         "feature_id": 203,
-        "source_id": 86
+        "source_id": 86,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C80059",
+                    "code": "C80059",
+                    "name": "Niraparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -7294,7 +9718,19 @@
         "_deprecated": false,
         "assertion_id": 204,
         "feature_id": 204,
-        "source_id": 81
+        "source_id": 81,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C71721",
+                    "code": "C71721",
+                    "name": "Olaparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -7332,7 +9768,19 @@
         "_deprecated": false,
         "assertion_id": 205,
         "feature_id": 205,
-        "source_id": 81
+        "source_id": 81,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C71721",
+                    "code": "C71721",
+                    "name": "Olaparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -7370,7 +9818,19 @@
         "_deprecated": false,
         "assertion_id": 206,
         "feature_id": 206,
-        "source_id": 81
+        "source_id": 81,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C71721",
+                    "code": "C71721",
+                    "name": "Olaparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -7408,7 +9868,19 @@
         "_deprecated": false,
         "assertion_id": 207,
         "feature_id": 207,
-        "source_id": 82
+        "source_id": 82,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C137800",
+                    "code": "C137800",
+                    "name": "Rucaparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -7446,7 +9918,19 @@
         "_deprecated": false,
         "assertion_id": 208,
         "feature_id": 208,
-        "source_id": 82
+        "source_id": 82,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C137800",
+                    "code": "C137800",
+                    "name": "Rucaparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -7484,7 +9968,19 @@
         "_deprecated": false,
         "assertion_id": 209,
         "feature_id": 209,
-        "source_id": 82
+        "source_id": 82,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C137800",
+                    "code": "C137800",
+                    "name": "Rucaparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -7522,7 +10018,19 @@
         "_deprecated": false,
         "assertion_id": 210,
         "feature_id": 210,
-        "source_id": 83
+        "source_id": 83,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C71721",
+                    "code": "C71721",
+                    "name": "Olaparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -7560,7 +10068,19 @@
         "_deprecated": false,
         "assertion_id": 211,
         "feature_id": 211,
-        "source_id": 84
+        "source_id": 84,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C71721",
+                    "code": "C71721",
+                    "name": "Olaparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -7598,7 +10118,19 @@
         "_deprecated": false,
         "assertion_id": 212,
         "feature_id": 212,
-        "source_id": 88
+        "source_id": 88,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C71721",
+                    "code": "C71721",
+                    "name": "Olaparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -7617,7 +10149,7 @@
         "context": "",
         "oncotree_term": "Pancreatic Adenocarcinoma",
         "oncotree_code": "PAAD",
-        "therapy_name": "Platinum",
+        "therapy_name": "Platinum Compound",
         "therapy_strategy": "Platinum-based chemotherapy",
         "therapy_type": "Chemotherapy",
         "therapy_sensitivity": 1,
@@ -7636,7 +10168,19 @@
         "_deprecated": false,
         "assertion_id": 213,
         "feature_id": 213,
-        "source_id": 85
+        "source_id": 85,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C1450",
+                    "code": "C1450",
+                    "name": "Platinum Compound",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -7674,7 +10218,29 @@
         "_deprecated": false,
         "assertion_id": 214,
         "feature_id": 214,
-        "source_id": 89
+        "source_id": 89,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C68814",
+                    "code": "C68814",
+                    "name": "Nivolumab",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C106432",
+                    "code": "C106432",
+                    "name": "Pembrolizumab",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -7712,7 +10278,19 @@
         "_deprecated": false,
         "assertion_id": 215,
         "feature_id": 215,
-        "source_id": 58
+        "source_id": 58,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C71721",
+                    "code": "C71721",
+                    "name": "Olaparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -7750,7 +10328,29 @@
         "_deprecated": false,
         "assertion_id": 216,
         "feature_id": 216,
-        "source_id": 87
+        "source_id": 87,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C2039",
+                    "code": "C2039",
+                    "name": "Bevacizumab",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C71721",
+                    "code": "C71721",
+                    "name": "Olaparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -7788,7 +10388,29 @@
         "_deprecated": false,
         "assertion_id": 217,
         "feature_id": 217,
-        "source_id": 87
+        "source_id": 87,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C2039",
+                    "code": "C2039",
+                    "name": "Bevacizumab",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C71721",
+                    "code": "C71721",
+                    "name": "Olaparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -7826,7 +10448,29 @@
         "_deprecated": false,
         "assertion_id": 218,
         "feature_id": 218,
-        "source_id": 87
+        "source_id": 87,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C2039",
+                    "code": "C2039",
+                    "name": "Bevacizumab",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C71721",
+                    "code": "C71721",
+                    "name": "Olaparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -7864,7 +10508,8 @@
         "_deprecated": false,
         "assertion_id": 219,
         "feature_id": 219,
-        "source_id": 59
+        "source_id": 59,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -7902,7 +10547,8 @@
         "_deprecated": false,
         "assertion_id": 220,
         "feature_id": 220,
-        "source_id": 59
+        "source_id": 59,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -7940,7 +10586,8 @@
         "_deprecated": false,
         "assertion_id": 221,
         "feature_id": 221,
-        "source_id": 59
+        "source_id": 59,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -7978,7 +10625,8 @@
         "_deprecated": false,
         "assertion_id": 222,
         "feature_id": 222,
-        "source_id": 59
+        "source_id": 59,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -8016,7 +10664,8 @@
         "_deprecated": false,
         "assertion_id": 223,
         "feature_id": 223,
-        "source_id": 59
+        "source_id": 59,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -8054,7 +10703,8 @@
         "_deprecated": false,
         "assertion_id": 224,
         "feature_id": 224,
-        "source_id": 59
+        "source_id": 59,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -8092,7 +10742,19 @@
         "_deprecated": false,
         "assertion_id": 225,
         "feature_id": 225,
-        "source_id": 58
+        "source_id": 58,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C71721",
+                    "code": "C71721",
+                    "name": "Olaparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -8130,7 +10792,19 @@
         "_deprecated": false,
         "assertion_id": 226,
         "feature_id": 226,
-        "source_id": 58
+        "source_id": 58,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C71721",
+                    "code": "C71721",
+                    "name": "Olaparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -8168,7 +10842,8 @@
         "_deprecated": false,
         "assertion_id": 227,
         "feature_id": 227,
-        "source_id": 59
+        "source_id": 59,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -8206,7 +10881,8 @@
         "_deprecated": false,
         "assertion_id": 228,
         "feature_id": 228,
-        "source_id": 59
+        "source_id": 59,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -8244,7 +10920,8 @@
         "_deprecated": false,
         "assertion_id": 229,
         "feature_id": 229,
-        "source_id": 59
+        "source_id": 59,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -8263,7 +10940,7 @@
         "context": "Primary",
         "oncotree_term": "Ovarian Cancer, Other",
         "oncotree_code": "OOVC",
-        "therapy_name": "Platinum",
+        "therapy_name": "Platinum Compound",
         "therapy_strategy": "Platinum-based chemotherapy",
         "therapy_type": "Chemotherapy",
         "therapy_sensitivity": 1,
@@ -8282,7 +10959,19 @@
         "_deprecated": false,
         "assertion_id": 230,
         "feature_id": 230,
-        "source_id": 59
+        "source_id": 59,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C1450",
+                    "code": "C1450",
+                    "name": "Platinum Compound",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -8301,7 +10990,7 @@
         "context": "Primary",
         "oncotree_term": "Peritoneal Mesothelioma",
         "oncotree_code": "PEMESO",
-        "therapy_name": "Platinum",
+        "therapy_name": "Platinum Compound",
         "therapy_strategy": "Platinum-based chemotherapy",
         "therapy_type": "Chemotherapy",
         "therapy_sensitivity": 1,
@@ -8320,7 +11009,19 @@
         "_deprecated": false,
         "assertion_id": 231,
         "feature_id": 231,
-        "source_id": 59
+        "source_id": 59,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C1450",
+                    "code": "C1450",
+                    "name": "Platinum Compound",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -8339,7 +11040,7 @@
         "context": "Primary",
         "oncotree_term": "Serous Ovarian Cancer",
         "oncotree_code": "SOC",
-        "therapy_name": "Platinum",
+        "therapy_name": "Platinum Compound",
         "therapy_strategy": "Platinum-based chemotherapy",
         "therapy_type": "Chemotherapy",
         "therapy_sensitivity": 1,
@@ -8358,7 +11059,19 @@
         "_deprecated": false,
         "assertion_id": 232,
         "feature_id": 232,
-        "source_id": 59
+        "source_id": 59,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C1450",
+                    "code": "C1450",
+                    "name": "Platinum Compound",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -8396,7 +11109,19 @@
         "_deprecated": false,
         "assertion_id": 233,
         "feature_id": 233,
-        "source_id": 58
+        "source_id": 58,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C71721",
+                    "code": "C71721",
+                    "name": "Olaparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -8434,7 +11159,8 @@
         "_deprecated": false,
         "assertion_id": 234,
         "feature_id": 234,
-        "source_id": 59
+        "source_id": 59,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -8472,7 +11198,8 @@
         "_deprecated": false,
         "assertion_id": 235,
         "feature_id": 235,
-        "source_id": 59
+        "source_id": 59,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -8510,7 +11237,8 @@
         "_deprecated": false,
         "assertion_id": 236,
         "feature_id": 236,
-        "source_id": 59
+        "source_id": 59,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -8529,7 +11257,7 @@
         "context": "Primary",
         "oncotree_term": "Ovarian Cancer, Other",
         "oncotree_code": "OOVC",
-        "therapy_name": "Platinum",
+        "therapy_name": "Platinum Compound",
         "therapy_strategy": "Platinum-based chemotherapy",
         "therapy_type": "Chemotherapy",
         "therapy_sensitivity": 1,
@@ -8548,7 +11276,19 @@
         "_deprecated": false,
         "assertion_id": 237,
         "feature_id": 237,
-        "source_id": 59
+        "source_id": 59,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C1450",
+                    "code": "C1450",
+                    "name": "Platinum Compound",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -8567,7 +11307,7 @@
         "context": "Primary",
         "oncotree_term": "Peritoneal Mesothelioma",
         "oncotree_code": "PEMESO",
-        "therapy_name": "Platinum",
+        "therapy_name": "Platinum Compound",
         "therapy_strategy": "Platinum-based chemotherapy",
         "therapy_type": "Chemotherapy",
         "therapy_sensitivity": 1,
@@ -8586,7 +11326,19 @@
         "_deprecated": false,
         "assertion_id": 238,
         "feature_id": 238,
-        "source_id": 59
+        "source_id": 59,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C1450",
+                    "code": "C1450",
+                    "name": "Platinum Compound",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -8605,7 +11357,7 @@
         "context": "Primary",
         "oncotree_term": "Serous Ovarian Cancer",
         "oncotree_code": "SOC",
-        "therapy_name": "Platinum",
+        "therapy_name": "Platinum Compound",
         "therapy_strategy": "Platinum-based chemotherapy",
         "therapy_type": "Chemotherapy",
         "therapy_sensitivity": 1,
@@ -8624,7 +11376,19 @@
         "_deprecated": false,
         "assertion_id": 239,
         "feature_id": 239,
-        "source_id": 59
+        "source_id": 59,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C1450",
+                    "code": "C1450",
+                    "name": "Platinum Compound",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -8662,7 +11426,19 @@
         "_deprecated": false,
         "assertion_id": 240,
         "feature_id": 240,
-        "source_id": 58
+        "source_id": 58,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C71721",
+                    "code": "C71721",
+                    "name": "Olaparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -8700,7 +11476,8 @@
         "_deprecated": false,
         "assertion_id": 241,
         "feature_id": 241,
-        "source_id": 90
+        "source_id": 90,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -8738,7 +11515,19 @@
         "_deprecated": false,
         "assertion_id": 242,
         "feature_id": 242,
-        "source_id": 91
+        "source_id": 91,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C116377",
+                    "code": "C116377",
+                    "name": "Osimertinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -8776,7 +11565,19 @@
         "_deprecated": false,
         "assertion_id": 243,
         "feature_id": 243,
-        "source_id": 20
+        "source_id": 20,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C65530",
+                    "code": "C65530",
+                    "name": "Erlotinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -8814,7 +11615,19 @@
         "_deprecated": false,
         "assertion_id": 244,
         "feature_id": 244,
-        "source_id": 20
+        "source_id": 20,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C1855",
+                    "code": "C1855",
+                    "name": "Gefitinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -8852,7 +11665,19 @@
         "_deprecated": false,
         "assertion_id": 245,
         "feature_id": 245,
-        "source_id": 20
+        "source_id": 20,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C1855",
+                    "code": "C1855",
+                    "name": "Gefitinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -8890,7 +11715,19 @@
         "_deprecated": false,
         "assertion_id": 246,
         "feature_id": 246,
-        "source_id": 20
+        "source_id": 20,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C66940",
+                    "code": "C66940",
+                    "name": "Afatinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -8928,7 +11765,19 @@
         "_deprecated": false,
         "assertion_id": 247,
         "feature_id": 247,
-        "source_id": 20
+        "source_id": 20,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C1855",
+                    "code": "C1855",
+                    "name": "Gefitinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -8966,7 +11815,19 @@
         "_deprecated": false,
         "assertion_id": 248,
         "feature_id": 248,
-        "source_id": 20
+        "source_id": 20,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C1855",
+                    "code": "C1855",
+                    "name": "Gefitinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -9004,7 +11865,29 @@
         "_deprecated": false,
         "assertion_id": 249,
         "feature_id": 249,
-        "source_id": 92
+        "source_id": 92,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C103194",
+                    "code": "C103194",
+                    "name": "Durvalumab",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C116377",
+                    "code": "C116377",
+                    "name": "Osimertinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -9042,7 +11925,19 @@
         "_deprecated": false,
         "assertion_id": 250,
         "feature_id": 250,
-        "source_id": 93
+        "source_id": 93,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C101791",
+                    "code": "C101791",
+                    "name": "Olmutinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -9080,7 +11975,19 @@
         "_deprecated": false,
         "assertion_id": 251,
         "feature_id": 251,
-        "source_id": 94
+        "source_id": 94,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C52200",
+                    "code": "C52200",
+                    "name": "Cabozantinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -9118,7 +12025,19 @@
         "_deprecated": false,
         "assertion_id": 252,
         "feature_id": 252,
-        "source_id": 94
+        "source_id": 94,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C90564",
+                    "code": "C90564",
+                    "name": "Capmatinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -9137,7 +12056,7 @@
         "context": "",
         "oncotree_term": "Non-Small Cell Lung Cancer",
         "oncotree_code": "NSCLC",
-        "therapy_name": "AZD3759",
+        "therapy_name": "Zorifertinib",
         "therapy_strategy": "EGFR inhibition",
         "therapy_type": "Targeted therapy",
         "therapy_sensitivity": 1,
@@ -9156,7 +12075,19 @@
         "_deprecated": false,
         "assertion_id": 253,
         "feature_id": 253,
-        "source_id": 94
+        "source_id": 94,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C118289",
+                    "code": "C118289",
+                    "name": "Zorifertinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -9194,7 +12125,19 @@
         "_deprecated": false,
         "assertion_id": 254,
         "feature_id": 254,
-        "source_id": 94
+        "source_id": 94,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C53398",
+                    "code": "C53398",
+                    "name": "Dacomitinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -9232,7 +12175,19 @@
         "_deprecated": false,
         "assertion_id": 255,
         "feature_id": 255,
-        "source_id": 94
+        "source_id": 94,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C138996",
+                    "code": "C138996",
+                    "name": "Icotinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -9270,7 +12225,19 @@
         "_deprecated": false,
         "assertion_id": 256,
         "feature_id": 256,
-        "source_id": 94
+        "source_id": 94,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C116377",
+                    "code": "C116377",
+                    "name": "Osimertinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -9308,7 +12275,19 @@
         "_deprecated": false,
         "assertion_id": 257,
         "feature_id": 257,
-        "source_id": 95
+        "source_id": 95,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C99905",
+                    "code": "C99905",
+                    "name": "Rociletinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -9346,7 +12325,19 @@
         "_deprecated": false,
         "assertion_id": 258,
         "feature_id": 258,
-        "source_id": 96
+        "source_id": 96,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C1855",
+                    "code": "C1855",
+                    "name": "Gefitinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -9384,7 +12375,19 @@
         "_deprecated": false,
         "assertion_id": 259,
         "feature_id": 259,
-        "source_id": 97
+        "source_id": 97,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C116377",
+                    "code": "C116377",
+                    "name": "Osimertinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -9403,7 +12406,7 @@
         "context": "",
         "oncotree_term": "Non-Small Cell Lung Cancer",
         "oncotree_code": "NSCLC",
-        "therapy_name": "EGF816",
+        "therapy_name": "Nazartinib",
         "therapy_strategy": "EGFR inhibition",
         "therapy_type": "Targeted therapy",
         "therapy_sensitivity": 1,
@@ -9422,7 +12425,19 @@
         "_deprecated": false,
         "assertion_id": 260,
         "feature_id": 260,
-        "source_id": 97
+        "source_id": 97,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C115109",
+                    "code": "C115109",
+                    "name": "Nazartinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -9441,7 +12456,7 @@
         "context": "",
         "oncotree_term": "Non-Small Cell Lung Cancer",
         "oncotree_code": "NSCLC",
-        "therapy_name": "EGF816",
+        "therapy_name": "Nazartinib",
         "therapy_strategy": "EGFR inhibition",
         "therapy_type": "Targeted therapy",
         "therapy_sensitivity": 1,
@@ -9460,7 +12475,19 @@
         "_deprecated": false,
         "assertion_id": 261,
         "feature_id": 261,
-        "source_id": 97
+        "source_id": 97,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C115109",
+                    "code": "C115109",
+                    "name": "Nazartinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -9479,7 +12506,7 @@
         "context": "",
         "oncotree_term": "Non-Small Cell Lung Cancer",
         "oncotree_code": "NSCLC",
-        "therapy_name": "PF-06747775",
+        "therapy_name": "Mavelertinib",
         "therapy_strategy": "EGFR inhibition",
         "therapy_type": "Targeted therapy",
         "therapy_sensitivity": 1,
@@ -9498,7 +12525,19 @@
         "_deprecated": false,
         "assertion_id": 262,
         "feature_id": 262,
-        "source_id": 97
+        "source_id": 97,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C120307",
+                    "code": "C120307",
+                    "name": "Mavelertinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -9517,7 +12556,7 @@
         "context": "",
         "oncotree_term": "Non-Small Cell Lung Cancer",
         "oncotree_code": "NSCLC",
-        "therapy_name": "PF-06747775",
+        "therapy_name": "Mavelertinib",
         "therapy_strategy": "EGFR inhibition",
         "therapy_type": "Targeted therapy",
         "therapy_sensitivity": 1,
@@ -9536,7 +12575,19 @@
         "_deprecated": false,
         "assertion_id": 263,
         "feature_id": 263,
-        "source_id": 97
+        "source_id": 97,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C120307",
+                    "code": "C120307",
+                    "name": "Mavelertinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -9574,7 +12625,19 @@
         "_deprecated": false,
         "assertion_id": 264,
         "feature_id": 264,
-        "source_id": 98
+        "source_id": 98,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C65530",
+                    "code": "C65530",
+                    "name": "Erlotinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -9612,7 +12675,19 @@
         "_deprecated": false,
         "assertion_id": 265,
         "feature_id": 265,
-        "source_id": 98
+        "source_id": 98,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C66940",
+                    "code": "C66940",
+                    "name": "Afatinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -9650,7 +12725,19 @@
         "_deprecated": false,
         "assertion_id": 266,
         "feature_id": 266,
-        "source_id": 99
+        "source_id": 99,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C66940",
+                    "code": "C66940",
+                    "name": "Afatinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -9688,7 +12775,19 @@
         "_deprecated": false,
         "assertion_id": 267,
         "feature_id": 267,
-        "source_id": 99
+        "source_id": 99,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C66940",
+                    "code": "C66940",
+                    "name": "Afatinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -9726,7 +12825,19 @@
         "_deprecated": false,
         "assertion_id": 268,
         "feature_id": 268,
-        "source_id": 99
+        "source_id": 99,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C66940",
+                    "code": "C66940",
+                    "name": "Afatinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -9764,7 +12875,19 @@
         "_deprecated": false,
         "assertion_id": 269,
         "feature_id": 269,
-        "source_id": 19
+        "source_id": 19,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C15382",
+                    "code": "C15382",
+                    "name": "Gamma knife",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -9802,7 +12925,19 @@
         "_deprecated": false,
         "assertion_id": 270,
         "feature_id": 270,
-        "source_id": 100
+        "source_id": 100,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C116377",
+                    "code": "C116377",
+                    "name": "Osimertinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -9840,7 +12975,19 @@
         "_deprecated": false,
         "assertion_id": 271,
         "feature_id": 271,
-        "source_id": 100
+        "source_id": 100,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C116377",
+                    "code": "C116377",
+                    "name": "Osimertinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -9878,7 +13025,19 @@
         "_deprecated": false,
         "assertion_id": 272,
         "feature_id": 272,
-        "source_id": 101
+        "source_id": 101,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C116377",
+                    "code": "C116377",
+                    "name": "Osimertinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -9916,7 +13075,19 @@
         "_deprecated": false,
         "assertion_id": 273,
         "feature_id": 273,
-        "source_id": 101
+        "source_id": 101,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C116377",
+                    "code": "C116377",
+                    "name": "Osimertinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -9935,7 +13106,7 @@
         "context": "Locally advanced or metastatic disease which has progressed on or after platinum-based chemotherapy.",
         "oncotree_term": "Non-Small Cell Lung Cancer",
         "oncotree_code": "NSCLC",
-        "therapy_name": "Amivantamab-vmjw",
+        "therapy_name": "Amivantamab",
         "therapy_strategy": "EGFR inhibition",
         "therapy_type": "Targeted therapy",
         "therapy_sensitivity": 1,
@@ -9954,7 +13125,19 @@
         "_deprecated": false,
         "assertion_id": 274,
         "feature_id": 274,
-        "source_id": 102
+        "source_id": 102,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C124993",
+                    "code": "C124993",
+                    "name": "Amivantamab",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -9992,7 +13175,19 @@
         "_deprecated": false,
         "assertion_id": 275,
         "feature_id": 275,
-        "source_id": 103
+        "source_id": 103,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C126752",
+                    "code": "C126752",
+                    "name": "Mobocertinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -10030,7 +13225,19 @@
         "_deprecated": false,
         "assertion_id": 276,
         "feature_id": 276,
-        "source_id": 104
+        "source_id": 104,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C49094",
+                    "code": "C49094",
+                    "name": "Neratinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -10049,7 +13256,7 @@
         "context": "Metastatic",
         "oncotree_term": "Non-Small Cell Lung Cancer",
         "oncotree_code": "NSCLC",
-        "therapy_name": "Ado-Trastuzumab Emtansine",
+        "therapy_name": "Trastuzumab Emtansine",
         "therapy_strategy": "ER signaling inhibition",
         "therapy_type": "Hormone therapy",
         "therapy_sensitivity": 1,
@@ -10068,7 +13275,19 @@
         "_deprecated": false,
         "assertion_id": 277,
         "feature_id": 277,
-        "source_id": 11
+        "source_id": 11,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C82492",
+                    "code": "C82492",
+                    "name": "Trastuzumab Emtansine",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -10106,7 +13325,19 @@
         "_deprecated": false,
         "assertion_id": 278,
         "feature_id": 278,
-        "source_id": 104
+        "source_id": 104,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C49094",
+                    "code": "C49094",
+                    "name": "Neratinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -10144,7 +13375,19 @@
         "_deprecated": false,
         "assertion_id": 279,
         "feature_id": 279,
-        "source_id": 105
+        "source_id": 105,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C376",
+                    "code": "C376",
+                    "name": "Cisplatin",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -10182,7 +13425,19 @@
         "_deprecated": false,
         "assertion_id": 280,
         "feature_id": 280,
-        "source_id": 106
+        "source_id": 106,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C376",
+                    "code": "C376",
+                    "name": "Cisplatin",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -10220,7 +13475,19 @@
         "_deprecated": false,
         "assertion_id": 281,
         "feature_id": 281,
-        "source_id": 23
+        "source_id": 23,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C65530",
+                    "code": "C65530",
+                    "name": "Erlotinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -10258,7 +13525,29 @@
         "_deprecated": false,
         "assertion_id": 282,
         "feature_id": 282,
-        "source_id": 107
+        "source_id": 107,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C1527",
+                    "code": "C1527",
+                    "name": "Letrozole",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C62078",
+                    "code": "C62078",
+                    "name": "Tamoxifen",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -10296,7 +13585,8 @@
         "_deprecated": false,
         "assertion_id": 283,
         "feature_id": 283,
-        "source_id": 33
+        "source_id": 33,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -10334,7 +13624,8 @@
         "_deprecated": false,
         "assertion_id": 284,
         "feature_id": 284,
-        "source_id": 33
+        "source_id": 33,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -10372,7 +13663,8 @@
         "_deprecated": false,
         "assertion_id": 285,
         "feature_id": 285,
-        "source_id": 33
+        "source_id": 33,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -10410,7 +13702,8 @@
         "_deprecated": false,
         "assertion_id": 286,
         "feature_id": 286,
-        "source_id": 33
+        "source_id": 33,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -10448,7 +13741,19 @@
         "_deprecated": false,
         "assertion_id": 287,
         "feature_id": 287,
-        "source_id": 108
+        "source_id": 108,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C107506",
+                    "code": "C107506",
+                    "name": "Tazemetostat",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -10486,7 +13791,19 @@
         "_deprecated": false,
         "assertion_id": 288,
         "feature_id": 288,
-        "source_id": 108
+        "source_id": 108,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C107506",
+                    "code": "C107506",
+                    "name": "Tazemetostat",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -10524,7 +13841,19 @@
         "_deprecated": false,
         "assertion_id": 289,
         "feature_id": 289,
-        "source_id": 108
+        "source_id": 108,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C107506",
+                    "code": "C107506",
+                    "name": "Tazemetostat",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -10562,7 +13891,19 @@
         "_deprecated": false,
         "assertion_id": 290,
         "feature_id": 290,
-        "source_id": 108
+        "source_id": 108,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C107506",
+                    "code": "C107506",
+                    "name": "Tazemetostat",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -10600,7 +13941,19 @@
         "_deprecated": false,
         "assertion_id": 291,
         "feature_id": 291,
-        "source_id": 108
+        "source_id": 108,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C107506",
+                    "code": "C107506",
+                    "name": "Tazemetostat",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -10638,7 +13991,19 @@
         "_deprecated": false,
         "assertion_id": 292,
         "feature_id": 292,
-        "source_id": 58
+        "source_id": 58,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C71721",
+                    "code": "C71721",
+                    "name": "Olaparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -10676,7 +14041,19 @@
         "_deprecated": false,
         "assertion_id": 293,
         "feature_id": 293,
-        "source_id": 109
+        "source_id": 109,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C1212",
+                    "code": "C1212",
+                    "name": "Sirolimus",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -10714,7 +14091,19 @@
         "_deprecated": false,
         "assertion_id": 294,
         "feature_id": 294,
-        "source_id": 26
+        "source_id": 26,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C103273",
+                    "code": "C103273",
+                    "name": "Erdafitinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -10752,7 +14141,19 @@
         "_deprecated": false,
         "assertion_id": 295,
         "feature_id": 295,
-        "source_id": 26
+        "source_id": 26,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C103273",
+                    "code": "C103273",
+                    "name": "Erdafitinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -10790,7 +14191,19 @@
         "_deprecated": false,
         "assertion_id": 296,
         "feature_id": 296,
-        "source_id": 26
+        "source_id": 26,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C103273",
+                    "code": "C103273",
+                    "name": "Erdafitinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -10828,7 +14241,19 @@
         "_deprecated": false,
         "assertion_id": 297,
         "feature_id": 297,
-        "source_id": 26
+        "source_id": 26,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C103273",
+                    "code": "C103273",
+                    "name": "Erdafitinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -10866,7 +14291,19 @@
         "_deprecated": false,
         "assertion_id": 298,
         "feature_id": 298,
-        "source_id": 110
+        "source_id": 110,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C48387",
+                    "code": "C48387",
+                    "name": "Everolimus",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -10904,7 +14341,19 @@
         "_deprecated": false,
         "assertion_id": 299,
         "feature_id": 299,
-        "source_id": 110
+        "source_id": 110,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C48387",
+                    "code": "C48387",
+                    "name": "Everolimus",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -10942,7 +14391,19 @@
         "_deprecated": false,
         "assertion_id": 300,
         "feature_id": 300,
-        "source_id": 111
+        "source_id": 111,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C48387",
+                    "code": "C48387",
+                    "name": "Everolimus",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -10980,7 +14441,19 @@
         "_deprecated": false,
         "assertion_id": 301,
         "feature_id": 301,
-        "source_id": 111
+        "source_id": 111,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C48387",
+                    "code": "C48387",
+                    "name": "Everolimus",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -11018,7 +14491,19 @@
         "_deprecated": false,
         "assertion_id": 302,
         "feature_id": 302,
-        "source_id": 111
+        "source_id": 111,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C48387",
+                    "code": "C48387",
+                    "name": "Everolimus",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -11056,7 +14541,19 @@
         "_deprecated": false,
         "assertion_id": 303,
         "feature_id": 303,
-        "source_id": 111
+        "source_id": 111,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C48387",
+                    "code": "C48387",
+                    "name": "Everolimus",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -11094,7 +14591,19 @@
         "_deprecated": false,
         "assertion_id": 304,
         "feature_id": 304,
-        "source_id": 112
+        "source_id": 112,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C68936",
+                    "code": "C68936",
+                    "name": "Quizartinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -11132,7 +14641,19 @@
         "_deprecated": false,
         "assertion_id": 305,
         "feature_id": 305,
-        "source_id": 113
+        "source_id": 113,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C71622",
+                    "code": "C71622",
+                    "name": "Sunitinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -11170,7 +14691,19 @@
         "_deprecated": false,
         "assertion_id": 306,
         "feature_id": 306,
-        "source_id": 114
+        "source_id": 114,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C1527",
+                    "code": "C1527",
+                    "name": "Letrozole",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -11208,7 +14741,19 @@
         "_deprecated": false,
         "assertion_id": 307,
         "feature_id": 307,
-        "source_id": 115
+        "source_id": 115,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C114383",
+                    "code": "C114383",
+                    "name": "Ivosidenib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -11227,7 +14772,7 @@
         "context": "",
         "oncotree_term": "Glioma",
         "oncotree_code": "GNOS",
-        "therapy_name": "Alkylating chemotherapy",
+        "therapy_name": "Antineoplastic Alkylating Agent",
         "therapy_strategy": "Alkylating chemotherapy",
         "therapy_type": "Chemotherapy",
         "therapy_sensitivity": 1,
@@ -11246,7 +14791,19 @@
         "_deprecated": false,
         "assertion_id": 308,
         "feature_id": 308,
-        "source_id": 116
+        "source_id": 116,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C1590",
+                    "code": "C1590",
+                    "name": "Antineoplastic Alkylating Agent",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -11284,7 +14841,8 @@
         "_deprecated": false,
         "assertion_id": 309,
         "feature_id": 309,
-        "source_id": 116
+        "source_id": 116,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -11322,7 +14880,19 @@
         "_deprecated": false,
         "assertion_id": 310,
         "feature_id": 310,
-        "source_id": 117
+        "source_id": 117,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C114383",
+                    "code": "C114383",
+                    "name": "Ivosidenib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -11360,7 +14930,19 @@
         "_deprecated": false,
         "assertion_id": 311,
         "feature_id": 311,
-        "source_id": 117
+        "source_id": 117,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C114383",
+                    "code": "C114383",
+                    "name": "Ivosidenib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -11398,7 +14980,19 @@
         "_deprecated": false,
         "assertion_id": 312,
         "feature_id": 312,
-        "source_id": 117
+        "source_id": 117,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C114383",
+                    "code": "C114383",
+                    "name": "Ivosidenib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -11436,7 +15030,19 @@
         "_deprecated": false,
         "assertion_id": 313,
         "feature_id": 313,
-        "source_id": 117
+        "source_id": 117,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C114383",
+                    "code": "C114383",
+                    "name": "Ivosidenib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -11474,7 +15080,19 @@
         "_deprecated": false,
         "assertion_id": 314,
         "feature_id": 314,
-        "source_id": 117
+        "source_id": 117,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C114383",
+                    "code": "C114383",
+                    "name": "Ivosidenib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -11512,7 +15130,19 @@
         "_deprecated": false,
         "assertion_id": 315,
         "feature_id": 315,
-        "source_id": 117
+        "source_id": 117,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C114383",
+                    "code": "C114383",
+                    "name": "Ivosidenib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -11550,7 +15180,19 @@
         "_deprecated": false,
         "assertion_id": 316,
         "feature_id": 316,
-        "source_id": 118
+        "source_id": 118,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C111573",
+                    "code": "C111573",
+                    "name": "Enasidenib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -11588,7 +15230,19 @@
         "_deprecated": false,
         "assertion_id": 317,
         "feature_id": 317,
-        "source_id": 118
+        "source_id": 118,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C111573",
+                    "code": "C111573",
+                    "name": "Enasidenib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -11626,7 +15280,19 @@
         "_deprecated": false,
         "assertion_id": 318,
         "feature_id": 318,
-        "source_id": 118
+        "source_id": 118,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C111573",
+                    "code": "C111573",
+                    "name": "Enasidenib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -11645,7 +15311,7 @@
         "context": "",
         "oncotree_term": "Glioma",
         "oncotree_code": "GNOS",
-        "therapy_name": "Alkylating chemotherapy",
+        "therapy_name": "Antineoplastic Alkylating Agent",
         "therapy_strategy": "Alkylating chemotherapy",
         "therapy_type": "Chemotherapy",
         "therapy_sensitivity": 1,
@@ -11664,7 +15330,19 @@
         "_deprecated": false,
         "assertion_id": 319,
         "feature_id": 319,
-        "source_id": 116
+        "source_id": 116,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C1590",
+                    "code": "C1590",
+                    "name": "Antineoplastic Alkylating Agent",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -11702,7 +15380,8 @@
         "_deprecated": false,
         "assertion_id": 320,
         "feature_id": 320,
-        "source_id": 116
+        "source_id": 116,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -11740,7 +15419,8 @@
         "_deprecated": false,
         "assertion_id": 321,
         "feature_id": 321,
-        "source_id": 33
+        "source_id": 33,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -11778,7 +15458,8 @@
         "_deprecated": false,
         "assertion_id": 322,
         "feature_id": 322,
-        "source_id": 33
+        "source_id": 33,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -11816,7 +15497,8 @@
         "_deprecated": false,
         "assertion_id": 323,
         "feature_id": 323,
-        "source_id": 33
+        "source_id": 33,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -11854,7 +15536,8 @@
         "_deprecated": false,
         "assertion_id": 324,
         "feature_id": 324,
-        "source_id": 119
+        "source_id": 119,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -11873,7 +15556,7 @@
         "context": "",
         "oncotree_term": "Acute Lymphoid Leukemia",
         "oncotree_code": "ALL",
-        "therapy_name": "PU-H71",
+        "therapy_name": "Zelavespib",
         "therapy_strategy": "HSP90 inhibition",
         "therapy_type": "Targeted therapy",
         "therapy_sensitivity": 1,
@@ -11892,7 +15575,19 @@
         "_deprecated": false,
         "assertion_id": 325,
         "feature_id": 325,
-        "source_id": 120
+        "source_id": 120,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C101227",
+                    "code": "C101227",
+                    "name": "Zelavespib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -11911,7 +15606,7 @@
         "context": "",
         "oncotree_term": "Acute Lymphoid Leukemia",
         "oncotree_code": "ALL",
-        "therapy_name": "PU-H71",
+        "therapy_name": "Zelavespib",
         "therapy_strategy": "HSP90 inhibition",
         "therapy_type": "Targeted therapy",
         "therapy_sensitivity": 1,
@@ -11930,7 +15625,19 @@
         "_deprecated": false,
         "assertion_id": 326,
         "feature_id": 326,
-        "source_id": 120
+        "source_id": 120,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C101227",
+                    "code": "C101227",
+                    "name": "Zelavespib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -11968,7 +15675,8 @@
         "_deprecated": false,
         "assertion_id": 327,
         "feature_id": 327,
-        "source_id": 119
+        "source_id": 119,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -12006,7 +15714,8 @@
         "_deprecated": false,
         "assertion_id": 328,
         "feature_id": 328,
-        "source_id": 121
+        "source_id": 121,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -12044,7 +15753,19 @@
         "_deprecated": false,
         "assertion_id": 329,
         "feature_id": 329,
-        "source_id": 122
+        "source_id": 122,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C77888",
+                    "code": "C77888",
+                    "name": "Ruxolitinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -12082,7 +15803,19 @@
         "_deprecated": false,
         "assertion_id": 330,
         "feature_id": 330,
-        "source_id": 122
+        "source_id": 122,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C77888",
+                    "code": "C77888",
+                    "name": "Ruxolitinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -12120,7 +15853,19 @@
         "_deprecated": false,
         "assertion_id": 331,
         "feature_id": 331,
-        "source_id": 122
+        "source_id": 122,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C77888",
+                    "code": "C77888",
+                    "name": "Ruxolitinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -12158,7 +15903,19 @@
         "_deprecated": false,
         "assertion_id": 332,
         "feature_id": 332,
-        "source_id": 122
+        "source_id": 122,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C95800",
+                    "code": "C95800",
+                    "name": "Tofacitinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -12196,7 +15953,19 @@
         "_deprecated": false,
         "assertion_id": 333,
         "feature_id": 333,
-        "source_id": 122
+        "source_id": 122,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C95800",
+                    "code": "C95800",
+                    "name": "Tofacitinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -12234,7 +16003,19 @@
         "_deprecated": false,
         "assertion_id": 334,
         "feature_id": 334,
-        "source_id": 122
+        "source_id": 122,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C95800",
+                    "code": "C95800",
+                    "name": "Tofacitinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -12272,7 +16053,19 @@
         "_deprecated": false,
         "assertion_id": 335,
         "feature_id": 335,
-        "source_id": 3
+        "source_id": 3,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C62035",
+                    "code": "C62035",
+                    "name": "Imatinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -12310,7 +16103,19 @@
         "_deprecated": false,
         "assertion_id": 336,
         "feature_id": 336,
-        "source_id": 3
+        "source_id": 3,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C62035",
+                    "code": "C62035",
+                    "name": "Imatinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -12348,7 +16153,19 @@
         "_deprecated": false,
         "assertion_id": 337,
         "feature_id": 337,
-        "source_id": 123
+        "source_id": 123,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C184955",
+                    "code": "C184955",
+                    "name": "Regorafenib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -12386,7 +16203,19 @@
         "_deprecated": false,
         "assertion_id": 338,
         "feature_id": 338,
-        "source_id": 123
+        "source_id": 123,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C184955",
+                    "code": "C184955",
+                    "name": "Regorafenib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -12424,7 +16253,19 @@
         "_deprecated": false,
         "assertion_id": 339,
         "feature_id": 339,
-        "source_id": 123
+        "source_id": 123,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C184955",
+                    "code": "C184955",
+                    "name": "Regorafenib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -12462,7 +16303,19 @@
         "_deprecated": false,
         "assertion_id": 340,
         "feature_id": 340,
-        "source_id": 123
+        "source_id": 123,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C184955",
+                    "code": "C184955",
+                    "name": "Regorafenib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -12500,7 +16353,19 @@
         "_deprecated": false,
         "assertion_id": 341,
         "feature_id": 341,
-        "source_id": 124
+        "source_id": 124,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C71622",
+                    "code": "C71622",
+                    "name": "Sunitinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -12538,7 +16403,19 @@
         "_deprecated": false,
         "assertion_id": 342,
         "feature_id": 342,
-        "source_id": 124
+        "source_id": 124,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C71622",
+                    "code": "C71622",
+                    "name": "Sunitinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -12576,7 +16453,19 @@
         "_deprecated": false,
         "assertion_id": 343,
         "feature_id": 343,
-        "source_id": 124
+        "source_id": 124,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C71622",
+                    "code": "C71622",
+                    "name": "Sunitinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -12614,7 +16503,19 @@
         "_deprecated": false,
         "assertion_id": 344,
         "feature_id": 344,
-        "source_id": 125
+        "source_id": 125,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C62035",
+                    "code": "C62035",
+                    "name": "Imatinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -12652,7 +16553,19 @@
         "_deprecated": false,
         "assertion_id": 345,
         "feature_id": 345,
-        "source_id": 126
+        "source_id": 126,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C62035",
+                    "code": "C62035",
+                    "name": "Imatinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -12690,7 +16603,19 @@
         "_deprecated": false,
         "assertion_id": 346,
         "feature_id": 346,
-        "source_id": 126
+        "source_id": 126,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C62035",
+                    "code": "C62035",
+                    "name": "Imatinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -12728,7 +16653,19 @@
         "_deprecated": false,
         "assertion_id": 347,
         "feature_id": 347,
-        "source_id": 126
+        "source_id": 126,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C62035",
+                    "code": "C62035",
+                    "name": "Imatinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -12766,7 +16703,19 @@
         "_deprecated": false,
         "assertion_id": 348,
         "feature_id": 348,
-        "source_id": 126
+        "source_id": 126,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C62035",
+                    "code": "C62035",
+                    "name": "Imatinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -12804,7 +16753,19 @@
         "_deprecated": false,
         "assertion_id": 349,
         "feature_id": 349,
-        "source_id": 126
+        "source_id": 126,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C62035",
+                    "code": "C62035",
+                    "name": "Imatinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -12842,7 +16803,19 @@
         "_deprecated": false,
         "assertion_id": 350,
         "feature_id": 350,
-        "source_id": 126
+        "source_id": 126,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C62035",
+                    "code": "C62035",
+                    "name": "Imatinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -12880,7 +16853,19 @@
         "_deprecated": false,
         "assertion_id": 351,
         "feature_id": 351,
-        "source_id": 126
+        "source_id": 126,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C62035",
+                    "code": "C62035",
+                    "name": "Imatinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -12918,7 +16903,19 @@
         "_deprecated": false,
         "assertion_id": 352,
         "feature_id": 352,
-        "source_id": 126
+        "source_id": 126,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C62035",
+                    "code": "C62035",
+                    "name": "Imatinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -12956,7 +16953,19 @@
         "_deprecated": false,
         "assertion_id": 353,
         "feature_id": 353,
-        "source_id": 126
+        "source_id": 126,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C62035",
+                    "code": "C62035",
+                    "name": "Imatinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -12994,7 +17003,19 @@
         "_deprecated": false,
         "assertion_id": 354,
         "feature_id": 354,
-        "source_id": 126
+        "source_id": 126,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C62035",
+                    "code": "C62035",
+                    "name": "Imatinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -13032,7 +17053,19 @@
         "_deprecated": false,
         "assertion_id": 355,
         "feature_id": 355,
-        "source_id": 126
+        "source_id": 126,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C62035",
+                    "code": "C62035",
+                    "name": "Imatinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -13070,7 +17103,19 @@
         "_deprecated": false,
         "assertion_id": 356,
         "feature_id": 356,
-        "source_id": 68
+        "source_id": 68,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C62035",
+                    "code": "C62035",
+                    "name": "Imatinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -13108,7 +17153,19 @@
         "_deprecated": false,
         "assertion_id": 357,
         "feature_id": 357,
-        "source_id": 127
+        "source_id": 127,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C62035",
+                    "code": "C62035",
+                    "name": "Imatinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -13146,7 +17203,19 @@
         "_deprecated": false,
         "assertion_id": 358,
         "feature_id": 358,
-        "source_id": 127
+        "source_id": 127,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C62035",
+                    "code": "C62035",
+                    "name": "Imatinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -13184,7 +17253,19 @@
         "_deprecated": false,
         "assertion_id": 359,
         "feature_id": 359,
-        "source_id": 128
+        "source_id": 128,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C71622",
+                    "code": "C71622",
+                    "name": "Sunitinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -13222,7 +17303,19 @@
         "_deprecated": false,
         "assertion_id": 360,
         "feature_id": 360,
-        "source_id": 129
+        "source_id": 129,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C123827",
+                    "code": "C123827",
+                    "name": "Avapritinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -13260,7 +17353,19 @@
         "_deprecated": false,
         "assertion_id": 361,
         "feature_id": 361,
-        "source_id": 129
+        "source_id": 129,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C123827",
+                    "code": "C123827",
+                    "name": "Avapritinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -13298,7 +17403,19 @@
         "_deprecated": false,
         "assertion_id": 362,
         "feature_id": 362,
-        "source_id": 129
+        "source_id": 129,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C123827",
+                    "code": "C123827",
+                    "name": "Avapritinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -13336,7 +17453,19 @@
         "_deprecated": false,
         "assertion_id": 363,
         "feature_id": 363,
-        "source_id": 129
+        "source_id": 129,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C123827",
+                    "code": "C123827",
+                    "name": "Avapritinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -13374,7 +17503,29 @@
         "_deprecated": false,
         "assertion_id": 364,
         "feature_id": 364,
-        "source_id": 130
+        "source_id": 130,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C49176",
+                    "code": "C49176",
+                    "name": "Palbociclib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C77908",
+                    "code": "C77908",
+                    "name": "Trametinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -13412,7 +17563,29 @@
         "_deprecated": false,
         "assertion_id": 365,
         "feature_id": 365,
-        "source_id": 131
+        "source_id": 131,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C90565",
+                    "code": "C90565",
+                    "name": "Buparlisib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C77908",
+                    "code": "C77908",
+                    "name": "Trametinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -13450,7 +17623,19 @@
         "_deprecated": false,
         "assertion_id": 366,
         "feature_id": 366,
-        "source_id": 66
+        "source_id": 66,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C1723",
+                    "code": "C1723",
+                    "name": "Cetuximab",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -13488,7 +17673,19 @@
         "_deprecated": false,
         "assertion_id": 367,
         "feature_id": 367,
-        "source_id": 66
+        "source_id": 66,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C1857",
+                    "code": "C1857",
+                    "name": "Panitumumab",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -13526,7 +17723,19 @@
         "_deprecated": false,
         "assertion_id": 368,
         "feature_id": 368,
-        "source_id": 66
+        "source_id": 66,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C1723",
+                    "code": "C1723",
+                    "name": "Cetuximab",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -13564,7 +17773,19 @@
         "_deprecated": false,
         "assertion_id": 369,
         "feature_id": 369,
-        "source_id": 66
+        "source_id": 66,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C1857",
+                    "code": "C1857",
+                    "name": "Panitumumab",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -13602,7 +17823,19 @@
         "_deprecated": false,
         "assertion_id": 370,
         "feature_id": 370,
-        "source_id": 66
+        "source_id": 66,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C1723",
+                    "code": "C1723",
+                    "name": "Cetuximab",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -13640,7 +17873,19 @@
         "_deprecated": false,
         "assertion_id": 371,
         "feature_id": 371,
-        "source_id": 66
+        "source_id": 66,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C1857",
+                    "code": "C1857",
+                    "name": "Panitumumab",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -13678,7 +17923,19 @@
         "_deprecated": false,
         "assertion_id": 372,
         "feature_id": 372,
-        "source_id": 132
+        "source_id": 132,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C154287",
+                    "code": "C154287",
+                    "name": "Sotorasib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -13716,7 +17973,19 @@
         "_deprecated": false,
         "assertion_id": 373,
         "feature_id": 373,
-        "source_id": 20
+        "source_id": 20,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C1855",
+                    "code": "C1855",
+                    "name": "Gefitinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -13754,7 +18023,8 @@
         "_deprecated": false,
         "assertion_id": 374,
         "feature_id": 374,
-        "source_id": 133
+        "source_id": 133,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -13773,7 +18043,7 @@
         "context": "Liver metastases from solid tumors",
         "oncotree_term": "Any solid tumor",
         "oncotree_code": "",
-        "therapy_name": "Proton-based SBRT",
+        "therapy_name": "Proton Stereotactic Body Radiation Therapy",
         "therapy_strategy": "Radiation",
         "therapy_type": "Radiation therapy",
         "therapy_sensitivity": "",
@@ -13792,7 +18062,19 @@
         "_deprecated": false,
         "assertion_id": 375,
         "feature_id": 375,
-        "source_id": 134
+        "source_id": 134,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C175032",
+                    "code": "C175032",
+                    "name": "Proton Stereotactic Body Radiation Therapy",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -13811,7 +18093,7 @@
         "context": "Liver metastases from solid tumors",
         "oncotree_term": "Any solid tumor",
         "oncotree_code": "",
-        "therapy_name": "Proton-based SBRT",
+        "therapy_name": "Proton Stereotactic Body Radiation Therapy",
         "therapy_strategy": "Radiation",
         "therapy_type": "Radiation therapy",
         "therapy_sensitivity": "",
@@ -13830,7 +18112,19 @@
         "_deprecated": false,
         "assertion_id": 376,
         "feature_id": 376,
-        "source_id": 134
+        "source_id": 134,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C175032",
+                    "code": "C175032",
+                    "name": "Proton Stereotactic Body Radiation Therapy",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -13849,7 +18143,7 @@
         "context": "Liver metastases from solid tumors",
         "oncotree_term": "Any solid tumor",
         "oncotree_code": "",
-        "therapy_name": "Proton-based SBRT",
+        "therapy_name": "Proton Stereotactic Body Radiation Therapy",
         "therapy_strategy": "Radiation",
         "therapy_type": "Radiation therapy",
         "therapy_sensitivity": "",
@@ -13868,7 +18162,19 @@
         "_deprecated": false,
         "assertion_id": 377,
         "feature_id": 377,
-        "source_id": 134
+        "source_id": 134,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C175032",
+                    "code": "C175032",
+                    "name": "Proton Stereotactic Body Radiation Therapy",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -13906,7 +18212,19 @@
         "_deprecated": false,
         "assertion_id": 378,
         "feature_id": 378,
-        "source_id": 135
+        "source_id": 135,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C77908",
+                    "code": "C77908",
+                    "name": "Trametinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -13944,7 +18262,19 @@
         "_deprecated": false,
         "assertion_id": 379,
         "feature_id": 379,
-        "source_id": 135
+        "source_id": 135,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C77908",
+                    "code": "C77908",
+                    "name": "Trametinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -13982,7 +18312,19 @@
         "_deprecated": false,
         "assertion_id": 380,
         "feature_id": 380,
-        "source_id": 136
+        "source_id": 136,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C106432",
+                    "code": "C106432",
+                    "name": "Pembrolizumab",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -14020,7 +18362,19 @@
         "_deprecated": false,
         "assertion_id": 381,
         "feature_id": 381,
-        "source_id": 54
+        "source_id": 54,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C64768",
+                    "code": "C64768",
+                    "name": "Vemurafenib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -14058,7 +18412,19 @@
         "_deprecated": false,
         "assertion_id": 382,
         "feature_id": 382,
-        "source_id": 137
+        "source_id": 137,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C88311",
+                    "code": "C88311",
+                    "name": "Momelotinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -14096,7 +18462,19 @@
         "_deprecated": false,
         "assertion_id": 383,
         "feature_id": 383,
-        "source_id": 137
+        "source_id": 137,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C77888",
+                    "code": "C77888",
+                    "name": "Ruxolitinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -14115,7 +18493,7 @@
         "context": "",
         "oncotree_term": "Rectal Adenocarcinoma",
         "oncotree_code": "READ",
-        "therapy_name": "Neoadjuvant chemoradiation",
+        "therapy_name": "Chemoradiotherapy",
         "therapy_strategy": "Chemotherapy + Radiation",
         "therapy_type": "Combination therapy",
         "therapy_sensitivity": "",
@@ -14134,7 +18512,19 @@
         "_deprecated": false,
         "assertion_id": 384,
         "feature_id": 384,
-        "source_id": 138
+        "source_id": 138,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C94626",
+                    "code": "C94626",
+                    "name": "Chemoradiotherapy",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -14153,7 +18543,7 @@
         "context": "Early stage",
         "oncotree_term": "Non-Small Cell Lung Cancer",
         "oncotree_code": "NSCLC",
-        "therapy_name": "SBRT",
+        "therapy_name": "Stereotactic Body Radiation Therapy",
         "therapy_strategy": "Radiation",
         "therapy_type": "Radiation therapy",
         "therapy_sensitivity": "",
@@ -14172,7 +18562,19 @@
         "_deprecated": false,
         "assertion_id": 385,
         "feature_id": 385,
-        "source_id": 139
+        "source_id": 139,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C118286",
+                    "code": "C118286",
+                    "name": "Stereotactic Body Radiation Therapy",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -14210,7 +18612,19 @@
         "_deprecated": false,
         "assertion_id": 386,
         "feature_id": 386,
-        "source_id": 71
+        "source_id": 71,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C64768",
+                    "code": "C64768",
+                    "name": "Vemurafenib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -14248,7 +18662,19 @@
         "_deprecated": false,
         "assertion_id": 387,
         "feature_id": 387,
-        "source_id": 71
+        "source_id": 71,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C64768",
+                    "code": "C64768",
+                    "name": "Vemurafenib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -14286,7 +18712,19 @@
         "_deprecated": false,
         "assertion_id": 388,
         "feature_id": 388,
-        "source_id": 71
+        "source_id": 71,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C66939",
+                    "code": "C66939",
+                    "name": "Selumetinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -14324,7 +18762,19 @@
         "_deprecated": false,
         "assertion_id": 389,
         "feature_id": 389,
-        "source_id": 140
+        "source_id": 140,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C66939",
+                    "code": "C66939",
+                    "name": "Selumetinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -14362,7 +18812,19 @@
         "_deprecated": false,
         "assertion_id": 390,
         "feature_id": 390,
-        "source_id": 141
+        "source_id": 141,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C64768",
+                    "code": "C64768",
+                    "name": "Vemurafenib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -14400,7 +18862,19 @@
         "_deprecated": false,
         "assertion_id": 391,
         "feature_id": 391,
-        "source_id": 141
+        "source_id": 141,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C66939",
+                    "code": "C66939",
+                    "name": "Selumetinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -14438,7 +18912,19 @@
         "_deprecated": false,
         "assertion_id": 392,
         "feature_id": 392,
-        "source_id": 142
+        "source_id": 142,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C64768",
+                    "code": "C64768",
+                    "name": "Vemurafenib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -14476,7 +18962,19 @@
         "_deprecated": false,
         "assertion_id": 393,
         "feature_id": 393,
-        "source_id": 142
+        "source_id": 142,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C66939",
+                    "code": "C66939",
+                    "name": "Selumetinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -14514,7 +19012,19 @@
         "_deprecated": false,
         "assertion_id": 394,
         "feature_id": 394,
-        "source_id": 78
+        "source_id": 78,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C77908",
+                    "code": "C77908",
+                    "name": "Trametinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -14552,7 +19062,19 @@
         "_deprecated": false,
         "assertion_id": 395,
         "feature_id": 395,
-        "source_id": 143
+        "source_id": 143,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C65530",
+                    "code": "C65530",
+                    "name": "Erlotinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -14590,7 +19112,8 @@
         "_deprecated": false,
         "assertion_id": 396,
         "feature_id": 396,
-        "source_id": 144
+        "source_id": 144,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -14628,7 +19151,8 @@
         "_deprecated": false,
         "assertion_id": 397,
         "feature_id": 397,
-        "source_id": 145
+        "source_id": 145,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -14666,7 +19190,19 @@
         "_deprecated": false,
         "assertion_id": 398,
         "feature_id": 398,
-        "source_id": 11
+        "source_id": 11,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C74061",
+                    "code": "C74061",
+                    "name": "Crizotinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -14704,7 +19240,19 @@
         "_deprecated": false,
         "assertion_id": 399,
         "feature_id": 399,
-        "source_id": 11
+        "source_id": 11,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C74061",
+                    "code": "C74061",
+                    "name": "Crizotinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -14742,7 +19290,19 @@
         "_deprecated": false,
         "assertion_id": 400,
         "feature_id": 400,
-        "source_id": 146
+        "source_id": 146,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C90564",
+                    "code": "C90564",
+                    "name": "Capmatinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -14780,7 +19340,19 @@
         "_deprecated": false,
         "assertion_id": 401,
         "feature_id": 401,
-        "source_id": 146
+        "source_id": 146,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C90564",
+                    "code": "C90564",
+                    "name": "Capmatinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -14818,7 +19390,19 @@
         "_deprecated": false,
         "assertion_id": 402,
         "feature_id": 402,
-        "source_id": 147
+        "source_id": 147,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C106432",
+                    "code": "C106432",
+                    "name": "Pembrolizumab",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -14856,7 +19440,8 @@
         "_deprecated": false,
         "assertion_id": 403,
         "feature_id": 403,
-        "source_id": 148
+        "source_id": 148,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -14894,7 +19479,19 @@
         "_deprecated": false,
         "assertion_id": 404,
         "feature_id": 404,
-        "source_id": 147
+        "source_id": 147,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C106432",
+                    "code": "C106432",
+                    "name": "Pembrolizumab",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -14932,7 +19529,19 @@
         "_deprecated": false,
         "assertion_id": 405,
         "feature_id": 405,
-        "source_id": 147
+        "source_id": 147,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C106432",
+                    "code": "C106432",
+                    "name": "Pembrolizumab",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -14970,7 +19579,19 @@
         "_deprecated": false,
         "assertion_id": 406,
         "feature_id": 406,
-        "source_id": 149
+        "source_id": 149,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C48387",
+                    "code": "C48387",
+                    "name": "Everolimus",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -15008,7 +19629,19 @@
         "_deprecated": false,
         "assertion_id": 407,
         "feature_id": 407,
-        "source_id": 147
+        "source_id": 147,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C106432",
+                    "code": "C106432",
+                    "name": "Pembrolizumab",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -15027,7 +19660,7 @@
         "context": "",
         "oncotree_term": "Lung Squamous Cell Carcinoma",
         "oncotree_code": "LUSC",
-        "therapy_name": "Radiation therapy",
+        "therapy_name": "Radiation Therapy",
         "therapy_strategy": "Radiation",
         "therapy_type": "Radiation therapy",
         "therapy_sensitivity": "",
@@ -15046,7 +19679,19 @@
         "_deprecated": false,
         "assertion_id": 408,
         "feature_id": 408,
-        "source_id": 150
+        "source_id": 150,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C15313",
+                    "code": "C15313",
+                    "name": "Radiation Therapy",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -15084,7 +19729,19 @@
         "_deprecated": false,
         "assertion_id": 409,
         "feature_id": 409,
-        "source_id": 66
+        "source_id": 66,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C1723",
+                    "code": "C1723",
+                    "name": "Cetuximab",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -15122,7 +19779,19 @@
         "_deprecated": false,
         "assertion_id": 410,
         "feature_id": 410,
-        "source_id": 66
+        "source_id": 66,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C1857",
+                    "code": "C1857",
+                    "name": "Panitumumab",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -15160,7 +19829,8 @@
         "_deprecated": false,
         "assertion_id": 411,
         "feature_id": 411,
-        "source_id": 33
+        "source_id": 33,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -15198,7 +19868,8 @@
         "_deprecated": false,
         "assertion_id": 412,
         "feature_id": 412,
-        "source_id": 33
+        "source_id": 33,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -15236,7 +19907,8 @@
         "_deprecated": false,
         "assertion_id": 413,
         "feature_id": 413,
-        "source_id": 33
+        "source_id": 33,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -15274,7 +19946,8 @@
         "_deprecated": false,
         "assertion_id": 414,
         "feature_id": 414,
-        "source_id": 33
+        "source_id": 33,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -15312,7 +19985,8 @@
         "_deprecated": false,
         "assertion_id": 415,
         "feature_id": 415,
-        "source_id": 33
+        "source_id": 33,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -15350,7 +20024,8 @@
         "_deprecated": false,
         "assertion_id": 416,
         "feature_id": 416,
-        "source_id": 33
+        "source_id": 33,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -15388,7 +20063,8 @@
         "_deprecated": false,
         "assertion_id": 417,
         "feature_id": 417,
-        "source_id": 33
+        "source_id": 33,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -15426,7 +20102,8 @@
         "_deprecated": false,
         "assertion_id": 418,
         "feature_id": 418,
-        "source_id": 33
+        "source_id": 33,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -15464,7 +20141,8 @@
         "_deprecated": false,
         "assertion_id": 419,
         "feature_id": 419,
-        "source_id": 33
+        "source_id": 33,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -15502,7 +20180,8 @@
         "_deprecated": false,
         "assertion_id": 420,
         "feature_id": 420,
-        "source_id": 33
+        "source_id": 33,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -15540,7 +20219,8 @@
         "_deprecated": false,
         "assertion_id": 421,
         "feature_id": 421,
-        "source_id": 33
+        "source_id": 33,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -15578,7 +20258,8 @@
         "_deprecated": false,
         "assertion_id": 422,
         "feature_id": 422,
-        "source_id": 33
+        "source_id": 33,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -15616,7 +20297,8 @@
         "_deprecated": false,
         "assertion_id": 423,
         "feature_id": 423,
-        "source_id": 33
+        "source_id": 33,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -15654,7 +20336,8 @@
         "_deprecated": false,
         "assertion_id": 424,
         "feature_id": 424,
-        "source_id": 33
+        "source_id": 33,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -15692,7 +20375,19 @@
         "_deprecated": false,
         "assertion_id": 425,
         "feature_id": 425,
-        "source_id": 151
+        "source_id": 151,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C66939",
+                    "code": "C66939",
+                    "name": "Selumetinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -15730,7 +20425,19 @@
         "_deprecated": false,
         "assertion_id": 426,
         "feature_id": 426,
-        "source_id": 151
+        "source_id": 151,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C66939",
+                    "code": "C66939",
+                    "name": "Selumetinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -15768,7 +20475,19 @@
         "_deprecated": false,
         "assertion_id": 427,
         "feature_id": 427,
-        "source_id": 151
+        "source_id": 151,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C66939",
+                    "code": "C66939",
+                    "name": "Selumetinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -15806,7 +20525,19 @@
         "_deprecated": false,
         "assertion_id": 428,
         "feature_id": 428,
-        "source_id": 151
+        "source_id": 151,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C66939",
+                    "code": "C66939",
+                    "name": "Selumetinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -15844,7 +20575,19 @@
         "_deprecated": false,
         "assertion_id": 429,
         "feature_id": 429,
-        "source_id": 151
+        "source_id": 151,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C66939",
+                    "code": "C66939",
+                    "name": "Selumetinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -15882,7 +20625,19 @@
         "_deprecated": false,
         "assertion_id": 430,
         "feature_id": 430,
-        "source_id": 151
+        "source_id": 151,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C66939",
+                    "code": "C66939",
+                    "name": "Selumetinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -15920,7 +20675,19 @@
         "_deprecated": false,
         "assertion_id": 431,
         "feature_id": 431,
-        "source_id": 151
+        "source_id": 151,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C66939",
+                    "code": "C66939",
+                    "name": "Selumetinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -15958,7 +20725,19 @@
         "_deprecated": false,
         "assertion_id": 432,
         "feature_id": 432,
-        "source_id": 151
+        "source_id": 151,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C66939",
+                    "code": "C66939",
+                    "name": "Selumetinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -15996,7 +20775,19 @@
         "_deprecated": false,
         "assertion_id": 433,
         "feature_id": 433,
-        "source_id": 151
+        "source_id": 151,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C66939",
+                    "code": "C66939",
+                    "name": "Selumetinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -16034,7 +20825,19 @@
         "_deprecated": false,
         "assertion_id": 434,
         "feature_id": 434,
-        "source_id": 151
+        "source_id": 151,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C66939",
+                    "code": "C66939",
+                    "name": "Selumetinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -16072,7 +20875,19 @@
         "_deprecated": false,
         "assertion_id": 435,
         "feature_id": 435,
-        "source_id": 151
+        "source_id": 151,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C66939",
+                    "code": "C66939",
+                    "name": "Selumetinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -16110,7 +20925,19 @@
         "_deprecated": false,
         "assertion_id": 436,
         "feature_id": 436,
-        "source_id": 151
+        "source_id": 151,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C66939",
+                    "code": "C66939",
+                    "name": "Selumetinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -16148,7 +20975,19 @@
         "_deprecated": false,
         "assertion_id": 437,
         "feature_id": 437,
-        "source_id": 151
+        "source_id": 151,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C66939",
+                    "code": "C66939",
+                    "name": "Selumetinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -16186,7 +21025,19 @@
         "_deprecated": false,
         "assertion_id": 438,
         "feature_id": 438,
-        "source_id": 151
+        "source_id": 151,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C66939",
+                    "code": "C66939",
+                    "name": "Selumetinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -16224,7 +21075,19 @@
         "_deprecated": false,
         "assertion_id": 439,
         "feature_id": 439,
-        "source_id": 151
+        "source_id": 151,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C66939",
+                    "code": "C66939",
+                    "name": "Selumetinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -16262,7 +21125,8 @@
         "_deprecated": false,
         "assertion_id": 440,
         "feature_id": 440,
-        "source_id": 152
+        "source_id": 152,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -16300,7 +21164,8 @@
         "_deprecated": false,
         "assertion_id": 441,
         "feature_id": 441,
-        "source_id": 59
+        "source_id": 59,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -16338,7 +21203,8 @@
         "_deprecated": false,
         "assertion_id": 442,
         "feature_id": 442,
-        "source_id": 59
+        "source_id": 59,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -16376,7 +21242,8 @@
         "_deprecated": false,
         "assertion_id": 443,
         "feature_id": 443,
-        "source_id": 59
+        "source_id": 59,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -16395,7 +21262,7 @@
         "context": "Primary",
         "oncotree_term": "Peritoneal Mesothelioma",
         "oncotree_code": "PEMESO",
-        "therapy_name": "Platinum",
+        "therapy_name": "Platinum Compound",
         "therapy_strategy": "Platinum-based chemotherapy",
         "therapy_type": "Chemotherapy",
         "therapy_sensitivity": 1,
@@ -16414,7 +21281,19 @@
         "_deprecated": false,
         "assertion_id": 444,
         "feature_id": 444,
-        "source_id": 59
+        "source_id": 59,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C1450",
+                    "code": "C1450",
+                    "name": "Platinum Compound",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -16433,7 +21312,7 @@
         "context": "Primary",
         "oncotree_term": "Serous Ovarian Cancer",
         "oncotree_code": "SOC",
-        "therapy_name": "Platinum",
+        "therapy_name": "Platinum Compound",
         "therapy_strategy": "Platinum-based chemotherapy",
         "therapy_type": "Chemotherapy",
         "therapy_sensitivity": 1,
@@ -16452,7 +21331,19 @@
         "_deprecated": false,
         "assertion_id": 445,
         "feature_id": 445,
-        "source_id": 59
+        "source_id": 59,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C1450",
+                    "code": "C1450",
+                    "name": "Platinum Compound",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -16471,7 +21362,7 @@
         "context": "Primary",
         "oncotree_term": "Ovarian Cancer, Other",
         "oncotree_code": "OOVC",
-        "therapy_name": "Platinum",
+        "therapy_name": "Platinum Compound",
         "therapy_strategy": "Platinum-based chemotherapy",
         "therapy_type": "Chemotherapy",
         "therapy_sensitivity": 1,
@@ -16490,7 +21381,19 @@
         "_deprecated": false,
         "assertion_id": 446,
         "feature_id": 446,
-        "source_id": 59
+        "source_id": 59,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C1450",
+                    "code": "C1450",
+                    "name": "Platinum Compound",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -16509,7 +21412,7 @@
         "context": "",
         "oncotree_term": "Pancreatic Adenocarcinoma",
         "oncotree_code": "PAAD",
-        "therapy_name": "Platinum",
+        "therapy_name": "Platinum Compound",
         "therapy_strategy": "Platinum-based chemotherapy",
         "therapy_type": "Chemotherapy",
         "therapy_sensitivity": 1,
@@ -16528,7 +21431,19 @@
         "_deprecated": false,
         "assertion_id": 447,
         "feature_id": 447,
-        "source_id": 85
+        "source_id": 85,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C1450",
+                    "code": "C1450",
+                    "name": "Platinum Compound",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -16566,7 +21481,19 @@
         "_deprecated": false,
         "assertion_id": 448,
         "feature_id": 448,
-        "source_id": 58
+        "source_id": 58,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C71721",
+                    "code": "C71721",
+                    "name": "Olaparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -16604,7 +21531,19 @@
         "_deprecated": false,
         "assertion_id": 449,
         "feature_id": 449,
-        "source_id": 153
+        "source_id": 153,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C68814",
+                    "code": "C68814",
+                    "name": "Nivolumab",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -16642,7 +21581,19 @@
         "_deprecated": false,
         "assertion_id": 450,
         "feature_id": 450,
-        "source_id": 127
+        "source_id": 127,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C62035",
+                    "code": "C62035",
+                    "name": "Imatinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -16680,7 +21631,19 @@
         "_deprecated": false,
         "assertion_id": 451,
         "feature_id": 451,
-        "source_id": 127
+        "source_id": 127,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C62035",
+                    "code": "C62035",
+                    "name": "Imatinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -16718,7 +21681,19 @@
         "_deprecated": false,
         "assertion_id": 452,
         "feature_id": 452,
-        "source_id": 129
+        "source_id": 129,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C123827",
+                    "code": "C123827",
+                    "name": "Avapritinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -16756,7 +21731,19 @@
         "_deprecated": false,
         "assertion_id": 453,
         "feature_id": 453,
-        "source_id": 129
+        "source_id": 129,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C123827",
+                    "code": "C123827",
+                    "name": "Avapritinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -16794,7 +21781,19 @@
         "_deprecated": false,
         "assertion_id": 454,
         "feature_id": 454,
-        "source_id": 129
+        "source_id": 129,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C123827",
+                    "code": "C123827",
+                    "name": "Avapritinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -16832,7 +21831,19 @@
         "_deprecated": false,
         "assertion_id": 455,
         "feature_id": 455,
-        "source_id": 153
+        "source_id": 153,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C68814",
+                    "code": "C68814",
+                    "name": "Nivolumab",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -16870,7 +21881,19 @@
         "_deprecated": false,
         "assertion_id": 456,
         "feature_id": 456,
-        "source_id": 154
+        "source_id": 154,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C94214",
+                    "code": "C94214",
+                    "name": "Alpelisib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -16908,7 +21931,19 @@
         "_deprecated": false,
         "assertion_id": 457,
         "feature_id": 457,
-        "source_id": 155
+        "source_id": 155,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C165479",
+                    "code": "C165479",
+                    "name": "Pictilisib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -16946,7 +21981,8 @@
         "_deprecated": false,
         "assertion_id": 458,
         "feature_id": 458,
-        "source_id": 44
+        "source_id": 44,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -16984,7 +22020,19 @@
         "_deprecated": false,
         "assertion_id": 459,
         "feature_id": 459,
-        "source_id": 60
+        "source_id": 60,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C165479",
+                    "code": "C165479",
+                    "name": "Pictilisib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -17022,7 +22070,19 @@
         "_deprecated": false,
         "assertion_id": 460,
         "feature_id": 460,
-        "source_id": 60
+        "source_id": 60,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C165479",
+                    "code": "C165479",
+                    "name": "Pictilisib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -17060,7 +22120,19 @@
         "_deprecated": false,
         "assertion_id": 461,
         "feature_id": 461,
-        "source_id": 60
+        "source_id": 60,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C165479",
+                    "code": "C165479",
+                    "name": "Pictilisib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -17098,7 +22170,19 @@
         "_deprecated": false,
         "assertion_id": 462,
         "feature_id": 462,
-        "source_id": 60
+        "source_id": 60,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C165479",
+                    "code": "C165479",
+                    "name": "Pictilisib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -17136,7 +22220,19 @@
         "_deprecated": false,
         "assertion_id": 463,
         "feature_id": 463,
-        "source_id": 60
+        "source_id": 60,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C165479",
+                    "code": "C165479",
+                    "name": "Pictilisib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -17174,7 +22270,19 @@
         "_deprecated": false,
         "assertion_id": 464,
         "feature_id": 464,
-        "source_id": 60
+        "source_id": 60,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C165479",
+                    "code": "C165479",
+                    "name": "Pictilisib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -17212,7 +22320,19 @@
         "_deprecated": false,
         "assertion_id": 465,
         "feature_id": 465,
-        "source_id": 60
+        "source_id": 60,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C165479",
+                    "code": "C165479",
+                    "name": "Pictilisib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -17250,7 +22370,19 @@
         "_deprecated": false,
         "assertion_id": 466,
         "feature_id": 466,
-        "source_id": 60
+        "source_id": 60,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C165479",
+                    "code": "C165479",
+                    "name": "Pictilisib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -17288,7 +22420,19 @@
         "_deprecated": false,
         "assertion_id": 467,
         "feature_id": 467,
-        "source_id": 60
+        "source_id": 60,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C165479",
+                    "code": "C165479",
+                    "name": "Pictilisib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -17326,7 +22470,19 @@
         "_deprecated": false,
         "assertion_id": 468,
         "feature_id": 468,
-        "source_id": 60
+        "source_id": 60,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C165479",
+                    "code": "C165479",
+                    "name": "Pictilisib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -17364,7 +22520,19 @@
         "_deprecated": false,
         "assertion_id": 469,
         "feature_id": 469,
-        "source_id": 60
+        "source_id": 60,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C165479",
+                    "code": "C165479",
+                    "name": "Pictilisib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -17402,7 +22570,19 @@
         "_deprecated": false,
         "assertion_id": 470,
         "feature_id": 470,
-        "source_id": 60
+        "source_id": 60,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C165479",
+                    "code": "C165479",
+                    "name": "Pictilisib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -17440,7 +22620,19 @@
         "_deprecated": false,
         "assertion_id": 471,
         "feature_id": 471,
-        "source_id": 60
+        "source_id": 60,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C165479",
+                    "code": "C165479",
+                    "name": "Pictilisib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -17478,7 +22670,19 @@
         "_deprecated": false,
         "assertion_id": 472,
         "feature_id": 472,
-        "source_id": 60
+        "source_id": 60,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C165479",
+                    "code": "C165479",
+                    "name": "Pictilisib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -17516,7 +22720,19 @@
         "_deprecated": false,
         "assertion_id": 473,
         "feature_id": 473,
-        "source_id": 60
+        "source_id": 60,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C165479",
+                    "code": "C165479",
+                    "name": "Pictilisib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -17554,7 +22770,19 @@
         "_deprecated": false,
         "assertion_id": 474,
         "feature_id": 474,
-        "source_id": 60
+        "source_id": 60,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C165479",
+                    "code": "C165479",
+                    "name": "Pictilisib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -17592,7 +22820,19 @@
         "_deprecated": false,
         "assertion_id": 475,
         "feature_id": 475,
-        "source_id": 60
+        "source_id": 60,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C165479",
+                    "code": "C165479",
+                    "name": "Pictilisib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -17630,7 +22870,19 @@
         "_deprecated": false,
         "assertion_id": 476,
         "feature_id": 476,
-        "source_id": 60
+        "source_id": 60,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C165479",
+                    "code": "C165479",
+                    "name": "Pictilisib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -17668,7 +22920,19 @@
         "_deprecated": false,
         "assertion_id": 477,
         "feature_id": 477,
-        "source_id": 60
+        "source_id": 60,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C165479",
+                    "code": "C165479",
+                    "name": "Pictilisib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -17706,7 +22970,19 @@
         "_deprecated": false,
         "assertion_id": 478,
         "feature_id": 478,
-        "source_id": 60
+        "source_id": 60,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C165479",
+                    "code": "C165479",
+                    "name": "Pictilisib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -17744,7 +23020,8 @@
         "_deprecated": false,
         "assertion_id": 479,
         "feature_id": 479,
-        "source_id": 156
+        "source_id": 156,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -17782,7 +23059,8 @@
         "_deprecated": false,
         "assertion_id": 480,
         "feature_id": 480,
-        "source_id": 156
+        "source_id": 156,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -17820,7 +23098,8 @@
         "_deprecated": false,
         "assertion_id": 481,
         "feature_id": 481,
-        "source_id": 156
+        "source_id": 156,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -17858,7 +23137,8 @@
         "_deprecated": false,
         "assertion_id": 482,
         "feature_id": 482,
-        "source_id": 156
+        "source_id": 156,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -17896,7 +23176,19 @@
         "_deprecated": false,
         "assertion_id": 483,
         "feature_id": 483,
-        "source_id": 147
+        "source_id": 147,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C106432",
+                    "code": "C106432",
+                    "name": "Pembrolizumab",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -17934,7 +23226,19 @@
         "_deprecated": false,
         "assertion_id": 484,
         "feature_id": 484,
-        "source_id": 157
+        "source_id": 157,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C103194",
+                    "code": "C103194",
+                    "name": "Durvalumab",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -17972,7 +23276,19 @@
         "_deprecated": false,
         "assertion_id": 485,
         "feature_id": 485,
-        "source_id": 157
+        "source_id": 157,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C106432",
+                    "code": "C106432",
+                    "name": "Pembrolizumab",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -18010,7 +23326,8 @@
         "_deprecated": false,
         "assertion_id": 486,
         "feature_id": 486,
-        "source_id": 156
+        "source_id": 156,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -18048,7 +23365,19 @@
         "_deprecated": false,
         "assertion_id": 487,
         "feature_id": 487,
-        "source_id": 147
+        "source_id": 147,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C106432",
+                    "code": "C106432",
+                    "name": "Pembrolizumab",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -18086,7 +23415,19 @@
         "_deprecated": false,
         "assertion_id": 488,
         "feature_id": 488,
-        "source_id": 157
+        "source_id": 157,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C103194",
+                    "code": "C103194",
+                    "name": "Durvalumab",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -18124,7 +23465,19 @@
         "_deprecated": false,
         "assertion_id": 489,
         "feature_id": 489,
-        "source_id": 157
+        "source_id": 157,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C106432",
+                    "code": "C106432",
+                    "name": "Pembrolizumab",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -18143,7 +23496,7 @@
         "context": "",
         "oncotree_term": "Prostate Adenocarcinoma",
         "oncotree_code": "PRAD",
-        "therapy_name": "AZD8186",
+        "therapy_name": "PI3Kbeta Inhibitor AZD8186",
         "therapy_strategy": "PI3K/AKT/mTOR inhibition",
         "therapy_type": "Targeted therapy",
         "therapy_sensitivity": 1,
@@ -18162,7 +23515,19 @@
         "_deprecated": false,
         "assertion_id": 490,
         "feature_id": 490,
-        "source_id": 158
+        "source_id": 158,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C107684",
+                    "code": "C107684",
+                    "name": "PI3Kbeta Inhibitor AZD8186",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -18181,7 +23546,7 @@
         "context": "",
         "oncotree_term": "Prostate Adenocarcinoma",
         "oncotree_code": "PRAD",
-        "therapy_name": "AZD8186",
+        "therapy_name": "PI3Kbeta Inhibitor AZD8186",
         "therapy_strategy": "PI3K/AKT/mTOR inhibition",
         "therapy_type": "Targeted therapy",
         "therapy_sensitivity": 1,
@@ -18200,7 +23565,19 @@
         "_deprecated": false,
         "assertion_id": 491,
         "feature_id": 491,
-        "source_id": 158
+        "source_id": 158,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C107684",
+                    "code": "C107684",
+                    "name": "PI3Kbeta Inhibitor AZD8186",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -18219,7 +23596,7 @@
         "context": "",
         "oncotree_term": "Prostate Adenocarcinoma",
         "oncotree_code": "PRAD",
-        "therapy_name": "AZD8186",
+        "therapy_name": "PI3Kbeta Inhibitor AZD8186",
         "therapy_strategy": "PI3K/AKT/mTOR inhibition",
         "therapy_type": "Targeted therapy",
         "therapy_sensitivity": 1,
@@ -18238,7 +23615,19 @@
         "_deprecated": false,
         "assertion_id": 492,
         "feature_id": 492,
-        "source_id": 158
+        "source_id": 158,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C107684",
+                    "code": "C107684",
+                    "name": "PI3Kbeta Inhibitor AZD8186",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -18276,7 +23665,19 @@
         "_deprecated": false,
         "assertion_id": 493,
         "feature_id": 493,
-        "source_id": 159
+        "source_id": 159,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C106432",
+                    "code": "C106432",
+                    "name": "Pembrolizumab",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -18314,7 +23715,19 @@
         "_deprecated": false,
         "assertion_id": 494,
         "feature_id": 494,
-        "source_id": 159
+        "source_id": 159,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C106432",
+                    "code": "C106432",
+                    "name": "Pembrolizumab",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -18352,7 +23765,19 @@
         "_deprecated": false,
         "assertion_id": 495,
         "feature_id": 495,
-        "source_id": 159
+        "source_id": 159,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C106432",
+                    "code": "C106432",
+                    "name": "Pembrolizumab",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -18390,7 +23815,8 @@
         "_deprecated": false,
         "assertion_id": 496,
         "feature_id": 496,
-        "source_id": 44
+        "source_id": 44,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -18428,7 +23854,19 @@
         "_deprecated": false,
         "assertion_id": 497,
         "feature_id": 497,
-        "source_id": 160
+        "source_id": 160,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C106432",
+                    "code": "C106432",
+                    "name": "Pembrolizumab",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -18466,7 +23904,19 @@
         "_deprecated": false,
         "assertion_id": 498,
         "feature_id": 498,
-        "source_id": 160
+        "source_id": 160,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C106432",
+                    "code": "C106432",
+                    "name": "Pembrolizumab",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -18504,7 +23954,19 @@
         "_deprecated": false,
         "assertion_id": 499,
         "feature_id": 499,
-        "source_id": 160
+        "source_id": 160,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C106432",
+                    "code": "C106432",
+                    "name": "Pembrolizumab",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -18542,7 +24004,19 @@
         "_deprecated": false,
         "assertion_id": 500,
         "feature_id": 500,
-        "source_id": 160
+        "source_id": 160,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C106432",
+                    "code": "C106432",
+                    "name": "Pembrolizumab",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -18580,7 +24054,8 @@
         "_deprecated": false,
         "assertion_id": 501,
         "feature_id": 501,
-        "source_id": 33
+        "source_id": 33,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -18618,7 +24093,19 @@
         "_deprecated": false,
         "assertion_id": 502,
         "feature_id": 502,
-        "source_id": 58
+        "source_id": 58,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C71721",
+                    "code": "C71721",
+                    "name": "Olaparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -18637,7 +24124,7 @@
         "context": "Primary",
         "oncotree_term": "Ovarian Cancer, Other",
         "oncotree_code": "OOVC",
-        "therapy_name": "Platinum",
+        "therapy_name": "Platinum Compound",
         "therapy_strategy": "Platinum-based chemotherapy",
         "therapy_type": "Chemotherapy",
         "therapy_sensitivity": 1,
@@ -18656,7 +24143,19 @@
         "_deprecated": false,
         "assertion_id": 503,
         "feature_id": 503,
-        "source_id": 59
+        "source_id": 59,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C1450",
+                    "code": "C1450",
+                    "name": "Platinum Compound",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -18675,7 +24174,7 @@
         "context": "Primary",
         "oncotree_term": "Peritoneal Mesothelioma",
         "oncotree_code": "PEMESO",
-        "therapy_name": "Platinum",
+        "therapy_name": "Platinum Compound",
         "therapy_strategy": "Platinum-based chemotherapy",
         "therapy_type": "Chemotherapy",
         "therapy_sensitivity": 1,
@@ -18694,7 +24193,19 @@
         "_deprecated": false,
         "assertion_id": 504,
         "feature_id": 504,
-        "source_id": 59
+        "source_id": 59,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C1450",
+                    "code": "C1450",
+                    "name": "Platinum Compound",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -18713,7 +24224,7 @@
         "context": "Primary",
         "oncotree_term": "Serous Ovarian Cancer",
         "oncotree_code": "SOC",
-        "therapy_name": "Platinum",
+        "therapy_name": "Platinum Compound",
         "therapy_strategy": "Platinum-based chemotherapy",
         "therapy_type": "Chemotherapy",
         "therapy_sensitivity": 1,
@@ -18732,7 +24243,19 @@
         "_deprecated": false,
         "assertion_id": 505,
         "feature_id": 505,
-        "source_id": 59
+        "source_id": 59,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C1450",
+                    "code": "C1450",
+                    "name": "Platinum Compound",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -18770,7 +24293,8 @@
         "_deprecated": false,
         "assertion_id": 506,
         "feature_id": 506,
-        "source_id": 59
+        "source_id": 59,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -18808,7 +24332,8 @@
         "_deprecated": false,
         "assertion_id": 507,
         "feature_id": 507,
-        "source_id": 59
+        "source_id": 59,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -18846,7 +24371,8 @@
         "_deprecated": false,
         "assertion_id": 508,
         "feature_id": 508,
-        "source_id": 59
+        "source_id": 59,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -18884,7 +24410,19 @@
         "_deprecated": false,
         "assertion_id": 509,
         "feature_id": 509,
-        "source_id": 58
+        "source_id": 58,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C71721",
+                    "code": "C71721",
+                    "name": "Olaparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -18903,7 +24441,7 @@
         "context": "Primary",
         "oncotree_term": "Ovarian Cancer, Other",
         "oncotree_code": "OOVC",
-        "therapy_name": "Platinum",
+        "therapy_name": "Platinum Compound",
         "therapy_strategy": "Platinum-based chemotherapy",
         "therapy_type": "Chemotherapy",
         "therapy_sensitivity": 1,
@@ -18922,7 +24460,19 @@
         "_deprecated": false,
         "assertion_id": 510,
         "feature_id": 510,
-        "source_id": 59
+        "source_id": 59,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C1450",
+                    "code": "C1450",
+                    "name": "Platinum Compound",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -18941,7 +24491,7 @@
         "context": "Primary",
         "oncotree_term": "Peritoneal Mesothelioma",
         "oncotree_code": "PEMESO",
-        "therapy_name": "Platinum",
+        "therapy_name": "Platinum Compound",
         "therapy_strategy": "Platinum-based chemotherapy",
         "therapy_type": "Chemotherapy",
         "therapy_sensitivity": 1,
@@ -18960,7 +24510,19 @@
         "_deprecated": false,
         "assertion_id": 511,
         "feature_id": 511,
-        "source_id": 59
+        "source_id": 59,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C1450",
+                    "code": "C1450",
+                    "name": "Platinum Compound",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -18979,7 +24541,7 @@
         "context": "Primary",
         "oncotree_term": "Serous Ovarian Cancer",
         "oncotree_code": "SOC",
-        "therapy_name": "Platinum",
+        "therapy_name": "Platinum Compound",
         "therapy_strategy": "Platinum-based chemotherapy",
         "therapy_type": "Chemotherapy",
         "therapy_sensitivity": 1,
@@ -18998,7 +24560,19 @@
         "_deprecated": false,
         "assertion_id": 512,
         "feature_id": 512,
-        "source_id": 59
+        "source_id": 59,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C1450",
+                    "code": "C1450",
+                    "name": "Platinum Compound",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -19036,7 +24610,8 @@
         "_deprecated": false,
         "assertion_id": 513,
         "feature_id": 513,
-        "source_id": 59
+        "source_id": 59,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -19074,7 +24649,8 @@
         "_deprecated": false,
         "assertion_id": 514,
         "feature_id": 514,
-        "source_id": 59
+        "source_id": 59,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -19112,7 +24688,8 @@
         "_deprecated": false,
         "assertion_id": 515,
         "feature_id": 515,
-        "source_id": 59
+        "source_id": 59,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -19150,7 +24727,19 @@
         "_deprecated": false,
         "assertion_id": 516,
         "feature_id": 516,
-        "source_id": 58
+        "source_id": 58,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C71721",
+                    "code": "C71721",
+                    "name": "Olaparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -19188,7 +24777,19 @@
         "_deprecated": false,
         "assertion_id": 517,
         "feature_id": 517,
-        "source_id": 58
+        "source_id": 58,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C71721",
+                    "code": "C71721",
+                    "name": "Olaparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -19226,7 +24827,8 @@
         "_deprecated": false,
         "assertion_id": 518,
         "feature_id": 518,
-        "source_id": 54
+        "source_id": 54,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -19245,7 +24847,7 @@
         "context": "",
         "oncotree_term": "Medullary Thyroid Cancer",
         "oncotree_code": "THME",
-        "therapy_name": "LOXO-292",
+        "therapy_name": "Selpercatinib",
         "therapy_strategy": "RET inhibition",
         "therapy_type": "Targeted therapy",
         "therapy_sensitivity": "",
@@ -19264,7 +24866,19 @@
         "_deprecated": false,
         "assertion_id": 519,
         "feature_id": 519,
-        "source_id": 161
+        "source_id": 161,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C134987",
+                    "code": "C134987",
+                    "name": "Selpercatinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -19283,7 +24897,7 @@
         "context": "",
         "oncotree_term": "Medullary Thyroid Cancer",
         "oncotree_code": "THME",
-        "therapy_name": "LOXO-292",
+        "therapy_name": "Selpercatinib",
         "therapy_strategy": "RET inhibition",
         "therapy_type": "Targeted therapy",
         "therapy_sensitivity": 1,
@@ -19302,7 +24916,19 @@
         "_deprecated": false,
         "assertion_id": 520,
         "feature_id": 520,
-        "source_id": 161
+        "source_id": 161,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C134987",
+                    "code": "C134987",
+                    "name": "Selpercatinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -19340,7 +24966,19 @@
         "_deprecated": false,
         "assertion_id": 521,
         "feature_id": 521,
-        "source_id": 162
+        "source_id": 162,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C134987",
+                    "code": "C134987",
+                    "name": "Selpercatinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -19378,7 +25016,8 @@
         "_deprecated": false,
         "assertion_id": 522,
         "feature_id": 522,
-        "source_id": 33
+        "source_id": 33,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -19416,7 +25055,8 @@
         "_deprecated": false,
         "assertion_id": 523,
         "feature_id": 523,
-        "source_id": 33
+        "source_id": 33,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -19454,7 +25094,8 @@
         "_deprecated": false,
         "assertion_id": 524,
         "feature_id": 524,
-        "source_id": 33
+        "source_id": 33,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -19492,7 +25133,8 @@
         "_deprecated": false,
         "assertion_id": 525,
         "feature_id": 525,
-        "source_id": 33
+        "source_id": 33,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -19530,7 +25172,8 @@
         "_deprecated": false,
         "assertion_id": 526,
         "feature_id": 526,
-        "source_id": 33
+        "source_id": 33,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -19568,7 +25211,8 @@
         "_deprecated": false,
         "assertion_id": 527,
         "feature_id": 527,
-        "source_id": 33
+        "source_id": 33,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -19606,7 +25250,8 @@
         "_deprecated": false,
         "assertion_id": 528,
         "feature_id": 528,
-        "source_id": 33
+        "source_id": 33,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -19644,7 +25289,8 @@
         "_deprecated": false,
         "assertion_id": 529,
         "feature_id": 529,
-        "source_id": 33
+        "source_id": 33,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -19682,7 +25328,8 @@
         "_deprecated": false,
         "assertion_id": 530,
         "feature_id": 530,
-        "source_id": 33
+        "source_id": 33,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -19720,7 +25367,8 @@
         "_deprecated": false,
         "assertion_id": 531,
         "feature_id": 531,
-        "source_id": 33
+        "source_id": 33,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -19758,7 +25406,8 @@
         "_deprecated": false,
         "assertion_id": 532,
         "feature_id": 532,
-        "source_id": 33
+        "source_id": 33,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -19796,7 +25445,8 @@
         "_deprecated": false,
         "assertion_id": 533,
         "feature_id": 533,
-        "source_id": 33
+        "source_id": 33,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -19834,7 +25484,8 @@
         "_deprecated": false,
         "assertion_id": 534,
         "feature_id": 534,
-        "source_id": 33
+        "source_id": 33,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -19872,7 +25523,8 @@
         "_deprecated": false,
         "assertion_id": 535,
         "feature_id": 535,
-        "source_id": 33
+        "source_id": 33,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -19910,7 +25562,8 @@
         "_deprecated": false,
         "assertion_id": 536,
         "feature_id": 536,
-        "source_id": 33
+        "source_id": 33,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -19948,7 +25601,8 @@
         "_deprecated": false,
         "assertion_id": 537,
         "feature_id": 537,
-        "source_id": 33
+        "source_id": 33,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -19986,7 +25640,8 @@
         "_deprecated": false,
         "assertion_id": 538,
         "feature_id": 538,
-        "source_id": 33
+        "source_id": 33,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -20024,7 +25679,8 @@
         "_deprecated": false,
         "assertion_id": 539,
         "feature_id": 539,
-        "source_id": 33
+        "source_id": 33,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -20062,7 +25718,8 @@
         "_deprecated": false,
         "assertion_id": 540,
         "feature_id": 540,
-        "source_id": 33
+        "source_id": 33,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -20100,7 +25757,8 @@
         "_deprecated": false,
         "assertion_id": 541,
         "feature_id": 541,
-        "source_id": 33
+        "source_id": 33,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -20138,7 +25796,8 @@
         "_deprecated": false,
         "assertion_id": 542,
         "feature_id": 542,
-        "source_id": 33
+        "source_id": 33,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -20176,7 +25835,8 @@
         "_deprecated": false,
         "assertion_id": 543,
         "feature_id": 543,
-        "source_id": 33
+        "source_id": 33,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -20214,7 +25874,8 @@
         "_deprecated": false,
         "assertion_id": 544,
         "feature_id": 544,
-        "source_id": 33
+        "source_id": 33,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -20252,7 +25913,8 @@
         "_deprecated": false,
         "assertion_id": 545,
         "feature_id": 545,
-        "source_id": 33
+        "source_id": 33,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -20290,7 +25952,8 @@
         "_deprecated": false,
         "assertion_id": 546,
         "feature_id": 546,
-        "source_id": 33
+        "source_id": 33,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -20328,7 +25991,8 @@
         "_deprecated": false,
         "assertion_id": 547,
         "feature_id": 547,
-        "source_id": 33
+        "source_id": 33,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -20366,7 +26030,8 @@
         "_deprecated": false,
         "assertion_id": 548,
         "feature_id": 548,
-        "source_id": 33
+        "source_id": 33,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -20404,7 +26069,8 @@
         "_deprecated": false,
         "assertion_id": 549,
         "feature_id": 549,
-        "source_id": 33
+        "source_id": 33,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -20423,7 +26089,7 @@
         "context": "",
         "oncotree_term": "Non-Small Cell Lung Cancer",
         "oncotree_code": "NSCLC",
-        "therapy_name": "VX-680",
+        "therapy_name": "Tozasertib Lactate",
         "therapy_strategy": "Aurora kinase inhibition",
         "therapy_type": "Targeted therapy",
         "therapy_sensitivity": 1,
@@ -20442,7 +26108,19 @@
         "_deprecated": false,
         "assertion_id": 550,
         "feature_id": 550,
-        "source_id": 163
+        "source_id": 163,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C61319",
+                    "code": "C61319",
+                    "name": "Tozasertib Lactate",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -20461,7 +26139,7 @@
         "context": "",
         "oncotree_term": "Non-Small Cell Lung Cancer",
         "oncotree_code": "NSCLC",
-        "therapy_name": "VX-680",
+        "therapy_name": "Tozasertib Lactate",
         "therapy_strategy": "Aurora kinase inhibition",
         "therapy_type": "Targeted therapy",
         "therapy_sensitivity": 1,
@@ -20480,7 +26158,19 @@
         "_deprecated": false,
         "assertion_id": 551,
         "feature_id": 551,
-        "source_id": 163
+        "source_id": 163,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C61319",
+                    "code": "C61319",
+                    "name": "Tozasertib Lactate",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -20499,7 +26189,7 @@
         "context": "",
         "oncotree_term": "Non-Small Cell Lung Cancer",
         "oncotree_code": "NSCLC",
-        "therapy_name": "VX-680",
+        "therapy_name": "Tozasertib Lactate",
         "therapy_strategy": "Aurora kinase inhibition",
         "therapy_type": "Targeted therapy",
         "therapy_sensitivity": 1,
@@ -20518,7 +26208,19 @@
         "_deprecated": false,
         "assertion_id": 552,
         "feature_id": 552,
-        "source_id": 163
+        "source_id": 163,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C61319",
+                    "code": "C61319",
+                    "name": "Tozasertib Lactate",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -20556,7 +26258,19 @@
         "_deprecated": false,
         "assertion_id": 553,
         "feature_id": 553,
-        "source_id": 164
+        "source_id": 164,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C77333",
+                    "code": "C77333",
+                    "name": "Abiraterone",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -20594,7 +26308,19 @@
         "_deprecated": false,
         "assertion_id": 554,
         "feature_id": 554,
-        "source_id": 165
+        "source_id": 165,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C77333",
+                    "code": "C77333",
+                    "name": "Abiraterone",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -20632,7 +26358,19 @@
         "_deprecated": false,
         "assertion_id": 555,
         "feature_id": 555,
-        "source_id": 166
+        "source_id": 166,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C77333",
+                    "code": "C77333",
+                    "name": "Abiraterone",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -20670,7 +26408,8 @@
         "_deprecated": false,
         "assertion_id": 556,
         "feature_id": 556,
-        "source_id": 33
+        "source_id": 33,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -20708,7 +26447,8 @@
         "_deprecated": false,
         "assertion_id": 557,
         "feature_id": 557,
-        "source_id": 33
+        "source_id": 33,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -20746,7 +26486,8 @@
         "_deprecated": false,
         "assertion_id": 558,
         "feature_id": 558,
-        "source_id": 33
+        "source_id": 33,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -20784,7 +26525,19 @@
         "_deprecated": false,
         "assertion_id": 559,
         "feature_id": 559,
-        "source_id": 167
+        "source_id": 167,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C288",
+                    "code": "C288",
+                    "name": "Azacitidine",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -20822,7 +26575,8 @@
         "_deprecated": false,
         "assertion_id": 560,
         "feature_id": 560,
-        "source_id": 33
+        "source_id": 33,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -20860,7 +26614,8 @@
         "_deprecated": false,
         "assertion_id": 561,
         "feature_id": 561,
-        "source_id": 33
+        "source_id": 33,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -20898,7 +26653,8 @@
         "_deprecated": false,
         "assertion_id": 562,
         "feature_id": 562,
-        "source_id": 33
+        "source_id": 33,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -20936,7 +26692,8 @@
         "_deprecated": false,
         "assertion_id": 563,
         "feature_id": 563,
-        "source_id": 33
+        "source_id": 33,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -20974,7 +26731,19 @@
         "_deprecated": false,
         "assertion_id": 564,
         "feature_id": 564,
-        "source_id": 33
+        "source_id": 33,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C2668",
+                    "code": "C2668",
+                    "name": "Lenalidomide",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -21012,7 +26781,19 @@
         "_deprecated": false,
         "assertion_id": 565,
         "feature_id": 565,
-        "source_id": 33
+        "source_id": 33,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C2668",
+                    "code": "C2668",
+                    "name": "Lenalidomide",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -21050,7 +26831,19 @@
         "_deprecated": false,
         "assertion_id": 566,
         "feature_id": 566,
-        "source_id": 33
+        "source_id": 33,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C2668",
+                    "code": "C2668",
+                    "name": "Lenalidomide",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -21088,7 +26881,19 @@
         "_deprecated": false,
         "assertion_id": 567,
         "feature_id": 567,
-        "source_id": 33
+        "source_id": 33,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C2668",
+                    "code": "C2668",
+                    "name": "Lenalidomide",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -21126,7 +26931,8 @@
         "_deprecated": false,
         "assertion_id": 568,
         "feature_id": 568,
-        "source_id": 168
+        "source_id": 168,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -21164,7 +26970,8 @@
         "_deprecated": false,
         "assertion_id": 569,
         "feature_id": 569,
-        "source_id": 44
+        "source_id": 44,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -21183,7 +26990,7 @@
         "context": "",
         "oncotree_term": "Rectal Adenocarcinoma",
         "oncotree_code": "READ",
-        "therapy_name": "Neoadjuvant chemoradiation",
+        "therapy_name": "Chemoradiotherapy",
         "therapy_strategy": "Chemotherapy + Radiation",
         "therapy_type": "Combination therapy",
         "therapy_sensitivity": "",
@@ -21202,7 +27009,19 @@
         "_deprecated": false,
         "assertion_id": 570,
         "feature_id": 570,
-        "source_id": 138
+        "source_id": 138,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C94626",
+                    "code": "C94626",
+                    "name": "Chemoradiotherapy",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -21240,7 +27059,19 @@
         "_deprecated": false,
         "assertion_id": 571,
         "feature_id": 571,
-        "source_id": 169
+        "source_id": 169,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C48387",
+                    "code": "C48387",
+                    "name": "Everolimus",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -21278,7 +27109,19 @@
         "_deprecated": false,
         "assertion_id": 572,
         "feature_id": 572,
-        "source_id": 110
+        "source_id": 110,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C48387",
+                    "code": "C48387",
+                    "name": "Everolimus",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -21316,7 +27159,19 @@
         "_deprecated": false,
         "assertion_id": 573,
         "feature_id": 573,
-        "source_id": 110
+        "source_id": 110,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C48387",
+                    "code": "C48387",
+                    "name": "Everolimus",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -21354,7 +27209,19 @@
         "_deprecated": false,
         "assertion_id": 574,
         "feature_id": 574,
-        "source_id": 111
+        "source_id": 111,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C48387",
+                    "code": "C48387",
+                    "name": "Everolimus",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -21392,7 +27259,19 @@
         "_deprecated": false,
         "assertion_id": 575,
         "feature_id": 575,
-        "source_id": 111
+        "source_id": 111,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C48387",
+                    "code": "C48387",
+                    "name": "Everolimus",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -21430,7 +27309,19 @@
         "_deprecated": false,
         "assertion_id": 576,
         "feature_id": 576,
-        "source_id": 149
+        "source_id": 149,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C48387",
+                    "code": "C48387",
+                    "name": "Everolimus",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -21468,7 +27359,19 @@
         "_deprecated": false,
         "assertion_id": 577,
         "feature_id": 577,
-        "source_id": 149
+        "source_id": 149,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C48387",
+                    "code": "C48387",
+                    "name": "Everolimus",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -21506,7 +27409,19 @@
         "_deprecated": false,
         "assertion_id": 578,
         "feature_id": 578,
-        "source_id": 169
+        "source_id": 169,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C48387",
+                    "code": "C48387",
+                    "name": "Everolimus",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -21544,7 +27459,19 @@
         "_deprecated": false,
         "assertion_id": 579,
         "feature_id": 579,
-        "source_id": 110
+        "source_id": 110,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C48387",
+                    "code": "C48387",
+                    "name": "Everolimus",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -21582,7 +27509,19 @@
         "_deprecated": false,
         "assertion_id": 580,
         "feature_id": 580,
-        "source_id": 110
+        "source_id": 110,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C48387",
+                    "code": "C48387",
+                    "name": "Everolimus",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -21620,7 +27559,19 @@
         "_deprecated": false,
         "assertion_id": 581,
         "feature_id": 581,
-        "source_id": 111
+        "source_id": 111,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C48387",
+                    "code": "C48387",
+                    "name": "Everolimus",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -21658,7 +27609,19 @@
         "_deprecated": false,
         "assertion_id": 582,
         "feature_id": 582,
-        "source_id": 111
+        "source_id": 111,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C48387",
+                    "code": "C48387",
+                    "name": "Everolimus",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -21696,7 +27659,8 @@
         "_deprecated": false,
         "assertion_id": 583,
         "feature_id": 583,
-        "source_id": 33
+        "source_id": 33,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -21734,7 +27698,8 @@
         "_deprecated": false,
         "assertion_id": 584,
         "feature_id": 584,
-        "source_id": 33
+        "source_id": 33,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Germline Variant",
@@ -21754,7 +27719,7 @@
         "context": "",
         "oncotree_term": "Any solid tumor",
         "oncotree_code": "",
-        "therapy_name": "Radiation therapy",
+        "therapy_name": "Radiation Therapy",
         "therapy_strategy": "Radiation",
         "therapy_type": "Radiation therapy",
         "therapy_sensitivity": "",
@@ -21774,7 +27739,19 @@
         "_deprecated": false,
         "assertion_id": 585,
         "feature_id": 585,
-        "source_id": 170
+        "source_id": 170,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C15313",
+                    "code": "C15313",
+                    "name": "Radiation Therapy",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Germline Variant",
@@ -21814,7 +27791,8 @@
         "_deprecated": false,
         "assertion_id": 586,
         "feature_id": 586,
-        "source_id": 171
+        "source_id": 171,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Germline Variant",
@@ -21854,7 +27832,19 @@
         "_deprecated": false,
         "assertion_id": 587,
         "feature_id": 587,
-        "source_id": 57
+        "source_id": 57,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C71721",
+                    "code": "C71721",
+                    "name": "Olaparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Germline Variant",
@@ -21894,7 +27884,8 @@
         "_deprecated": false,
         "assertion_id": 588,
         "feature_id": 588,
-        "source_id": 59
+        "source_id": 59,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Germline Variant",
@@ -21934,7 +27925,8 @@
         "_deprecated": false,
         "assertion_id": 589,
         "feature_id": 589,
-        "source_id": 59
+        "source_id": 59,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Germline Variant",
@@ -21974,7 +27966,8 @@
         "_deprecated": false,
         "assertion_id": 590,
         "feature_id": 590,
-        "source_id": 59
+        "source_id": 59,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Germline Variant",
@@ -22014,7 +28007,8 @@
         "_deprecated": false,
         "assertion_id": 591,
         "feature_id": 591,
-        "source_id": 59
+        "source_id": 59,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Germline Variant",
@@ -22054,7 +28048,8 @@
         "_deprecated": false,
         "assertion_id": 592,
         "feature_id": 592,
-        "source_id": 59
+        "source_id": 59,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Germline Variant",
@@ -22094,7 +28089,8 @@
         "_deprecated": false,
         "assertion_id": 593,
         "feature_id": 593,
-        "source_id": 59
+        "source_id": 59,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Germline Variant",
@@ -22134,7 +28130,19 @@
         "_deprecated": false,
         "assertion_id": 594,
         "feature_id": 594,
-        "source_id": 86
+        "source_id": 86,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C80059",
+                    "code": "C80059",
+                    "name": "Niraparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Germline Variant",
@@ -22174,7 +28182,19 @@
         "_deprecated": false,
         "assertion_id": 595,
         "feature_id": 595,
-        "source_id": 86
+        "source_id": 86,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C80059",
+                    "code": "C80059",
+                    "name": "Niraparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Germline Variant",
@@ -22214,7 +28234,19 @@
         "_deprecated": false,
         "assertion_id": 596,
         "feature_id": 596,
-        "source_id": 86
+        "source_id": 86,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C80059",
+                    "code": "C80059",
+                    "name": "Niraparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Germline Variant",
@@ -22254,7 +28286,19 @@
         "_deprecated": false,
         "assertion_id": 597,
         "feature_id": 597,
-        "source_id": 172
+        "source_id": 172,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C71721",
+                    "code": "C71721",
+                    "name": "Olaparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Germline Variant",
@@ -22294,7 +28338,19 @@
         "_deprecated": false,
         "assertion_id": 598,
         "feature_id": 598,
-        "source_id": 81
+        "source_id": 81,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C71721",
+                    "code": "C71721",
+                    "name": "Olaparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Germline Variant",
@@ -22334,7 +28390,19 @@
         "_deprecated": false,
         "assertion_id": 599,
         "feature_id": 599,
-        "source_id": 81
+        "source_id": 81,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C71721",
+                    "code": "C71721",
+                    "name": "Olaparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Germline Variant",
@@ -22374,7 +28442,19 @@
         "_deprecated": false,
         "assertion_id": 600,
         "feature_id": 600,
-        "source_id": 81
+        "source_id": 81,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C71721",
+                    "code": "C71721",
+                    "name": "Olaparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Germline Variant",
@@ -22414,7 +28494,19 @@
         "_deprecated": false,
         "assertion_id": 601,
         "feature_id": 601,
-        "source_id": 173
+        "source_id": 173,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C71721",
+                    "code": "C71721",
+                    "name": "Olaparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Germline Variant",
@@ -22434,7 +28526,7 @@
         "context": "",
         "oncotree_term": "Pancreatic Adenocarcinoma",
         "oncotree_code": "PAAD",
-        "therapy_name": "Platinum",
+        "therapy_name": "Platinum Compound",
         "therapy_strategy": "Platinum-based chemotherapy",
         "therapy_type": "Chemotherapy",
         "therapy_sensitivity": 1,
@@ -22454,7 +28546,19 @@
         "_deprecated": false,
         "assertion_id": 602,
         "feature_id": 602,
-        "source_id": 85
+        "source_id": 85,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C1450",
+                    "code": "C1450",
+                    "name": "Platinum Compound",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Germline Variant",
@@ -22494,7 +28598,19 @@
         "_deprecated": false,
         "assertion_id": 603,
         "feature_id": 603,
-        "source_id": 174
+        "source_id": 174,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C71721",
+                    "code": "C71721",
+                    "name": "Olaparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Germline Variant",
@@ -22534,7 +28650,19 @@
         "_deprecated": false,
         "assertion_id": 604,
         "feature_id": 604,
-        "source_id": 174
+        "source_id": 174,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C95733",
+                    "code": "C95733",
+                    "name": "Talazoparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Germline Variant",
@@ -22574,7 +28702,19 @@
         "_deprecated": false,
         "assertion_id": 605,
         "feature_id": 605,
-        "source_id": 174
+        "source_id": 174,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C1282",
+                    "code": "C1282",
+                    "name": "Carboplatin",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Germline Variant",
@@ -22614,7 +28754,19 @@
         "_deprecated": false,
         "assertion_id": 606,
         "feature_id": 606,
-        "source_id": 174
+        "source_id": 174,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C376",
+                    "code": "C376",
+                    "name": "Cisplatin",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Germline Variant",
@@ -22654,7 +28806,19 @@
         "_deprecated": false,
         "assertion_id": 607,
         "feature_id": 607,
-        "source_id": 175
+        "source_id": 175,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C95733",
+                    "code": "C95733",
+                    "name": "Talazoparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Germline Variant",
@@ -22694,7 +28858,19 @@
         "_deprecated": false,
         "assertion_id": 608,
         "feature_id": 608,
-        "source_id": 86
+        "source_id": 86,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C80059",
+                    "code": "C80059",
+                    "name": "Niraparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Germline Variant",
@@ -22734,7 +28910,19 @@
         "_deprecated": false,
         "assertion_id": 609,
         "feature_id": 609,
-        "source_id": 86
+        "source_id": 86,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C80059",
+                    "code": "C80059",
+                    "name": "Niraparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Germline Variant",
@@ -22774,7 +28962,19 @@
         "_deprecated": false,
         "assertion_id": 610,
         "feature_id": 610,
-        "source_id": 86
+        "source_id": 86,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C80059",
+                    "code": "C80059",
+                    "name": "Niraparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Germline Variant",
@@ -22814,7 +29014,19 @@
         "_deprecated": false,
         "assertion_id": 611,
         "feature_id": 611,
-        "source_id": 58
+        "source_id": 58,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C71721",
+                    "code": "C71721",
+                    "name": "Olaparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Germline Variant",
@@ -22854,7 +29066,19 @@
         "_deprecated": false,
         "assertion_id": 612,
         "feature_id": 612,
-        "source_id": 174
+        "source_id": 174,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C71721",
+                    "code": "C71721",
+                    "name": "Olaparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Germline Variant",
@@ -22894,7 +29118,19 @@
         "_deprecated": false,
         "assertion_id": 613,
         "feature_id": 613,
-        "source_id": 174
+        "source_id": 174,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C95733",
+                    "code": "C95733",
+                    "name": "Talazoparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Germline Variant",
@@ -22934,7 +29170,19 @@
         "_deprecated": false,
         "assertion_id": 614,
         "feature_id": 614,
-        "source_id": 174
+        "source_id": 174,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C1282",
+                    "code": "C1282",
+                    "name": "Carboplatin",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Germline Variant",
@@ -22974,7 +29222,19 @@
         "_deprecated": false,
         "assertion_id": 615,
         "feature_id": 615,
-        "source_id": 174
+        "source_id": 174,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C376",
+                    "code": "C376",
+                    "name": "Cisplatin",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Germline Variant",
@@ -23014,7 +29274,19 @@
         "_deprecated": false,
         "assertion_id": 616,
         "feature_id": 616,
-        "source_id": 176
+        "source_id": 176,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C95733",
+                    "code": "C95733",
+                    "name": "Talazoparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Germline Variant",
@@ -23054,7 +29326,19 @@
         "_deprecated": false,
         "assertion_id": 617,
         "feature_id": 617,
-        "source_id": 172
+        "source_id": 172,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C71721",
+                    "code": "C71721",
+                    "name": "Olaparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Germline Variant",
@@ -23094,7 +29378,19 @@
         "_deprecated": false,
         "assertion_id": 618,
         "feature_id": 618,
-        "source_id": 86
+        "source_id": 86,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C80059",
+                    "code": "C80059",
+                    "name": "Niraparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Germline Variant",
@@ -23134,7 +29430,19 @@
         "_deprecated": false,
         "assertion_id": 619,
         "feature_id": 619,
-        "source_id": 86
+        "source_id": 86,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C80059",
+                    "code": "C80059",
+                    "name": "Niraparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Germline Variant",
@@ -23174,7 +29482,19 @@
         "_deprecated": false,
         "assertion_id": 620,
         "feature_id": 620,
-        "source_id": 86
+        "source_id": 86,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C80059",
+                    "code": "C80059",
+                    "name": "Niraparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Germline Variant",
@@ -23214,7 +29534,19 @@
         "_deprecated": false,
         "assertion_id": 621,
         "feature_id": 621,
-        "source_id": 177
+        "source_id": 177,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C71721",
+                    "code": "C71721",
+                    "name": "Olaparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Germline Variant",
@@ -23254,7 +29586,19 @@
         "_deprecated": false,
         "assertion_id": 622,
         "feature_id": 622,
-        "source_id": 177
+        "source_id": 177,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C71721",
+                    "code": "C71721",
+                    "name": "Olaparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Germline Variant",
@@ -23294,7 +29638,19 @@
         "_deprecated": false,
         "assertion_id": 623,
         "feature_id": 623,
-        "source_id": 177
+        "source_id": 177,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C71721",
+                    "code": "C71721",
+                    "name": "Olaparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Germline Variant",
@@ -23334,7 +29690,19 @@
         "_deprecated": false,
         "assertion_id": 624,
         "feature_id": 624,
-        "source_id": 173
+        "source_id": 173,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C71721",
+                    "code": "C71721",
+                    "name": "Olaparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Germline Variant",
@@ -23374,7 +29742,19 @@
         "_deprecated": false,
         "assertion_id": 625,
         "feature_id": 625,
-        "source_id": 88
+        "source_id": 88,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C71721",
+                    "code": "C71721",
+                    "name": "Olaparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Germline Variant",
@@ -23394,7 +29774,7 @@
         "context": "",
         "oncotree_term": "Pancreatic Adenocarcinoma",
         "oncotree_code": "PAAD",
-        "therapy_name": "Platinum",
+        "therapy_name": "Platinum Compound",
         "therapy_strategy": "Platinum-based chemotherapy",
         "therapy_type": "Chemotherapy",
         "therapy_sensitivity": 1,
@@ -23414,7 +29794,19 @@
         "_deprecated": false,
         "assertion_id": 626,
         "feature_id": 626,
-        "source_id": 85
+        "source_id": 85,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C1450",
+                    "code": "C1450",
+                    "name": "Platinum Compound",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Germline Variant",
@@ -23454,7 +29846,19 @@
         "_deprecated": false,
         "assertion_id": 627,
         "feature_id": 627,
-        "source_id": 58
+        "source_id": 58,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C71721",
+                    "code": "C71721",
+                    "name": "Olaparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Germline Variant",
@@ -23494,7 +29898,8 @@
         "_deprecated": false,
         "assertion_id": 628,
         "feature_id": 628,
-        "source_id": 59
+        "source_id": 59,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Germline Variant",
@@ -23534,7 +29939,8 @@
         "_deprecated": false,
         "assertion_id": 629,
         "feature_id": 629,
-        "source_id": 59
+        "source_id": 59,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Germline Variant",
@@ -23574,7 +29980,8 @@
         "_deprecated": false,
         "assertion_id": 630,
         "feature_id": 630,
-        "source_id": 59
+        "source_id": 59,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Germline Variant",
@@ -23614,7 +30021,8 @@
         "_deprecated": false,
         "assertion_id": 631,
         "feature_id": 631,
-        "source_id": 59
+        "source_id": 59,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Germline Variant",
@@ -23654,7 +30062,8 @@
         "_deprecated": false,
         "assertion_id": 632,
         "feature_id": 632,
-        "source_id": 59
+        "source_id": 59,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Germline Variant",
@@ -23694,7 +30103,8 @@
         "_deprecated": false,
         "assertion_id": 633,
         "feature_id": 633,
-        "source_id": 59
+        "source_id": 59,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Germline Variant",
@@ -23734,7 +30144,8 @@
         "_deprecated": false,
         "assertion_id": 634,
         "feature_id": 634,
-        "source_id": 59
+        "source_id": 59,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Germline Variant",
@@ -23774,7 +30185,8 @@
         "_deprecated": false,
         "assertion_id": 635,
         "feature_id": 635,
-        "source_id": 59
+        "source_id": 59,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Germline Variant",
@@ -23814,7 +30226,8 @@
         "_deprecated": false,
         "assertion_id": 636,
         "feature_id": 636,
-        "source_id": 59
+        "source_id": 59,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Germline Variant",
@@ -23854,7 +30267,8 @@
         "_deprecated": false,
         "assertion_id": 637,
         "feature_id": 637,
-        "source_id": 59
+        "source_id": 59,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Germline Variant",
@@ -23894,7 +30308,8 @@
         "_deprecated": false,
         "assertion_id": 638,
         "feature_id": 638,
-        "source_id": 59
+        "source_id": 59,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Germline Variant",
@@ -23934,7 +30349,8 @@
         "_deprecated": false,
         "assertion_id": 639,
         "feature_id": 639,
-        "source_id": 59
+        "source_id": 59,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Germline Variant",
@@ -23974,7 +30390,8 @@
         "_deprecated": false,
         "assertion_id": 640,
         "feature_id": 640,
-        "source_id": 178
+        "source_id": 178,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Germline Variant",
@@ -24014,7 +30431,8 @@
         "_deprecated": false,
         "assertion_id": 641,
         "feature_id": 641,
-        "source_id": 80
+        "source_id": 80,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Germline Variant",
@@ -24054,7 +30472,8 @@
         "_deprecated": false,
         "assertion_id": 642,
         "feature_id": 642,
-        "source_id": 179
+        "source_id": 179,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Germline Variant",
@@ -24094,7 +30513,8 @@
         "_deprecated": false,
         "assertion_id": 643,
         "feature_id": 643,
-        "source_id": 179
+        "source_id": 179,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Germline Variant",
@@ -24134,7 +30554,8 @@
         "_deprecated": false,
         "assertion_id": 644,
         "feature_id": 644,
-        "source_id": 179
+        "source_id": 179,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Germline Variant",
@@ -24174,7 +30595,8 @@
         "_deprecated": false,
         "assertion_id": 645,
         "feature_id": 645,
-        "source_id": 179
+        "source_id": 179,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Germline Variant",
@@ -24214,7 +30636,8 @@
         "_deprecated": false,
         "assertion_id": 646,
         "feature_id": 646,
-        "source_id": 179
+        "source_id": 179,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Germline Variant",
@@ -24254,7 +30677,8 @@
         "_deprecated": false,
         "assertion_id": 647,
         "feature_id": 647,
-        "source_id": 80
+        "source_id": 80,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Germline Variant",
@@ -24294,7 +30718,19 @@
         "_deprecated": false,
         "assertion_id": 648,
         "feature_id": 648,
-        "source_id": 147
+        "source_id": 147,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C106432",
+                    "code": "C106432",
+                    "name": "Pembrolizumab",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Germline Variant",
@@ -24334,7 +30770,8 @@
         "_deprecated": false,
         "assertion_id": 649,
         "feature_id": 649,
-        "source_id": 179
+        "source_id": 179,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Germline Variant",
@@ -24374,7 +30811,8 @@
         "_deprecated": false,
         "assertion_id": 650,
         "feature_id": 650,
-        "source_id": 179
+        "source_id": 179,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Germline Variant",
@@ -24414,7 +30852,8 @@
         "_deprecated": false,
         "assertion_id": 651,
         "feature_id": 651,
-        "source_id": 179
+        "source_id": 179,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Germline Variant",
@@ -24454,7 +30893,8 @@
         "_deprecated": false,
         "assertion_id": 652,
         "feature_id": 652,
-        "source_id": 80
+        "source_id": 80,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Germline Variant",
@@ -24494,7 +30934,19 @@
         "_deprecated": false,
         "assertion_id": 653,
         "feature_id": 653,
-        "source_id": 147
+        "source_id": 147,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C106432",
+                    "code": "C106432",
+                    "name": "Pembrolizumab",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Germline Variant",
@@ -24534,7 +30986,8 @@
         "_deprecated": false,
         "assertion_id": 654,
         "feature_id": 654,
-        "source_id": 80
+        "source_id": 80,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Germline Variant",
@@ -24574,7 +31027,19 @@
         "_deprecated": false,
         "assertion_id": 655,
         "feature_id": 655,
-        "source_id": 147
+        "source_id": 147,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C106432",
+                    "code": "C106432",
+                    "name": "Pembrolizumab",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Germline Variant",
@@ -24594,7 +31059,7 @@
         "context": "",
         "oncotree_term": "Any solid tumor",
         "oncotree_code": "",
-        "therapy_name": "Radiation therapy",
+        "therapy_name": "Radiation Therapy",
         "therapy_strategy": "Radiation",
         "therapy_type": "Radiation therapy",
         "therapy_sensitivity": "",
@@ -24614,7 +31079,19 @@
         "_deprecated": false,
         "assertion_id": 656,
         "feature_id": 656,
-        "source_id": 180
+        "source_id": 180,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C15313",
+                    "code": "C15313",
+                    "name": "Radiation Therapy",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Germline Variant",
@@ -24654,7 +31131,8 @@
         "_deprecated": false,
         "assertion_id": 657,
         "feature_id": 657,
-        "source_id": 59
+        "source_id": 59,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Germline Variant",
@@ -24694,7 +31172,8 @@
         "_deprecated": false,
         "assertion_id": 658,
         "feature_id": 658,
-        "source_id": 59
+        "source_id": 59,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Germline Variant",
@@ -24734,7 +31213,8 @@
         "_deprecated": false,
         "assertion_id": 659,
         "feature_id": 659,
-        "source_id": 59
+        "source_id": 59,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Germline Variant",
@@ -24774,7 +31254,8 @@
         "_deprecated": false,
         "assertion_id": 660,
         "feature_id": 660,
-        "source_id": 59
+        "source_id": 59,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Germline Variant",
@@ -24814,7 +31295,8 @@
         "_deprecated": false,
         "assertion_id": 661,
         "feature_id": 661,
-        "source_id": 59
+        "source_id": 59,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Germline Variant",
@@ -24854,7 +31336,8 @@
         "_deprecated": false,
         "assertion_id": 662,
         "feature_id": 662,
-        "source_id": 59
+        "source_id": 59,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Germline Variant",
@@ -24874,7 +31357,7 @@
         "context": "",
         "oncotree_term": "Pancreatic Adenocarcinoma",
         "oncotree_code": "PAAD",
-        "therapy_name": "Platinum",
+        "therapy_name": "Platinum Compound",
         "therapy_strategy": "Platinum-based chemotherapy",
         "therapy_type": "Chemotherapy",
         "therapy_sensitivity": 1,
@@ -24894,7 +31377,19 @@
         "_deprecated": false,
         "assertion_id": 663,
         "feature_id": 663,
-        "source_id": 85
+        "source_id": 85,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C1450",
+                    "code": "C1450",
+                    "name": "Platinum Compound",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Germline Variant",
@@ -24934,7 +31429,8 @@
         "_deprecated": false,
         "assertion_id": 664,
         "feature_id": 664,
-        "source_id": 171
+        "source_id": 171,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Germline Variant",
@@ -24974,7 +31470,8 @@
         "_deprecated": false,
         "assertion_id": 665,
         "feature_id": 665,
-        "source_id": 80
+        "source_id": 80,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Germline Variant",
@@ -25014,7 +31511,8 @@
         "_deprecated": false,
         "assertion_id": 666,
         "feature_id": 666,
-        "source_id": 179
+        "source_id": 179,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Germline Variant",
@@ -25054,7 +31552,8 @@
         "_deprecated": false,
         "assertion_id": 667,
         "feature_id": 667,
-        "source_id": 179
+        "source_id": 179,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Germline Variant",
@@ -25094,7 +31593,8 @@
         "_deprecated": false,
         "assertion_id": 668,
         "feature_id": 668,
-        "source_id": 179
+        "source_id": 179,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Germline Variant",
@@ -25134,7 +31634,8 @@
         "_deprecated": false,
         "assertion_id": 669,
         "feature_id": 669,
-        "source_id": 179
+        "source_id": 179,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Germline Variant",
@@ -25174,7 +31675,8 @@
         "_deprecated": false,
         "assertion_id": 670,
         "feature_id": 670,
-        "source_id": 59
+        "source_id": 59,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Germline Variant",
@@ -25214,7 +31716,8 @@
         "_deprecated": false,
         "assertion_id": 671,
         "feature_id": 671,
-        "source_id": 59
+        "source_id": 59,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Germline Variant",
@@ -25254,7 +31757,8 @@
         "_deprecated": false,
         "assertion_id": 672,
         "feature_id": 672,
-        "source_id": 59
+        "source_id": 59,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Germline Variant",
@@ -25294,7 +31798,8 @@
         "_deprecated": false,
         "assertion_id": 673,
         "feature_id": 673,
-        "source_id": 59
+        "source_id": 59,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Germline Variant",
@@ -25334,7 +31839,8 @@
         "_deprecated": false,
         "assertion_id": 674,
         "feature_id": 674,
-        "source_id": 59
+        "source_id": 59,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Germline Variant",
@@ -25374,7 +31880,8 @@
         "_deprecated": false,
         "assertion_id": 675,
         "feature_id": 675,
-        "source_id": 59
+        "source_id": 59,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Germline Variant",
@@ -25414,7 +31921,8 @@
         "_deprecated": false,
         "assertion_id": 676,
         "feature_id": 676,
-        "source_id": 59
+        "source_id": 59,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Germline Variant",
@@ -25454,7 +31962,8 @@
         "_deprecated": false,
         "assertion_id": 677,
         "feature_id": 677,
-        "source_id": 59
+        "source_id": 59,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Germline Variant",
@@ -25494,7 +32003,8 @@
         "_deprecated": false,
         "assertion_id": 678,
         "feature_id": 678,
-        "source_id": 59
+        "source_id": 59,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Germline Variant",
@@ -25534,7 +32044,8 @@
         "_deprecated": false,
         "assertion_id": 679,
         "feature_id": 679,
-        "source_id": 59
+        "source_id": 59,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Germline Variant",
@@ -25574,7 +32085,8 @@
         "_deprecated": false,
         "assertion_id": 680,
         "feature_id": 680,
-        "source_id": 59
+        "source_id": 59,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Germline Variant",
@@ -25614,7 +32126,8 @@
         "_deprecated": false,
         "assertion_id": 681,
         "feature_id": 681,
-        "source_id": 59
+        "source_id": 59,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Germline Variant",
@@ -25634,7 +32147,7 @@
         "context": "",
         "oncotree_term": "Any solid tumor",
         "oncotree_code": "",
-        "therapy_name": "Radiation therapy",
+        "therapy_name": "Radiation Therapy",
         "therapy_strategy": "Radiation",
         "therapy_type": "Radiation therapy",
         "therapy_sensitivity": "",
@@ -25654,7 +32167,19 @@
         "_deprecated": false,
         "assertion_id": 682,
         "feature_id": 682,
-        "source_id": 180
+        "source_id": 180,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C15313",
+                    "code": "C15313",
+                    "name": "Radiation Therapy",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Germline Variant",
@@ -25674,7 +32199,7 @@
         "context": "",
         "oncotree_term": "Any solid tumor",
         "oncotree_code": "",
-        "therapy_name": "Radiation therapy",
+        "therapy_name": "Radiation Therapy",
         "therapy_strategy": "Radiation",
         "therapy_type": "Radiation therapy",
         "therapy_sensitivity": "",
@@ -25694,7 +32219,19 @@
         "_deprecated": false,
         "assertion_id": 683,
         "feature_id": 683,
-        "source_id": 180
+        "source_id": 180,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C15313",
+                    "code": "C15313",
+                    "name": "Radiation Therapy",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Copy Number",
@@ -25724,7 +32261,19 @@
         "_deprecated": false,
         "assertion_id": 684,
         "feature_id": 684,
-        "source_id": 181
+        "source_id": 181,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C77333",
+                    "code": "C77333",
+                    "name": "Abiraterone",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Copy Number",
@@ -25754,7 +32303,19 @@
         "_deprecated": false,
         "assertion_id": 685,
         "feature_id": 685,
-        "source_id": 181
+        "source_id": 181,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C77333",
+                    "code": "C77333",
+                    "name": "Abiraterone",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Copy Number",
@@ -25784,7 +32345,19 @@
         "_deprecated": false,
         "assertion_id": 686,
         "feature_id": 686,
-        "source_id": 181
+        "source_id": 181,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C71744",
+                    "code": "C71744",
+                    "name": "Enzalutamide",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Copy Number",
@@ -25795,7 +32368,7 @@
         "context": "Triple-negative",
         "oncotree_term": "Invasive Breast Carcinoma",
         "oncotree_code": "BRCA",
-        "therapy_name": "Radiation therapy",
+        "therapy_name": "Radiation Therapy",
         "therapy_strategy": "Radiation",
         "therapy_type": "Radiation therapy",
         "therapy_sensitivity": "",
@@ -25814,7 +32387,19 @@
         "_deprecated": false,
         "assertion_id": 687,
         "feature_id": 687,
-        "source_id": 182
+        "source_id": 182,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C15313",
+                    "code": "C15313",
+                    "name": "Radiation Therapy",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Copy Number",
@@ -25844,7 +32429,19 @@
         "_deprecated": false,
         "assertion_id": 688,
         "feature_id": 688,
-        "source_id": 53
+        "source_id": 53,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C103194",
+                    "code": "C103194",
+                    "name": "Durvalumab",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Copy Number",
@@ -25874,7 +32471,19 @@
         "_deprecated": false,
         "assertion_id": 689,
         "feature_id": 689,
-        "source_id": 183
+        "source_id": 183,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C61587",
+                    "code": "C61587",
+                    "name": "Danusertib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Copy Number",
@@ -25904,7 +32513,8 @@
         "_deprecated": false,
         "assertion_id": 690,
         "feature_id": 690,
-        "source_id": 184
+        "source_id": 184,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Copy Number",
@@ -25934,7 +32544,19 @@
         "_deprecated": false,
         "assertion_id": 691,
         "feature_id": 691,
-        "source_id": 185
+        "source_id": 185,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C62502",
+                    "code": "C62502",
+                    "name": "Barasertib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Copy Number",
@@ -25964,7 +32586,19 @@
         "_deprecated": false,
         "assertion_id": 692,
         "feature_id": 692,
-        "source_id": 186
+        "source_id": 186,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C66939",
+                    "code": "C66939",
+                    "name": "Selumetinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Copy Number",
@@ -25994,7 +32628,19 @@
         "_deprecated": false,
         "assertion_id": 693,
         "feature_id": 693,
-        "source_id": 78
+        "source_id": 78,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C64768",
+                    "code": "C64768",
+                    "name": "Vemurafenib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Copy Number",
@@ -26024,7 +32670,19 @@
         "_deprecated": false,
         "assertion_id": 694,
         "feature_id": 694,
-        "source_id": 88
+        "source_id": 88,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C71721",
+                    "code": "C71721",
+                    "name": "Olaparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Copy Number",
@@ -26054,7 +32712,8 @@
         "_deprecated": false,
         "assertion_id": 695,
         "feature_id": 695,
-        "source_id": 187
+        "source_id": 187,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Copy Number",
@@ -26084,7 +32743,19 @@
         "_deprecated": false,
         "assertion_id": 696,
         "feature_id": 696,
-        "source_id": 54
+        "source_id": 54,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C49176",
+                    "code": "C49176",
+                    "name": "Palbociclib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Copy Number",
@@ -26114,7 +32785,19 @@
         "_deprecated": false,
         "assertion_id": 697,
         "feature_id": 697,
-        "source_id": 188
+        "source_id": 188,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C1851",
+                    "code": "C1851",
+                    "name": "Bortezomib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Copy Number",
@@ -26144,7 +32827,19 @@
         "_deprecated": false,
         "assertion_id": 698,
         "feature_id": 698,
-        "source_id": 189
+        "source_id": 189,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C106432",
+                    "code": "C106432",
+                    "name": "Pembrolizumab",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Copy Number",
@@ -26174,7 +32869,19 @@
         "_deprecated": false,
         "assertion_id": 699,
         "feature_id": 699,
-        "source_id": 190
+        "source_id": 190,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C106250",
+                    "code": "C106250",
+                    "name": "Atezolizumab",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Copy Number",
@@ -26204,7 +32911,29 @@
         "_deprecated": false,
         "assertion_id": 700,
         "feature_id": 700,
-        "source_id": 191
+        "source_id": 191,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C15632",
+                    "code": "C15632",
+                    "name": "Chemotherapy",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C106432",
+                    "code": "C106432",
+                    "name": "Pembrolizumab",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Copy Number",
@@ -26234,7 +32963,19 @@
         "_deprecated": false,
         "assertion_id": 701,
         "feature_id": 701,
-        "source_id": 192
+        "source_id": 192,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C106432",
+                    "code": "C106432",
+                    "name": "Pembrolizumab",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Copy Number",
@@ -26264,7 +33005,19 @@
         "_deprecated": false,
         "assertion_id": 702,
         "feature_id": 702,
-        "source_id": 192
+        "source_id": 192,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C106432",
+                    "code": "C106432",
+                    "name": "Pembrolizumab",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Copy Number",
@@ -26294,7 +33047,19 @@
         "_deprecated": false,
         "assertion_id": 703,
         "feature_id": 703,
-        "source_id": 193
+        "source_id": 193,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C106250",
+                    "code": "C106250",
+                    "name": "Atezolizumab",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Copy Number",
@@ -26324,7 +33089,19 @@
         "_deprecated": false,
         "assertion_id": 704,
         "feature_id": 704,
-        "source_id": 194
+        "source_id": 194,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C49176",
+                    "code": "C49176",
+                    "name": "Palbociclib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Copy Number",
@@ -26354,7 +33131,19 @@
         "_deprecated": false,
         "assertion_id": 705,
         "feature_id": 705,
-        "source_id": 194
+        "source_id": 194,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C49176",
+                    "code": "C49176",
+                    "name": "Palbociclib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Copy Number",
@@ -26384,7 +33173,19 @@
         "_deprecated": false,
         "assertion_id": 706,
         "feature_id": 706,
-        "source_id": 195
+        "source_id": 195,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C49176",
+                    "code": "C49176",
+                    "name": "Palbociclib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Copy Number",
@@ -26414,7 +33215,19 @@
         "_deprecated": false,
         "assertion_id": 707,
         "feature_id": 707,
-        "source_id": 54
+        "source_id": 54,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C49176",
+                    "code": "C49176",
+                    "name": "Palbociclib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Copy Number",
@@ -26444,7 +33257,8 @@
         "_deprecated": false,
         "assertion_id": 708,
         "feature_id": 708,
-        "source_id": 196
+        "source_id": 196,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Copy Number",
@@ -26474,7 +33288,19 @@
         "_deprecated": false,
         "assertion_id": 709,
         "feature_id": 709,
-        "source_id": 54
+        "source_id": 54,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C49176",
+                    "code": "C49176",
+                    "name": "Palbociclib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Copy Number",
@@ -26504,7 +33330,8 @@
         "_deprecated": false,
         "assertion_id": 710,
         "feature_id": 710,
-        "source_id": 197
+        "source_id": 197,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Copy Number",
@@ -26534,7 +33361,19 @@
         "_deprecated": false,
         "assertion_id": 711,
         "feature_id": 711,
-        "source_id": 16
+        "source_id": 16,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C49176",
+                    "code": "C49176",
+                    "name": "Palbociclib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Copy Number",
@@ -26564,7 +33403,19 @@
         "_deprecated": false,
         "assertion_id": 712,
         "feature_id": 712,
-        "source_id": 198
+        "source_id": 198,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C1855",
+                    "code": "C1855",
+                    "name": "Gefitinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Copy Number",
@@ -26594,7 +33445,19 @@
         "_deprecated": false,
         "assertion_id": 713,
         "feature_id": 713,
-        "source_id": 96
+        "source_id": 96,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C1855",
+                    "code": "C1855",
+                    "name": "Gefitinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Copy Number",
@@ -26624,7 +33487,29 @@
         "_deprecated": false,
         "assertion_id": 714,
         "feature_id": 714,
-        "source_id": 199
+        "source_id": 199,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C26653",
+                    "code": "C26653",
+                    "name": "Lapatinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C1647",
+                    "code": "C1647",
+                    "name": "Trastuzumab",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Copy Number",
@@ -26635,7 +33520,7 @@
         "context": "",
         "oncotree_term": "Invasive Breast Carcinoma",
         "oncotree_code": "BRCA",
-        "therapy_name": "Ado-Trastuzumab Emtansine",
+        "therapy_name": "Trastuzumab Emtansine",
         "therapy_strategy": "ER signaling inhibition",
         "therapy_type": "Hormone therapy",
         "therapy_sensitivity": 1,
@@ -26654,7 +33539,19 @@
         "_deprecated": false,
         "assertion_id": 715,
         "feature_id": 715,
-        "source_id": 200
+        "source_id": 200,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C82492",
+                    "code": "C82492",
+                    "name": "Trastuzumab Emtansine",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Copy Number",
@@ -26684,7 +33581,19 @@
         "_deprecated": false,
         "assertion_id": 716,
         "feature_id": 716,
-        "source_id": 201
+        "source_id": 201,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C26653",
+                    "code": "C26653",
+                    "name": "Lapatinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Copy Number",
@@ -26714,7 +33623,29 @@
         "_deprecated": false,
         "assertion_id": 717,
         "feature_id": 717,
-        "source_id": 201
+        "source_id": 201,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C26653",
+                    "code": "C26653",
+                    "name": "Lapatinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C1647",
+                    "code": "C1647",
+                    "name": "Trastuzumab",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Copy Number",
@@ -26744,7 +33675,19 @@
         "_deprecated": false,
         "assertion_id": 718,
         "feature_id": 718,
-        "source_id": 202
+        "source_id": 202,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C49094",
+                    "code": "C49094",
+                    "name": "Neratinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Copy Number",
@@ -26774,7 +33717,29 @@
         "_deprecated": false,
         "assertion_id": 719,
         "feature_id": 719,
-        "source_id": 203
+        "source_id": 203,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C38692",
+                    "code": "C38692",
+                    "name": "Pertuzumab",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C1647",
+                    "code": "C1647",
+                    "name": "Trastuzumab",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Copy Number",
@@ -26804,7 +33769,19 @@
         "_deprecated": false,
         "assertion_id": 720,
         "feature_id": 720,
-        "source_id": 204
+        "source_id": 204,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C1647",
+                    "code": "C1647",
+                    "name": "Trastuzumab",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Copy Number",
@@ -26834,7 +33811,19 @@
         "_deprecated": false,
         "assertion_id": 721,
         "feature_id": 721,
-        "source_id": 204
+        "source_id": 204,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C1647",
+                    "code": "C1647",
+                    "name": "Trastuzumab",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Copy Number",
@@ -26864,7 +33853,19 @@
         "_deprecated": false,
         "assertion_id": 722,
         "feature_id": 722,
-        "source_id": 204
+        "source_id": 204,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C1647",
+                    "code": "C1647",
+                    "name": "Trastuzumab",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Copy Number",
@@ -26894,7 +33895,29 @@
         "_deprecated": false,
         "assertion_id": 723,
         "feature_id": 723,
-        "source_id": 205
+        "source_id": 205,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C15632",
+                    "code": "C15632",
+                    "name": "Chemotherapy",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C1647",
+                    "code": "C1647",
+                    "name": "Trastuzumab",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Copy Number",
@@ -26924,7 +33947,39 @@
         "_deprecated": false,
         "assertion_id": 724,
         "feature_id": 724,
-        "source_id": 206
+        "source_id": 206,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C1794",
+                    "code": "C1794",
+                    "name": "Capecitabine",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C1647",
+                    "code": "C1647",
+                    "name": "Trastuzumab",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C77896",
+                    "code": "C77896",
+                    "name": "Tucatinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Copy Number",
@@ -26954,7 +34009,8 @@
         "_deprecated": false,
         "assertion_id": 725,
         "feature_id": 725,
-        "source_id": 207
+        "source_id": 207,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Copy Number",
@@ -26965,7 +34021,7 @@
         "context": "",
         "oncotree_term": "Invasive Breast Carcinoma",
         "oncotree_code": "BRCA",
-        "therapy_name": "Radiation therapy",
+        "therapy_name": "Radiation Therapy",
         "therapy_strategy": "Radiation",
         "therapy_type": "Radiation therapy",
         "therapy_sensitivity": "",
@@ -26984,7 +34040,19 @@
         "_deprecated": false,
         "assertion_id": 726,
         "feature_id": 726,
-        "source_id": 208
+        "source_id": 208,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C15313",
+                    "code": "C15313",
+                    "name": "Radiation Therapy",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Copy Number",
@@ -27014,7 +34082,39 @@
         "_deprecated": false,
         "assertion_id": 727,
         "feature_id": 727,
-        "source_id": 209
+        "source_id": 209,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C15632",
+                    "code": "C15632",
+                    "name": "Chemotherapy",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C38692",
+                    "code": "C38692",
+                    "name": "Pertuzumab",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C1647",
+                    "code": "C1647",
+                    "name": "Trastuzumab",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Copy Number",
@@ -27044,7 +34144,39 @@
         "_deprecated": false,
         "assertion_id": 728,
         "feature_id": 728,
-        "source_id": 209
+        "source_id": 209,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C1526",
+                    "code": "C1526",
+                    "name": "Docetaxel",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C38692",
+                    "code": "C38692",
+                    "name": "Pertuzumab",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C1647",
+                    "code": "C1647",
+                    "name": "Trastuzumab",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Copy Number",
@@ -27055,7 +34187,7 @@
         "context": "Metastatic",
         "oncotree_term": "Invasive Breast Carcinoma",
         "oncotree_code": "BRCA",
-        "therapy_name": "Margetuximab-cmkb + Chemotherapy",
+        "therapy_name": "Chemotherapy + Margetuximab",
         "therapy_strategy": "ER signaling inhibition + Chemotherapy",
         "therapy_type": "Combination therapy",
         "therapy_sensitivity": 1,
@@ -27074,7 +34206,29 @@
         "_deprecated": false,
         "assertion_id": 729,
         "feature_id": 729,
-        "source_id": 210
+        "source_id": 210,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C91733",
+                    "code": "C91733",
+                    "name": "Margetuximab",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C15632",
+                    "code": "C15632",
+                    "name": "Chemotherapy",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Copy Number",
@@ -27085,7 +34239,7 @@
         "context": "Locally advanced unresectable or metastatic",
         "oncotree_term": "Stomach Adenocarcinoma",
         "oncotree_code": "STAD",
-        "therapy_name": "Fluoropyrimidine + Trastuzumab + Pembrolizumab + Platinum",
+        "therapy_name": "Fluoropyrimidine + Pembrolizumab + Platinum Compound + Trastuzumab",
         "therapy_strategy": "Antimetabolite + ER signaling inhibition + PD-1/PD-L1 inhibition + Chemotherapy",
         "therapy_type": "Combination therapy",
         "therapy_sensitivity": 1,
@@ -27104,7 +34258,49 @@
         "_deprecated": false,
         "assertion_id": 730,
         "feature_id": 730,
-        "source_id": 211
+        "source_id": 211,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C94728",
+                    "code": "C94728",
+                    "name": "Fluoropyrimidine",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C1647",
+                    "code": "C1647",
+                    "name": "Trastuzumab",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C106432",
+                    "code": "C106432",
+                    "name": "Pembrolizumab",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C1450",
+                    "code": "C1450",
+                    "name": "Platinum Compound",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Copy Number",
@@ -27115,7 +34311,7 @@
         "context": "Locally advanced unresectable or metastatic",
         "oncotree_term": "Adenocarcinoma of the Gastroesophageal Junction",
         "oncotree_code": "GEJ",
-        "therapy_name": "Fluoropyrimidine + Trastuzumab + Pembrolizumab + Platinum",
+        "therapy_name": "Fluoropyrimidine + Pembrolizumab + Platinum Compound + Trastuzumab",
         "therapy_strategy": "Antimetabolite + ER signaling inhibition + PD-1/PD-L1 inhibition + Chemotherapy",
         "therapy_type": "Combination therapy",
         "therapy_sensitivity": 1,
@@ -27134,7 +34330,49 @@
         "_deprecated": false,
         "assertion_id": 731,
         "feature_id": 731,
-        "source_id": 211
+        "source_id": 211,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C94728",
+                    "code": "C94728",
+                    "name": "Fluoropyrimidine",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C1647",
+                    "code": "C1647",
+                    "name": "Trastuzumab",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C106432",
+                    "code": "C106432",
+                    "name": "Pembrolizumab",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C1450",
+                    "code": "C1450",
+                    "name": "Platinum Compound",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Copy Number",
@@ -27164,7 +34402,8 @@
         "_deprecated": false,
         "assertion_id": 732,
         "feature_id": 732,
-        "source_id": 212
+        "source_id": 212,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Copy Number",
@@ -27194,7 +34433,19 @@
         "_deprecated": false,
         "assertion_id": 733,
         "feature_id": 733,
-        "source_id": 109
+        "source_id": 109,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C1212",
+                    "code": "C1212",
+                    "name": "Sirolimus",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Copy Number",
@@ -27224,7 +34475,19 @@
         "_deprecated": false,
         "assertion_id": 734,
         "feature_id": 734,
-        "source_id": 213
+        "source_id": 213,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C88302",
+                    "code": "C88302",
+                    "name": "Infigratinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Copy Number",
@@ -27254,7 +34517,19 @@
         "_deprecated": false,
         "assertion_id": 735,
         "feature_id": 735,
-        "source_id": 213
+        "source_id": 213,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C88302",
+                    "code": "C88302",
+                    "name": "Infigratinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Copy Number",
@@ -27284,7 +34559,19 @@
         "_deprecated": false,
         "assertion_id": 736,
         "feature_id": 736,
-        "source_id": 213
+        "source_id": 213,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C88302",
+                    "code": "C88302",
+                    "name": "Infigratinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Copy Number",
@@ -27314,7 +34601,19 @@
         "_deprecated": false,
         "assertion_id": 737,
         "feature_id": 737,
-        "source_id": 213
+        "source_id": 213,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C88302",
+                    "code": "C88302",
+                    "name": "Infigratinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Copy Number",
@@ -27344,7 +34643,19 @@
         "_deprecated": false,
         "assertion_id": 738,
         "feature_id": 738,
-        "source_id": 213
+        "source_id": 213,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C88302",
+                    "code": "C88302",
+                    "name": "Infigratinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Copy Number",
@@ -27374,7 +34685,19 @@
         "_deprecated": false,
         "assertion_id": 739,
         "feature_id": 739,
-        "source_id": 213
+        "source_id": 213,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C88302",
+                    "code": "C88302",
+                    "name": "Infigratinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Copy Number",
@@ -27404,7 +34727,19 @@
         "_deprecated": false,
         "assertion_id": 740,
         "feature_id": 740,
-        "source_id": 213
+        "source_id": 213,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C88302",
+                    "code": "C88302",
+                    "name": "Infigratinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Copy Number",
@@ -27434,7 +34769,19 @@
         "_deprecated": false,
         "assertion_id": 741,
         "feature_id": 741,
-        "source_id": 213
+        "source_id": 213,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C88302",
+                    "code": "C88302",
+                    "name": "Infigratinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Copy Number",
@@ -27445,7 +34792,7 @@
         "context": "Muscle-Invasive",
         "oncotree_term": "Bladder Urothelial Carcinoma",
         "oncotree_code": "BLCA",
-        "therapy_name": "Carbogen and nicotinamide  + radiotherapy",
+        "therapy_name": "Carbogen + Radiation Therapy",
         "therapy_strategy": "Radiation",
         "therapy_type": "Radiation therapy",
         "therapy_sensitivity": 1,
@@ -27464,7 +34811,29 @@
         "_deprecated": false,
         "assertion_id": 742,
         "feature_id": 742,
-        "source_id": 214
+        "source_id": 214,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C1038",
+                    "code": "C1038",
+                    "name": "Carbogen",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C15313",
+                    "code": "C15313",
+                    "name": "Radiation Therapy",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Copy Number",
@@ -27475,7 +34844,7 @@
         "context": "",
         "oncotree_term": "Lung Squamous Cell Carcinoma",
         "oncotree_code": "LUSC",
-        "therapy_name": "Radiation therapy",
+        "therapy_name": "Radiation Therapy",
         "therapy_strategy": "Radiation",
         "therapy_type": "Radiation therapy",
         "therapy_sensitivity": "",
@@ -27494,7 +34863,19 @@
         "_deprecated": false,
         "assertion_id": 743,
         "feature_id": 743,
-        "source_id": 215
+        "source_id": 215,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C15313",
+                    "code": "C15313",
+                    "name": "Radiation Therapy",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Copy Number",
@@ -27524,7 +34905,19 @@
         "_deprecated": false,
         "assertion_id": 744,
         "feature_id": 744,
-        "source_id": 126
+        "source_id": 126,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C62035",
+                    "code": "C62035",
+                    "name": "Imatinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Copy Number",
@@ -27554,7 +34947,8 @@
         "_deprecated": false,
         "assertion_id": 745,
         "feature_id": 745,
-        "source_id": 168
+        "source_id": 168,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Copy Number",
@@ -27584,7 +34978,19 @@
         "_deprecated": false,
         "assertion_id": 746,
         "feature_id": 746,
-        "source_id": 11
+        "source_id": 11,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C74061",
+                    "code": "C74061",
+                    "name": "Crizotinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Copy Number",
@@ -27614,7 +35020,19 @@
         "_deprecated": false,
         "assertion_id": 747,
         "feature_id": 747,
-        "source_id": 20
+        "source_id": 20,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C1855",
+                    "code": "C1855",
+                    "name": "Gefitinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Copy Number",
@@ -27644,7 +35062,19 @@
         "_deprecated": false,
         "assertion_id": 748,
         "feature_id": 748,
-        "source_id": 216
+        "source_id": 216,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C52200",
+                    "code": "C52200",
+                    "name": "Cabozantinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Copy Number",
@@ -27674,7 +35104,19 @@
         "_deprecated": false,
         "assertion_id": 749,
         "feature_id": 749,
-        "source_id": 217
+        "source_id": 217,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C74061",
+                    "code": "C74061",
+                    "name": "Crizotinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Copy Number",
@@ -27685,7 +35127,7 @@
         "context": "",
         "oncotree_term": "Rectal Adenocarcinoma",
         "oncotree_code": "READ",
-        "therapy_name": "Neoadjuvant chemotherapy + surgery",
+        "therapy_name": "Chemotherapy + Surgery",
         "therapy_strategy": "Chemotherapy + Surgical removal",
         "therapy_type": "Combination therapy",
         "therapy_sensitivity": 1,
@@ -27704,7 +35146,29 @@
         "_deprecated": false,
         "assertion_id": 750,
         "feature_id": 750,
-        "source_id": 218
+        "source_id": 218,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C15632",
+                    "code": "C15632",
+                    "name": "Chemotherapy",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C17173",
+                    "code": "C17173",
+                    "name": "Surgery",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Copy Number",
@@ -27715,7 +35179,7 @@
         "context": "",
         "oncotree_term": "Rectal Adenocarcinoma",
         "oncotree_code": "READ",
-        "therapy_name": "Neoadjuvant chemotherapy + surgery",
+        "therapy_name": "Chemotherapy + Surgery",
         "therapy_strategy": "Chemotherapy + Surgical removal",
         "therapy_type": "Combination therapy",
         "therapy_sensitivity": "",
@@ -27734,7 +35198,29 @@
         "_deprecated": false,
         "assertion_id": 751,
         "feature_id": 751,
-        "source_id": 218
+        "source_id": 218,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C15632",
+                    "code": "C15632",
+                    "name": "Chemotherapy",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C17173",
+                    "code": "C17173",
+                    "name": "Surgery",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Copy Number",
@@ -27745,7 +35231,7 @@
         "context": "Muscle-Invasive",
         "oncotree_term": "Bladder Urothelial Carcinoma",
         "oncotree_code": "BLCA",
-        "therapy_name": "Radical radiotherapy",
+        "therapy_name": "Radiation Therapy",
         "therapy_strategy": "Radiation",
         "therapy_type": "Radiation therapy",
         "therapy_sensitivity": 1,
@@ -27764,7 +35250,19 @@
         "_deprecated": false,
         "assertion_id": 752,
         "feature_id": 752,
-        "source_id": 219
+        "source_id": 219,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C15313",
+                    "code": "C15313",
+                    "name": "Radiation Therapy",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Copy Number",
@@ -27794,7 +35292,8 @@
         "_deprecated": false,
         "assertion_id": 753,
         "feature_id": 753,
-        "source_id": 220
+        "source_id": 220,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Copy Number",
@@ -27824,7 +35323,8 @@
         "_deprecated": false,
         "assertion_id": 754,
         "feature_id": 754,
-        "source_id": 54
+        "source_id": 54,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Copy Number",
@@ -27854,7 +35354,8 @@
         "_deprecated": false,
         "assertion_id": 755,
         "feature_id": 755,
-        "source_id": 187
+        "source_id": 187,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Copy Number",
@@ -27884,7 +35385,19 @@
         "_deprecated": false,
         "assertion_id": 756,
         "feature_id": 756,
-        "source_id": 187
+        "source_id": 187,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C62078",
+                    "code": "C62078",
+                    "name": "Tamoxifen",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Copy Number",
@@ -27914,7 +35427,19 @@
         "_deprecated": false,
         "assertion_id": 757,
         "feature_id": 757,
-        "source_id": 153
+        "source_id": 153,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C68814",
+                    "code": "C68814",
+                    "name": "Nivolumab",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Copy Number",
@@ -27944,7 +35469,19 @@
         "_deprecated": false,
         "assertion_id": 758,
         "feature_id": 758,
-        "source_id": 221
+        "source_id": 221,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C165479",
+                    "code": "C165479",
+                    "name": "Pictilisib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Copy Number",
@@ -27955,7 +35492,7 @@
         "context": "",
         "oncotree_term": "Prostate Adenocarcinoma",
         "oncotree_code": "PRAD",
-        "therapy_name": "AZD8186",
+        "therapy_name": "PI3Kbeta Inhibitor AZD8186",
         "therapy_strategy": "PI3K/AKT/mTOR inhibition",
         "therapy_type": "Targeted therapy",
         "therapy_sensitivity": 1,
@@ -27974,7 +35511,19 @@
         "_deprecated": false,
         "assertion_id": 759,
         "feature_id": 759,
-        "source_id": 158
+        "source_id": 158,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C107684",
+                    "code": "C107684",
+                    "name": "PI3Kbeta Inhibitor AZD8186",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Copy Number",
@@ -28004,7 +35553,19 @@
         "_deprecated": false,
         "assertion_id": 760,
         "feature_id": 760,
-        "source_id": 159
+        "source_id": 159,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C106432",
+                    "code": "C106432",
+                    "name": "Pembrolizumab",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Copy Number",
@@ -28034,7 +35595,19 @@
         "_deprecated": false,
         "assertion_id": 761,
         "feature_id": 761,
-        "source_id": 222
+        "source_id": 222,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C48387",
+                    "code": "C48387",
+                    "name": "Everolimus",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Copy Number",
@@ -28064,7 +35637,19 @@
         "_deprecated": false,
         "assertion_id": 762,
         "feature_id": 762,
-        "source_id": 160
+        "source_id": 160,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C106432",
+                    "code": "C106432",
+                    "name": "Pembrolizumab",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Copy Number",
@@ -28094,7 +35679,19 @@
         "_deprecated": false,
         "assertion_id": 763,
         "feature_id": 763,
-        "source_id": 149
+        "source_id": 149,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C48387",
+                    "code": "C48387",
+                    "name": "Everolimus",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Copy Number",
@@ -28124,7 +35721,19 @@
         "_deprecated": false,
         "assertion_id": 764,
         "feature_id": 764,
-        "source_id": 149
+        "source_id": 149,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C71622",
+                    "code": "C71622",
+                    "name": "Sunitinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Copy Number",
@@ -28154,7 +35763,8 @@
         "_deprecated": false,
         "assertion_id": 765,
         "feature_id": 765,
-        "source_id": 28
+        "source_id": 28,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Copy Number",
@@ -28184,7 +35794,8 @@
         "_deprecated": false,
         "assertion_id": 766,
         "feature_id": 766,
-        "source_id": 28
+        "source_id": 28,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Copy Number",
@@ -28214,7 +35825,8 @@
         "_deprecated": false,
         "assertion_id": 767,
         "feature_id": 767,
-        "source_id": 184
+        "source_id": 184,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Microsatellite Stability",
@@ -28242,7 +35854,19 @@
         "_deprecated": false,
         "assertion_id": 768,
         "feature_id": 768,
-        "source_id": 223
+        "source_id": 223,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C106432",
+                    "code": "C106432",
+                    "name": "Pembrolizumab",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Microsatellite Stability",
@@ -28270,7 +35894,19 @@
         "_deprecated": false,
         "assertion_id": 769,
         "feature_id": 769,
-        "source_id": 223
+        "source_id": 223,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C106432",
+                    "code": "C106432",
+                    "name": "Pembrolizumab",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Microsatellite Stability",
@@ -28279,7 +35915,7 @@
         "context": "",
         "oncotree_term": "Colorectal Adenocarcinoma",
         "oncotree_code": "COADREAD",
-        "therapy_name": "5-Fluorouracil",
+        "therapy_name": "Fluorouracil",
         "therapy_strategy": "Thymidylate synthase inhibition",
         "therapy_type": "Chemotherapy",
         "therapy_sensitivity": 0,
@@ -28298,7 +35934,19 @@
         "_deprecated": false,
         "assertion_id": 770,
         "feature_id": 770,
-        "source_id": 80
+        "source_id": 80,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C505",
+                    "code": "C505",
+                    "name": "Fluorouracil",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Microsatellite Stability",
@@ -28307,7 +35955,7 @@
         "context": "",
         "oncotree_term": "Colorectal Adenocarcinoma",
         "oncotree_code": "COADREAD",
-        "therapy_name": "5-Fluorouracil",
+        "therapy_name": "Fluorouracil",
         "therapy_strategy": "Thymidylate synthase inhibition",
         "therapy_type": "Chemotherapy",
         "therapy_sensitivity": "",
@@ -28326,7 +35974,19 @@
         "_deprecated": false,
         "assertion_id": 771,
         "feature_id": 771,
-        "source_id": 80
+        "source_id": 80,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C505",
+                    "code": "C505",
+                    "name": "Fluorouracil",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Microsatellite Stability",
@@ -28354,7 +36014,8 @@
         "_deprecated": false,
         "assertion_id": 772,
         "feature_id": 772,
-        "source_id": 80
+        "source_id": 80,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Microsatellite Stability",
@@ -28382,7 +36043,19 @@
         "_deprecated": false,
         "assertion_id": 773,
         "feature_id": 773,
-        "source_id": 147
+        "source_id": 147,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C106432",
+                    "code": "C106432",
+                    "name": "Pembrolizumab",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Mutational Signature",
@@ -28410,7 +36083,19 @@
         "_deprecated": false,
         "assertion_id": 774,
         "feature_id": 774,
-        "source_id": 147
+        "source_id": 147,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C106432",
+                    "code": "C106432",
+                    "name": "Pembrolizumab",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Mutational Signature",
@@ -28438,7 +36123,19 @@
         "_deprecated": false,
         "assertion_id": 775,
         "feature_id": 775,
-        "source_id": 147
+        "source_id": 147,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C106432",
+                    "code": "C106432",
+                    "name": "Pembrolizumab",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Mutational Signature",
@@ -28466,7 +36163,19 @@
         "_deprecated": false,
         "assertion_id": 776,
         "feature_id": 776,
-        "source_id": 157
+        "source_id": 157,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C103194",
+                    "code": "C103194",
+                    "name": "Durvalumab",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Mutational Signature",
@@ -28494,7 +36203,19 @@
         "_deprecated": false,
         "assertion_id": 777,
         "feature_id": 777,
-        "source_id": 157
+        "source_id": 157,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C103194",
+                    "code": "C103194",
+                    "name": "Durvalumab",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Mutational Signature",
@@ -28522,7 +36243,19 @@
         "_deprecated": false,
         "assertion_id": 778,
         "feature_id": 778,
-        "source_id": 157
+        "source_id": 157,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C106432",
+                    "code": "C106432",
+                    "name": "Pembrolizumab",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Mutational Signature",
@@ -28550,7 +36283,19 @@
         "_deprecated": false,
         "assertion_id": 779,
         "feature_id": 779,
-        "source_id": 157
+        "source_id": 157,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C106432",
+                    "code": "C106432",
+                    "name": "Pembrolizumab",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Mutational Signature",
@@ -28578,7 +36323,19 @@
         "_deprecated": false,
         "assertion_id": 780,
         "feature_id": 780,
-        "source_id": 224
+        "source_id": 224,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C103194",
+                    "code": "C103194",
+                    "name": "Durvalumab",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Mutational Signature",
@@ -28606,7 +36363,19 @@
         "_deprecated": false,
         "assertion_id": 781,
         "feature_id": 781,
-        "source_id": 224
+        "source_id": 224,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C103194",
+                    "code": "C103194",
+                    "name": "Durvalumab",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Mutational Signature",
@@ -28615,7 +36384,7 @@
         "context": "",
         "oncotree_term": "Gastric Remnant Adenocarcinoma",
         "oncotree_code": "GRC",
-        "therapy_name": "Platinum",
+        "therapy_name": "Platinum Compound",
         "therapy_strategy": "Platinum-based chemotherapy",
         "therapy_type": "Chemotherapy",
         "therapy_sensitivity": 1,
@@ -28634,7 +36403,19 @@
         "_deprecated": false,
         "assertion_id": 782,
         "feature_id": 782,
-        "source_id": 225
+        "source_id": 225,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C1450",
+                    "code": "C1450",
+                    "name": "Platinum Compound",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Mutational Signature",
@@ -28662,7 +36443,19 @@
         "_deprecated": false,
         "assertion_id": 783,
         "feature_id": 783,
-        "source_id": 225
+        "source_id": 225,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C71721",
+                    "code": "C71721",
+                    "name": "Olaparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Mutational Signature",
@@ -28671,7 +36464,7 @@
         "context": "",
         "oncotree_term": "Gastric Remnant Adenocarcinoma",
         "oncotree_code": "GRC",
-        "therapy_name": "Platinum",
+        "therapy_name": "Platinum Compound",
         "therapy_strategy": "Platinum-based chemotherapy",
         "therapy_type": "Chemotherapy",
         "therapy_sensitivity": 1,
@@ -28690,7 +36483,19 @@
         "_deprecated": false,
         "assertion_id": 784,
         "feature_id": 784,
-        "source_id": 225
+        "source_id": 225,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C1450",
+                    "code": "C1450",
+                    "name": "Platinum Compound",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Mutational Signature",
@@ -28718,7 +36523,19 @@
         "_deprecated": false,
         "assertion_id": 785,
         "feature_id": 785,
-        "source_id": 225
+        "source_id": 225,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C71721",
+                    "code": "C71721",
+                    "name": "Olaparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Mutational Signature",
@@ -28727,7 +36544,7 @@
         "context": "",
         "oncotree_term": "Pancreatic Adenocarcinoma",
         "oncotree_code": "PAAD",
-        "therapy_name": "Platinum",
+        "therapy_name": "Platinum Compound",
         "therapy_strategy": "Platinum-based chemotherapy",
         "therapy_type": "Chemotherapy",
         "therapy_sensitivity": 1,
@@ -28746,7 +36563,19 @@
         "_deprecated": false,
         "assertion_id": 786,
         "feature_id": 786,
-        "source_id": 225
+        "source_id": 225,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C1450",
+                    "code": "C1450",
+                    "name": "Platinum Compound",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Mutational Signature",
@@ -28755,7 +36584,7 @@
         "context": "",
         "oncotree_term": "Pancreatic Adenocarcinoma",
         "oncotree_code": "PAAD",
-        "therapy_name": "Platinum",
+        "therapy_name": "Platinum Compound",
         "therapy_strategy": "Platinum-based chemotherapy",
         "therapy_type": "Chemotherapy",
         "therapy_sensitivity": 1,
@@ -28774,7 +36603,19 @@
         "_deprecated": false,
         "assertion_id": 787,
         "feature_id": 787,
-        "source_id": 85
+        "source_id": 85,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C1450",
+                    "code": "C1450",
+                    "name": "Platinum Compound",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Mutational Signature",
@@ -28802,7 +36643,19 @@
         "_deprecated": false,
         "assertion_id": 788,
         "feature_id": 788,
-        "source_id": 136
+        "source_id": 136,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C106432",
+                    "code": "C106432",
+                    "name": "Pembrolizumab",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Mutational Signature",
@@ -28830,7 +36683,19 @@
         "_deprecated": false,
         "assertion_id": 789,
         "feature_id": 789,
-        "source_id": 136
+        "source_id": 136,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C106432",
+                    "code": "C106432",
+                    "name": "Pembrolizumab",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Mutational Signature",
@@ -28858,7 +36723,19 @@
         "_deprecated": false,
         "assertion_id": 790,
         "feature_id": 790,
-        "source_id": 226
+        "source_id": 226,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C376",
+                    "code": "C376",
+                    "name": "Cisplatin",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Mutational Signature",
@@ -28886,7 +36763,29 @@
         "_deprecated": false,
         "assertion_id": 791,
         "feature_id": 791,
-        "source_id": 87
+        "source_id": 87,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C2039",
+                    "code": "C2039",
+                    "name": "Bevacizumab",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C71721",
+                    "code": "C71721",
+                    "name": "Olaparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Mutational Signature",
@@ -28914,7 +36813,29 @@
         "_deprecated": false,
         "assertion_id": 792,
         "feature_id": 792,
-        "source_id": 87
+        "source_id": 87,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C2039",
+                    "code": "C2039",
+                    "name": "Bevacizumab",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C71721",
+                    "code": "C71721",
+                    "name": "Olaparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Mutational Signature",
@@ -28942,7 +36863,29 @@
         "_deprecated": false,
         "assertion_id": 793,
         "feature_id": 793,
-        "source_id": 87
+        "source_id": 87,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C2039",
+                    "code": "C2039",
+                    "name": "Bevacizumab",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C71721",
+                    "code": "C71721",
+                    "name": "Olaparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Mutational Burden",
@@ -28972,7 +36915,29 @@
         "_deprecated": false,
         "assertion_id": 794,
         "feature_id": 794,
-        "source_id": 11
+        "source_id": 11,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C2654",
+                    "code": "C2654",
+                    "name": "Ipilimumab",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C68814",
+                    "code": "C68814",
+                    "name": "Nivolumab",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Mutational Burden",
@@ -29002,7 +36967,19 @@
         "_deprecated": false,
         "assertion_id": 795,
         "feature_id": 795,
-        "source_id": 11
+        "source_id": 11,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C68814",
+                    "code": "C68814",
+                    "name": "Nivolumab",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Mutational Burden",
@@ -29032,7 +37009,19 @@
         "_deprecated": false,
         "assertion_id": 796,
         "feature_id": 796,
-        "source_id": 136
+        "source_id": 136,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C106432",
+                    "code": "C106432",
+                    "name": "Pembrolizumab",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Mutational Burden",
@@ -29062,7 +37051,19 @@
         "_deprecated": false,
         "assertion_id": 797,
         "feature_id": 797,
-        "source_id": 227
+        "source_id": 227,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C2654",
+                    "code": "C2654",
+                    "name": "Ipilimumab",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Mutational Burden",
@@ -29092,7 +37093,19 @@
         "_deprecated": false,
         "assertion_id": 798,
         "feature_id": 798,
-        "source_id": 228
+        "source_id": 228,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C2654",
+                    "code": "C2654",
+                    "name": "Ipilimumab",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Mutational Burden",
@@ -29122,7 +37135,19 @@
         "_deprecated": false,
         "assertion_id": 799,
         "feature_id": 799,
-        "source_id": 223
+        "source_id": 223,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C106432",
+                    "code": "C106432",
+                    "name": "Pembrolizumab",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Knockdown",
@@ -29151,7 +37176,19 @@
         "_deprecated": false,
         "assertion_id": 800,
         "feature_id": 800,
-        "source_id": 57
+        "source_id": 57,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C71721",
+                    "code": "C71721",
+                    "name": "Olaparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Knockdown",
@@ -29180,7 +37217,8 @@
         "_deprecated": false,
         "assertion_id": 801,
         "feature_id": 801,
-        "source_id": 229
+        "source_id": 229,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Knockdown",
@@ -29209,7 +37247,19 @@
         "_deprecated": false,
         "assertion_id": 802,
         "feature_id": 802,
-        "source_id": 230
+        "source_id": 230,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C71721",
+                    "code": "C71721",
+                    "name": "Olaparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Knockdown",
@@ -29238,7 +37288,19 @@
         "_deprecated": false,
         "assertion_id": 803,
         "feature_id": 803,
-        "source_id": 231
+        "source_id": 231,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C60768",
+                    "code": "C60768",
+                    "name": "Veliparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Knockdown",
@@ -29267,7 +37329,8 @@
         "_deprecated": false,
         "assertion_id": 804,
         "feature_id": 804,
-        "source_id": 232
+        "source_id": 232,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Knockdown",
@@ -29296,7 +37359,19 @@
         "_deprecated": false,
         "assertion_id": 805,
         "feature_id": 805,
-        "source_id": 233
+        "source_id": 233,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C60768",
+                    "code": "C60768",
+                    "name": "Veliparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Knockdown",
@@ -29325,7 +37400,19 @@
         "_deprecated": false,
         "assertion_id": 806,
         "feature_id": 806,
-        "source_id": 233
+        "source_id": 233,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C1282",
+                    "code": "C1282",
+                    "name": "Carboplatin",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Knockdown",
@@ -29354,7 +37441,19 @@
         "_deprecated": false,
         "assertion_id": 807,
         "feature_id": 807,
-        "source_id": 233
+        "source_id": 233,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C1282",
+                    "code": "C1282",
+                    "name": "Carboplatin",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Knockdown",
@@ -29383,7 +37482,8 @@
         "_deprecated": false,
         "assertion_id": 808,
         "feature_id": 808,
-        "source_id": 229
+        "source_id": 229,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Knockdown",
@@ -29412,7 +37512,8 @@
         "_deprecated": false,
         "assertion_id": 809,
         "feature_id": 809,
-        "source_id": 234
+        "source_id": 234,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Aneuploidy",
@@ -29440,7 +37541,8 @@
         "_deprecated": false,
         "assertion_id": 810,
         "feature_id": 810,
-        "source_id": 235
+        "source_id": 235,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -29478,7 +37580,29 @@
         "_deprecated": false,
         "assertion_id": 811,
         "feature_id": 811,
-        "source_id": 236
+        "source_id": 236,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C82386",
+                    "code": "C82386",
+                    "name": "Dabrafenib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C77908",
+                    "code": "C77908",
+                    "name": "Trametinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -29516,7 +37640,19 @@
         "_deprecated": false,
         "assertion_id": 812,
         "feature_id": 812,
-        "source_id": 237
+        "source_id": 237,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C114383",
+                    "code": "C114383",
+                    "name": "Ivosidenib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -29554,7 +37690,19 @@
         "_deprecated": false,
         "assertion_id": 813,
         "feature_id": 813,
-        "source_id": 237
+        "source_id": 237,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C114383",
+                    "code": "C114383",
+                    "name": "Ivosidenib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -29573,7 +37721,7 @@
         "context": "newly diagnosed AML who are 75 years or older, or who have comorbities that preclude use of intensive induction chemotherapy.",
         "oncotree_term": "Acute Myeloid Leukemia",
         "oncotree_code": "AML",
-        "therapy_name": "Ivosidenib + Azacitidine",
+        "therapy_name": "Azacitidine + Ivosidenib",
         "therapy_strategy": "IDH1 inhibition",
         "therapy_type": "Targeted therapy",
         "therapy_sensitivity": 1,
@@ -29592,7 +37740,29 @@
         "_deprecated": false,
         "assertion_id": 814,
         "feature_id": 814,
-        "source_id": 237
+        "source_id": 237,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C114383",
+                    "code": "C114383",
+                    "name": "Ivosidenib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C288",
+                    "code": "C288",
+                    "name": "Azacitidine",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -29611,7 +37781,7 @@
         "context": "newly diagnosed AML who are 75 years or older, or who have comorbities that preclude use of intensive induction chemotherapy.",
         "oncotree_term": "Acute Myeloid Leukemia",
         "oncotree_code": "AML",
-        "therapy_name": "Ivosidenib + Azacitidine",
+        "therapy_name": "Azacitidine + Ivosidenib",
         "therapy_strategy": "IDH1 inhibition",
         "therapy_type": "Targeted therapy",
         "therapy_sensitivity": 1,
@@ -29630,7 +37800,29 @@
         "_deprecated": false,
         "assertion_id": 815,
         "feature_id": 815,
-        "source_id": 237
+        "source_id": 237,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C114383",
+                    "code": "C114383",
+                    "name": "Ivosidenib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C288",
+                    "code": "C288",
+                    "name": "Azacitidine",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Microsatellite Stability",
@@ -29658,7 +37850,19 @@
         "_deprecated": false,
         "assertion_id": 816,
         "feature_id": 816,
-        "source_id": 147
+        "source_id": 147,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C106432",
+                    "code": "C106432",
+                    "name": "Pembrolizumab",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Microsatellite Stability",
@@ -29686,7 +37890,19 @@
         "_deprecated": false,
         "assertion_id": 817,
         "feature_id": 817,
-        "source_id": 238
+        "source_id": 238,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C106432",
+                    "code": "C106432",
+                    "name": "Pembrolizumab",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Germline Variant",
@@ -29726,7 +37942,19 @@
         "_deprecated": false,
         "assertion_id": 818,
         "feature_id": 818,
-        "source_id": 239
+        "source_id": 239,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C71721",
+                    "code": "C71721",
+                    "name": "Olaparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Germline Variant",
@@ -29766,7 +37994,19 @@
         "_deprecated": false,
         "assertion_id": 819,
         "feature_id": 819,
-        "source_id": 239
+        "source_id": 239,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C71721",
+                    "code": "C71721",
+                    "name": "Olaparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Germline Variant",
@@ -29806,7 +38046,19 @@
         "_deprecated": false,
         "assertion_id": 820,
         "feature_id": 820,
-        "source_id": 239
+        "source_id": 239,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C71721",
+                    "code": "C71721",
+                    "name": "Olaparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Germline Variant",
@@ -29846,7 +38098,19 @@
         "_deprecated": false,
         "assertion_id": 821,
         "feature_id": 821,
-        "source_id": 239
+        "source_id": 239,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C71721",
+                    "code": "C71721",
+                    "name": "Olaparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Germline Variant",
@@ -29886,7 +38150,19 @@
         "_deprecated": false,
         "assertion_id": 822,
         "feature_id": 822,
-        "source_id": 239
+        "source_id": 239,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C71721",
+                    "code": "C71721",
+                    "name": "Olaparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Germline Variant",
@@ -29926,7 +38202,19 @@
         "_deprecated": false,
         "assertion_id": 823,
         "feature_id": 823,
-        "source_id": 239
+        "source_id": 239,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C71721",
+                    "code": "C71721",
+                    "name": "Olaparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Knockdown",
@@ -29955,7 +38243,19 @@
         "_deprecated": false,
         "assertion_id": 824,
         "feature_id": 824,
-        "source_id": 240
+        "source_id": 240,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C49176",
+                    "code": "C49176",
+                    "name": "Palbociclib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Knockdown",
@@ -29984,7 +38284,19 @@
         "_deprecated": false,
         "assertion_id": 825,
         "feature_id": 825,
-        "source_id": 241
+        "source_id": 241,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C71721",
+                    "code": "C71721",
+                    "name": "Olaparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Rearrangement",
@@ -30015,7 +38327,19 @@
         "_deprecated": false,
         "assertion_id": 826,
         "feature_id": 826,
-        "source_id": 242
+        "source_id": 242,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C74061",
+                    "code": "C74061",
+                    "name": "Crizotinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -30053,7 +38377,8 @@
         "_deprecated": false,
         "assertion_id": 827,
         "feature_id": 827,
-        "source_id": 243
+        "source_id": 243,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -30091,7 +38416,8 @@
         "_deprecated": false,
         "assertion_id": 828,
         "feature_id": 828,
-        "source_id": 243
+        "source_id": 243,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -30129,7 +38455,8 @@
         "_deprecated": false,
         "assertion_id": 829,
         "feature_id": 829,
-        "source_id": 243
+        "source_id": 243,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -30167,7 +38494,8 @@
         "_deprecated": false,
         "assertion_id": 830,
         "feature_id": 830,
-        "source_id": 243
+        "source_id": 243,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -30205,7 +38533,8 @@
         "_deprecated": false,
         "assertion_id": 831,
         "feature_id": 831,
-        "source_id": 243
+        "source_id": 243,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -30243,7 +38572,8 @@
         "_deprecated": false,
         "assertion_id": 832,
         "feature_id": 832,
-        "source_id": 243
+        "source_id": 243,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -30281,7 +38611,8 @@
         "_deprecated": false,
         "assertion_id": 833,
         "feature_id": 833,
-        "source_id": 243
+        "source_id": 243,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -30319,7 +38650,8 @@
         "_deprecated": false,
         "assertion_id": 834,
         "feature_id": 834,
-        "source_id": 243
+        "source_id": 243,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -30357,7 +38689,19 @@
         "_deprecated": false,
         "assertion_id": 835,
         "feature_id": 835,
-        "source_id": 244
+        "source_id": 244,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C71721",
+                    "code": "C71721",
+                    "name": "Olaparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -30395,7 +38739,19 @@
         "_deprecated": false,
         "assertion_id": 836,
         "feature_id": 836,
-        "source_id": 244
+        "source_id": 244,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C71721",
+                    "code": "C71721",
+                    "name": "Olaparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -30433,7 +38789,29 @@
         "_deprecated": false,
         "assertion_id": 837,
         "feature_id": 837,
-        "source_id": 240
+        "source_id": 240,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C71721",
+                    "code": "C71721",
+                    "name": "Olaparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C95733",
+                    "code": "C95733",
+                    "name": "Talazoparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -30471,7 +38849,29 @@
         "_deprecated": false,
         "assertion_id": 838,
         "feature_id": 838,
-        "source_id": 240
+        "source_id": 240,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C71721",
+                    "code": "C71721",
+                    "name": "Olaparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C95733",
+                    "code": "C95733",
+                    "name": "Talazoparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Copy Number",
@@ -30502,7 +38902,8 @@
         "_deprecated": false,
         "assertion_id": 839,
         "feature_id": 839,
-        "source_id": 245
+        "source_id": 245,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Copy Number",
@@ -30533,7 +38934,8 @@
         "_deprecated": false,
         "assertion_id": 840,
         "feature_id": 840,
-        "source_id": 243
+        "source_id": 243,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Copy Number",
@@ -30564,7 +38966,8 @@
         "_deprecated": false,
         "assertion_id": 841,
         "feature_id": 841,
-        "source_id": 243
+        "source_id": 243,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Copy Number",
@@ -30595,7 +38998,19 @@
         "_deprecated": false,
         "assertion_id": 842,
         "feature_id": 842,
-        "source_id": 244
+        "source_id": 244,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C71721",
+                    "code": "C71721",
+                    "name": "Olaparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Copy Number",
@@ -30626,7 +39041,19 @@
         "_deprecated": false,
         "assertion_id": 843,
         "feature_id": 843,
-        "source_id": 246
+        "source_id": 246,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C49176",
+                    "code": "C49176",
+                    "name": "Palbociclib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Copy Number",
@@ -30657,7 +39084,19 @@
         "_deprecated": false,
         "assertion_id": 844,
         "feature_id": 844,
-        "source_id": 247
+        "source_id": 247,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C49176",
+                    "code": "C49176",
+                    "name": "Palbociclib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Copy Number",
@@ -30688,7 +39127,19 @@
         "_deprecated": false,
         "assertion_id": 845,
         "feature_id": 845,
-        "source_id": 248
+        "source_id": 248,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C15632",
+                    "code": "C15632",
+                    "name": "Chemotherapy",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Copy Number",
@@ -30719,7 +39170,8 @@
         "_deprecated": false,
         "assertion_id": 846,
         "feature_id": 846,
-        "source_id": 248
+        "source_id": 248,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Copy Number",
@@ -30750,7 +39202,8 @@
         "_deprecated": false,
         "assertion_id": 847,
         "feature_id": 847,
-        "source_id": 248
+        "source_id": 248,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Copy Number",
@@ -30781,7 +39234,19 @@
         "_deprecated": false,
         "assertion_id": 848,
         "feature_id": 848,
-        "source_id": 248
+        "source_id": 248,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C15632",
+                    "code": "C15632",
+                    "name": "Chemotherapy",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Copy Number",
@@ -30812,7 +39277,8 @@
         "_deprecated": false,
         "assertion_id": 849,
         "feature_id": 849,
-        "source_id": 249
+        "source_id": 249,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Copy Number",
@@ -30843,7 +39309,8 @@
         "_deprecated": false,
         "assertion_id": 850,
         "feature_id": 850,
-        "source_id": 250
+        "source_id": 250,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Copy Number",
@@ -30874,7 +39341,8 @@
         "_deprecated": false,
         "assertion_id": 851,
         "feature_id": 851,
-        "source_id": 251
+        "source_id": 251,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Copy Number",
@@ -30885,7 +39353,7 @@
         "context": "",
         "oncotree_term": "Uterine Leiomyosarcoma",
         "oncotree_code": "ULMS",
-        "therapy_name": "Sapanisertib + Alpelisib",
+        "therapy_name": "Alpelisib + Sapanisertib",
         "therapy_strategy": "PI3K/AKT/mTOR inhibition",
         "therapy_type": "Targeted therapy",
         "therapy_sensitivity": 1,
@@ -30905,7 +39373,29 @@
         "_deprecated": false,
         "assertion_id": 852,
         "feature_id": 852,
-        "source_id": 251
+        "source_id": 251,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C90548",
+                    "code": "C90548",
+                    "name": "Sapanisertib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C94214",
+                    "code": "C94214",
+                    "name": "Alpelisib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Copy Number",
@@ -30936,7 +39426,29 @@
         "_deprecated": false,
         "assertion_id": 853,
         "feature_id": 853,
-        "source_id": 240
+        "source_id": 240,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C71721",
+                    "code": "C71721",
+                    "name": "Olaparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C95733",
+                    "code": "C95733",
+                    "name": "Talazoparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Rearrangement",
@@ -30967,7 +39479,19 @@
         "_deprecated": false,
         "assertion_id": 854,
         "feature_id": 854,
-        "source_id": 252
+        "source_id": 252,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C121553",
+                    "code": "C121553",
+                    "name": "Pemigatinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Rearrangement",
@@ -30998,7 +39522,19 @@
         "_deprecated": false,
         "assertion_id": 855,
         "feature_id": 855,
-        "source_id": 253
+        "source_id": 253,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C114283",
+                    "code": "C114283",
+                    "name": "Futibatinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Rearrangement",
@@ -31029,7 +39565,19 @@
         "_deprecated": false,
         "assertion_id": 856,
         "feature_id": 856,
-        "source_id": 254
+        "source_id": 254,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C134987",
+                    "code": "C134987",
+                    "name": "Selpercatinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -31067,7 +39615,19 @@
         "_deprecated": false,
         "assertion_id": 857,
         "feature_id": 857,
-        "source_id": 255
+        "source_id": 255,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C129687",
+                    "code": "C129687",
+                    "name": "Olutasidenib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -31105,7 +39665,19 @@
         "_deprecated": false,
         "assertion_id": 858,
         "feature_id": 858,
-        "source_id": 255
+        "source_id": 255,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C129687",
+                    "code": "C129687",
+                    "name": "Olutasidenib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -31143,7 +39715,19 @@
         "_deprecated": false,
         "assertion_id": 859,
         "feature_id": 859,
-        "source_id": 255
+        "source_id": 255,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C129687",
+                    "code": "C129687",
+                    "name": "Olutasidenib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -31181,7 +39765,19 @@
         "_deprecated": false,
         "assertion_id": 860,
         "feature_id": 860,
-        "source_id": 255
+        "source_id": 255,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C129687",
+                    "code": "C129687",
+                    "name": "Olutasidenib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -31219,7 +39815,19 @@
         "_deprecated": false,
         "assertion_id": 861,
         "feature_id": 861,
-        "source_id": 255
+        "source_id": 255,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C129687",
+                    "code": "C129687",
+                    "name": "Olutasidenib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -31257,7 +39865,19 @@
         "_deprecated": false,
         "assertion_id": 862,
         "feature_id": 862,
-        "source_id": 256
+        "source_id": 256,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C157493",
+                    "code": "C157493",
+                    "name": "Adagrasib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Copy Number",
@@ -31287,7 +39907,29 @@
         "_deprecated": false,
         "assertion_id": 863,
         "feature_id": 863,
-        "source_id": 257
+        "source_id": 257,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C1647",
+                    "code": "C1647",
+                    "name": "Trastuzumab",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C77896",
+                    "code": "C77896",
+                    "name": "Tucatinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -31325,7 +39967,19 @@
         "_deprecated": false,
         "assertion_id": 864,
         "feature_id": 864,
-        "source_id": 258
+        "source_id": 258,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C120211",
+                    "code": "C120211",
+                    "name": "Elacestrant",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -31363,7 +40017,29 @@
         "_deprecated": false,
         "assertion_id": 865,
         "feature_id": 865,
-        "source_id": 259
+        "source_id": 259,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C82386",
+                    "code": "C82386",
+                    "name": "Dabrafenib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C77908",
+                    "code": "C77908",
+                    "name": "Trametinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -31382,7 +40058,7 @@
         "context": "Metastatic castration-resistant",
         "oncotree_term": "Prostate Adenocarcinoma",
         "oncotree_code": "PRAD",
-        "therapy_name": "Abiraterone + Prednisone + Olaparib",
+        "therapy_name": "Abiraterone + Olaparib + Prednisone",
         "therapy_strategy": "Antiandrogen + Corticosteroid + PARP inhibition",
         "therapy_type": "Combination therapy",
         "therapy_sensitivity": 1,
@@ -31401,7 +40077,39 @@
         "_deprecated": false,
         "assertion_id": 866,
         "feature_id": 866,
-        "source_id": 172
+        "source_id": 172,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C77333",
+                    "code": "C77333",
+                    "name": "Abiraterone",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C770",
+                    "code": "C770",
+                    "name": "Prednisone",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C71721",
+                    "code": "C71721",
+                    "name": "Olaparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -31420,7 +40128,7 @@
         "context": "Metastatic castration-resistant",
         "oncotree_term": "Prostate Adenocarcinoma",
         "oncotree_code": "PRAD",
-        "therapy_name": "Abiraterone + Prednisone + Olaparib",
+        "therapy_name": "Abiraterone + Olaparib + Prednisone",
         "therapy_strategy": "Antiandrogen + Corticosteroid + PARP inhibition",
         "therapy_type": "Combination therapy",
         "therapy_sensitivity": 1,
@@ -31439,7 +40147,39 @@
         "_deprecated": false,
         "assertion_id": 867,
         "feature_id": 867,
-        "source_id": 172
+        "source_id": 172,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C77333",
+                    "code": "C77333",
+                    "name": "Abiraterone",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C770",
+                    "code": "C770",
+                    "name": "Prednisone",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C71721",
+                    "code": "C71721",
+                    "name": "Olaparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Germline Variant",
@@ -31459,7 +40199,7 @@
         "context": "Metastatic castration-resistant",
         "oncotree_term": "Prostate Adenocarcinoma",
         "oncotree_code": "PRAD",
-        "therapy_name": "Abiraterone + Prednisone + Olaparib",
+        "therapy_name": "Abiraterone + Olaparib + Prednisone",
         "therapy_strategy": "Antiandrogen + Corticosteroid + PARP inhibition",
         "therapy_type": "Combination therapy",
         "therapy_sensitivity": 1,
@@ -31478,7 +40218,39 @@
         "_deprecated": false,
         "assertion_id": 868,
         "feature_id": 868,
-        "source_id": 172
+        "source_id": 172,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C77333",
+                    "code": "C77333",
+                    "name": "Abiraterone",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C770",
+                    "code": "C770",
+                    "name": "Prednisone",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C71721",
+                    "code": "C71721",
+                    "name": "Olaparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Germline Variant",
@@ -31498,7 +40270,7 @@
         "context": "Metastatic castration-resistant",
         "oncotree_term": "Prostate Adenocarcinoma",
         "oncotree_code": "PRAD",
-        "therapy_name": "Abiraterone + Prednisone + Olaparib",
+        "therapy_name": "Abiraterone + Olaparib + Prednisone",
         "therapy_strategy": "Antiandrogen + Corticosteroid + PARP inhibition",
         "therapy_type": "Combination therapy",
         "therapy_sensitivity": 1,
@@ -31517,7 +40289,39 @@
         "_deprecated": false,
         "assertion_id": 869,
         "feature_id": 869,
-        "source_id": 172
+        "source_id": 172,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C77333",
+                    "code": "C77333",
+                    "name": "Abiraterone",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C770",
+                    "code": "C770",
+                    "name": "Prednisone",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C71721",
+                    "code": "C71721",
+                    "name": "Olaparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Germline Variant",
@@ -31556,7 +40360,19 @@
         "_deprecated": false,
         "assertion_id": 870,
         "feature_id": 870,
-        "source_id": 172
+        "source_id": 172,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C71721",
+                    "code": "C71721",
+                    "name": "Olaparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Germline Variant",
@@ -31595,7 +40411,19 @@
         "_deprecated": false,
         "assertion_id": 871,
         "feature_id": 871,
-        "source_id": 172
+        "source_id": 172,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C71721",
+                    "code": "C71721",
+                    "name": "Olaparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Germline Variant",
@@ -31635,7 +40463,19 @@
         "_deprecated": false,
         "assertion_id": 872,
         "feature_id": 872,
-        "source_id": 172
+        "source_id": 172,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C71721",
+                    "code": "C71721",
+                    "name": "Olaparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Germline Variant",
@@ -31675,7 +40515,19 @@
         "_deprecated": false,
         "assertion_id": 873,
         "feature_id": 873,
-        "source_id": 172
+        "source_id": 172,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C71721",
+                    "code": "C71721",
+                    "name": "Olaparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -31714,7 +40566,29 @@
         "_deprecated": false,
         "assertion_id": 874,
         "feature_id": 874,
-        "source_id": 260
+        "source_id": 260,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C71744",
+                    "code": "C71744",
+                    "name": "Enzalutamide",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C95733",
+                    "code": "C95733",
+                    "name": "Talazoparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -31753,7 +40627,29 @@
         "_deprecated": false,
         "assertion_id": 875,
         "feature_id": 875,
-        "source_id": 260
+        "source_id": 260,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C71744",
+                    "code": "C71744",
+                    "name": "Enzalutamide",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C95733",
+                    "code": "C95733",
+                    "name": "Talazoparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -31792,7 +40688,29 @@
         "_deprecated": false,
         "assertion_id": 876,
         "feature_id": 876,
-        "source_id": 260
+        "source_id": 260,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C71744",
+                    "code": "C71744",
+                    "name": "Enzalutamide",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C95733",
+                    "code": "C95733",
+                    "name": "Talazoparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -31831,7 +40749,29 @@
         "_deprecated": false,
         "assertion_id": 877,
         "feature_id": 877,
-        "source_id": 260
+        "source_id": 260,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C71744",
+                    "code": "C71744",
+                    "name": "Enzalutamide",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C95733",
+                    "code": "C95733",
+                    "name": "Talazoparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -31870,7 +40810,29 @@
         "_deprecated": false,
         "assertion_id": 878,
         "feature_id": 878,
-        "source_id": 260
+        "source_id": 260,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C71744",
+                    "code": "C71744",
+                    "name": "Enzalutamide",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C95733",
+                    "code": "C95733",
+                    "name": "Talazoparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -31909,7 +40871,29 @@
         "_deprecated": false,
         "assertion_id": 879,
         "feature_id": 879,
-        "source_id": 260
+        "source_id": 260,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C71744",
+                    "code": "C71744",
+                    "name": "Enzalutamide",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C95733",
+                    "code": "C95733",
+                    "name": "Talazoparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -31948,7 +40932,29 @@
         "_deprecated": false,
         "assertion_id": 880,
         "feature_id": 880,
-        "source_id": 260
+        "source_id": 260,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C71744",
+                    "code": "C71744",
+                    "name": "Enzalutamide",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C95733",
+                    "code": "C95733",
+                    "name": "Talazoparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -31987,7 +40993,29 @@
         "_deprecated": false,
         "assertion_id": 881,
         "feature_id": 881,
-        "source_id": 260
+        "source_id": 260,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C71744",
+                    "code": "C71744",
+                    "name": "Enzalutamide",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C95733",
+                    "code": "C95733",
+                    "name": "Talazoparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -32026,7 +41054,29 @@
         "_deprecated": true,
         "assertion_id": 882,
         "feature_id": 882,
-        "source_id": 260
+        "source_id": 260,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C71744",
+                    "code": "C71744",
+                    "name": "Enzalutamide",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C95733",
+                    "code": "C95733",
+                    "name": "Talazoparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -32065,7 +41115,29 @@
         "_deprecated": false,
         "assertion_id": 883,
         "feature_id": 883,
-        "source_id": 260
+        "source_id": 260,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C71744",
+                    "code": "C71744",
+                    "name": "Enzalutamide",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C95733",
+                    "code": "C95733",
+                    "name": "Talazoparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -32104,7 +41176,29 @@
         "_deprecated": false,
         "assertion_id": 884,
         "feature_id": 884,
-        "source_id": 260
+        "source_id": 260,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C71744",
+                    "code": "C71744",
+                    "name": "Enzalutamide",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C95733",
+                    "code": "C95733",
+                    "name": "Talazoparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -32143,7 +41237,29 @@
         "_deprecated": false,
         "assertion_id": 885,
         "feature_id": 885,
-        "source_id": 260
+        "source_id": 260,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C71744",
+                    "code": "C71744",
+                    "name": "Enzalutamide",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C95733",
+                    "code": "C95733",
+                    "name": "Talazoparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Germline Variant",
@@ -32183,7 +41299,29 @@
         "_deprecated": false,
         "assertion_id": 886,
         "feature_id": 886,
-        "source_id": 261
+        "source_id": 261,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C68845",
+                    "code": "C68845",
+                    "name": "Abiraterone acetate",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C80059",
+                    "code": "C80059",
+                    "name": "Niraparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -32222,7 +41360,29 @@
         "_deprecated": false,
         "assertion_id": 887,
         "feature_id": 887,
-        "source_id": 261
+        "source_id": 261,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C68845",
+                    "code": "C68845",
+                    "name": "Abiraterone acetate",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C80059",
+                    "code": "C80059",
+                    "name": "Niraparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Germline Variant",
@@ -32262,7 +41422,29 @@
         "_deprecated": false,
         "assertion_id": 888,
         "feature_id": 888,
-        "source_id": 261
+        "source_id": 261,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C68845",
+                    "code": "C68845",
+                    "name": "Abiraterone acetate",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C80059",
+                    "code": "C80059",
+                    "name": "Niraparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -32301,7 +41483,29 @@
         "_deprecated": false,
         "assertion_id": 889,
         "feature_id": 889,
-        "source_id": 261
+        "source_id": 261,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C68845",
+                    "code": "C68845",
+                    "name": "Abiraterone acetate",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C80059",
+                    "code": "C80059",
+                    "name": "Niraparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Microsatellite Stability",
@@ -32310,7 +41514,7 @@
         "context": "Primary advanced or recurrent",
         "oncotree_term": "Endometrial Carcinoma",
         "oncotree_code": "UCEC",
-        "therapy_name": "Dostarlimab-gxly",
+        "therapy_name": "Dostarlimab",
         "therapy_strategy": "PD-1/PD-L1 inhibition",
         "therapy_type": "Immunotherapy",
         "therapy_sensitivity": 1,
@@ -32329,7 +41533,19 @@
         "_deprecated": false,
         "assertion_id": 890,
         "feature_id": 890,
-        "source_id": 262
+        "source_id": 262,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C126799",
+                    "code": "C126799",
+                    "name": "Dostarlimab",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -32368,7 +41584,8 @@
         "_deprecated": false,
         "assertion_id": 891,
         "feature_id": 891,
-        "source_id": 263
+        "source_id": 263,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -32407,7 +41624,19 @@
         "_deprecated": false,
         "assertion_id": 892,
         "feature_id": 892,
-        "source_id": 264
+        "source_id": 264,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C49176",
+                    "code": "C49176",
+                    "name": "Palbociclib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Copy Number",
@@ -32418,7 +41647,7 @@
         "context": "",
         "oncotree_term": "Osteosarcoma",
         "oncotree_code": "OS",
-        "therapy_name": "AZ4547",
+        "therapy_name": "Fexagratinib",
         "therapy_strategy": "FGFR1 inhibition",
         "therapy_type": "Targeted therapy",
         "therapy_sensitivity": 1,
@@ -32438,7 +41667,19 @@
         "_deprecated": false,
         "assertion_id": 893,
         "feature_id": 893,
-        "source_id": 264
+        "source_id": 264,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C88272",
+                    "code": "C88272",
+                    "name": "Fexagratinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Copy Number",
@@ -32469,7 +41710,8 @@
         "_deprecated": false,
         "assertion_id": 894,
         "feature_id": 894,
-        "source_id": 264
+        "source_id": 264,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -32508,7 +41750,19 @@
         "_deprecated": false,
         "assertion_id": 895,
         "feature_id": 895,
-        "source_id": 265
+        "source_id": 265,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C71721",
+                    "code": "C71721",
+                    "name": "Olaparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Copy Number",
@@ -32519,7 +41773,7 @@
         "context": "",
         "oncotree_term": "Osteosarcoma",
         "oncotree_code": "OS",
-        "therapy_name": "AT7519",
+        "therapy_name": "CDK Inhibitor AT7519",
         "therapy_strategy": "CDK inhibition",
         "therapy_type": "Targeted therapy",
         "therapy_sensitivity": 1,
@@ -32539,7 +41793,19 @@
         "_deprecated": false,
         "assertion_id": 896,
         "feature_id": 896,
-        "source_id": 266
+        "source_id": 266,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C64761",
+                    "code": "C64761",
+                    "name": "CDK Inhibitor AT7519",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Copy Number",
@@ -32570,7 +41836,19 @@
         "_deprecated": false,
         "assertion_id": 897,
         "feature_id": 897,
-        "source_id": 266
+        "source_id": 266,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C78854",
+                    "code": "C78854",
+                    "name": "Dinaciclib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Copy Number",
@@ -32601,7 +41879,19 @@
         "_deprecated": false,
         "assertion_id": 898,
         "feature_id": 898,
-        "source_id": 266
+        "source_id": 266,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C49176",
+                    "code": "C49176",
+                    "name": "Palbociclib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Copy Number",
@@ -32612,7 +41902,7 @@
         "context": "",
         "oncotree_term": "Osteosarcoma",
         "oncotree_code": "OS",
-        "therapy_name": "MK-2206",
+        "therapy_name": "Akt Inhibitor MK2206",
         "therapy_strategy": "PI3K/AKT/mTOR inhibition",
         "therapy_type": "Targeted therapy",
         "therapy_sensitivity": 1,
@@ -32632,7 +41922,19 @@
         "_deprecated": false,
         "assertion_id": 899,
         "feature_id": 899,
-        "source_id": 266
+        "source_id": 266,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C90581",
+                    "code": "C90581",
+                    "name": "Akt Inhibitor MK2206",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Copy Number",
@@ -32643,7 +41945,7 @@
         "context": "",
         "oncotree_term": "Osteosarcoma",
         "oncotree_code": "OS",
-        "therapy_name": "Rapamycin",
+        "therapy_name": "Sirolimus",
         "therapy_strategy": "PI3K/AKT/mTOR inhibition",
         "therapy_type": "Targeted therapy",
         "therapy_sensitivity": 1,
@@ -32663,7 +41965,19 @@
         "_deprecated": false,
         "assertion_id": 900,
         "feature_id": 900,
-        "source_id": 266
+        "source_id": 266,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C1212",
+                    "code": "C1212",
+                    "name": "Sirolimus",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Copy Number",
@@ -32694,7 +42008,19 @@
         "_deprecated": false,
         "assertion_id": 901,
         "feature_id": 901,
-        "source_id": 267
+        "source_id": 267,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C95733",
+                    "code": "C95733",
+                    "name": "Talazoparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Copy Number",
@@ -32725,7 +42051,19 @@
         "_deprecated": false,
         "assertion_id": 902,
         "feature_id": 902,
-        "source_id": 267
+        "source_id": 267,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C95733",
+                    "code": "C95733",
+                    "name": "Talazoparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Copy Number",
@@ -32756,7 +42094,19 @@
         "_deprecated": false,
         "assertion_id": 903,
         "feature_id": 903,
-        "source_id": 267
+        "source_id": 267,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C95733",
+                    "code": "C95733",
+                    "name": "Talazoparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Copy Number",
@@ -32787,7 +42137,19 @@
         "_deprecated": false,
         "assertion_id": 904,
         "feature_id": 904,
-        "source_id": 267
+        "source_id": 267,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C95733",
+                    "code": "C95733",
+                    "name": "Talazoparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Copy Number",
@@ -32818,7 +42180,19 @@
         "_deprecated": false,
         "assertion_id": 905,
         "feature_id": 905,
-        "source_id": 267
+        "source_id": 267,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C95733",
+                    "code": "C95733",
+                    "name": "Talazoparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Copy Number",
@@ -32849,7 +42223,19 @@
         "_deprecated": false,
         "assertion_id": 906,
         "feature_id": 906,
-        "source_id": 267
+        "source_id": 267,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C95733",
+                    "code": "C95733",
+                    "name": "Talazoparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Rearrangement",
@@ -32881,7 +42267,19 @@
         "_deprecated": false,
         "assertion_id": 907,
         "feature_id": 907,
-        "source_id": 268
+        "source_id": 268,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C60809",
+                    "code": "C60809",
+                    "name": "Bosutinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -32919,7 +42317,19 @@
         "_deprecated": false,
         "assertion_id": 908,
         "feature_id": 908,
-        "source_id": 269
+        "source_id": 269,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C114383",
+                    "code": "C114383",
+                    "name": "Ivosidenib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -32957,7 +42367,19 @@
         "_deprecated": false,
         "assertion_id": 909,
         "feature_id": 909,
-        "source_id": 269
+        "source_id": 269,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C114383",
+                    "code": "C114383",
+                    "name": "Ivosidenib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -32995,7 +42417,19 @@
         "_deprecated": false,
         "assertion_id": 910,
         "feature_id": 910,
-        "source_id": 269
+        "source_id": 269,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C114383",
+                    "code": "C114383",
+                    "name": "Ivosidenib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -33033,7 +42467,29 @@
         "_deprecated": false,
         "assertion_id": 911,
         "feature_id": 911,
-        "source_id": 270
+        "source_id": 270,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C84865",
+                    "code": "C84865",
+                    "name": "Binimetinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C98283",
+                    "code": "C98283",
+                    "name": "Encorafenib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -33071,7 +42527,8 @@
         "_deprecated": false,
         "assertion_id": 912,
         "feature_id": 912,
-        "source_id": 33
+        "source_id": 33,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -33109,7 +42566,8 @@
         "_deprecated": false,
         "assertion_id": 913,
         "feature_id": 913,
-        "source_id": 33
+        "source_id": 33,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -33147,7 +42605,8 @@
         "_deprecated": false,
         "assertion_id": 914,
         "feature_id": 914,
-        "source_id": 33
+        "source_id": 33,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -33185,7 +42644,8 @@
         "_deprecated": false,
         "assertion_id": 915,
         "feature_id": 915,
-        "source_id": 33
+        "source_id": 33,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -33223,7 +42683,8 @@
         "_deprecated": false,
         "assertion_id": 916,
         "feature_id": 916,
-        "source_id": 33
+        "source_id": 33,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -33261,7 +42722,8 @@
         "_deprecated": false,
         "assertion_id": 917,
         "feature_id": 917,
-        "source_id": 33
+        "source_id": 33,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -33299,7 +42761,8 @@
         "_deprecated": false,
         "assertion_id": 918,
         "feature_id": 918,
-        "source_id": 33
+        "source_id": 33,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -33337,7 +42800,8 @@
         "_deprecated": false,
         "assertion_id": 919,
         "feature_id": 919,
-        "source_id": 33
+        "source_id": 33,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -33375,7 +42839,8 @@
         "_deprecated": false,
         "assertion_id": 920,
         "feature_id": 920,
-        "source_id": 33
+        "source_id": 33,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -33413,7 +42878,8 @@
         "_deprecated": false,
         "assertion_id": 921,
         "feature_id": 921,
-        "source_id": 33
+        "source_id": 33,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -33451,7 +42917,8 @@
         "_deprecated": false,
         "assertion_id": 922,
         "feature_id": 922,
-        "source_id": 33
+        "source_id": 33,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -33489,7 +42956,8 @@
         "_deprecated": false,
         "assertion_id": 923,
         "feature_id": 923,
-        "source_id": 33
+        "source_id": 33,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -33527,7 +42995,8 @@
         "_deprecated": false,
         "assertion_id": 924,
         "feature_id": 924,
-        "source_id": 33
+        "source_id": 33,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -33565,7 +43034,8 @@
         "_deprecated": false,
         "assertion_id": 925,
         "feature_id": 925,
-        "source_id": 33
+        "source_id": 33,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -33603,7 +43073,8 @@
         "_deprecated": false,
         "assertion_id": 926,
         "feature_id": 926,
-        "source_id": 33
+        "source_id": 33,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -33641,7 +43112,8 @@
         "_deprecated": false,
         "assertion_id": 927,
         "feature_id": 927,
-        "source_id": 33
+        "source_id": 33,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -33679,7 +43151,8 @@
         "_deprecated": false,
         "assertion_id": 928,
         "feature_id": 928,
-        "source_id": 33
+        "source_id": 33,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -33717,7 +43190,8 @@
         "_deprecated": false,
         "assertion_id": 929,
         "feature_id": 929,
-        "source_id": 33
+        "source_id": 33,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -33755,7 +43229,8 @@
         "_deprecated": false,
         "assertion_id": 930,
         "feature_id": 930,
-        "source_id": 33
+        "source_id": 33,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -33793,7 +43268,8 @@
         "_deprecated": false,
         "assertion_id": 931,
         "feature_id": 931,
-        "source_id": 33
+        "source_id": 33,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -33831,7 +43307,8 @@
         "_deprecated": false,
         "assertion_id": 932,
         "feature_id": 932,
-        "source_id": 33
+        "source_id": 33,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -33869,7 +43346,8 @@
         "_deprecated": false,
         "assertion_id": 933,
         "feature_id": 933,
-        "source_id": 33
+        "source_id": 33,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -33907,7 +43385,8 @@
         "_deprecated": false,
         "assertion_id": 934,
         "feature_id": 934,
-        "source_id": 33
+        "source_id": 33,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Somatic Variant",
@@ -33945,7 +43424,8 @@
         "_deprecated": false,
         "assertion_id": 935,
         "feature_id": 935,
-        "source_id": 33
+        "source_id": 33,
+        "therapy_name_mappings": []
     },
     {
         "feature_type": "Rearrangement",
@@ -33976,7 +43456,19 @@
         "_deprecated": true,
         "assertion_id": 936,
         "feature_id": 936,
-        "source_id": 271
+        "source_id": 271,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C133821",
+                    "code": "C133821",
+                    "name": "Repotrectinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -34014,7 +43506,29 @@
         "_deprecated": false,
         "assertion_id": 937,
         "feature_id": 937,
-        "source_id": 272
+        "source_id": 272,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C102564",
+                    "code": "C102564",
+                    "name": "Capivasertib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C1379",
+                    "code": "C1379",
+                    "name": "Fulvestrant",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -34052,7 +43566,29 @@
         "_deprecated": false,
         "assertion_id": 938,
         "feature_id": 938,
-        "source_id": 272
+        "source_id": 272,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C102564",
+                    "code": "C102564",
+                    "name": "Capivasertib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C1379",
+                    "code": "C1379",
+                    "name": "Fulvestrant",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -34090,7 +43626,29 @@
         "_deprecated": false,
         "assertion_id": 939,
         "feature_id": 939,
-        "source_id": 272
+        "source_id": 272,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C102564",
+                    "code": "C102564",
+                    "name": "Capivasertib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C1379",
+                    "code": "C1379",
+                    "name": "Fulvestrant",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -34128,7 +43686,29 @@
         "_deprecated": false,
         "assertion_id": 940,
         "feature_id": 940,
-        "source_id": 272
+        "source_id": 272,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C102564",
+                    "code": "C102564",
+                    "name": "Capivasertib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C1379",
+                    "code": "C1379",
+                    "name": "Fulvestrant",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -34166,7 +43746,29 @@
         "_deprecated": false,
         "assertion_id": 941,
         "feature_id": 941,
-        "source_id": 272
+        "source_id": 272,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C102564",
+                    "code": "C102564",
+                    "name": "Capivasertib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C1379",
+                    "code": "C1379",
+                    "name": "Fulvestrant",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Copy Number",
@@ -34196,7 +43798,29 @@
         "_deprecated": false,
         "assertion_id": 942,
         "feature_id": 942,
-        "source_id": 272
+        "source_id": 272,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C102564",
+                    "code": "C102564",
+                    "name": "Capivasertib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C1379",
+                    "code": "C1379",
+                    "name": "Fulvestrant",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Copy Number",
@@ -34207,7 +43831,7 @@
         "context": "Advanced or metastatic",
         "oncotree_term": "Invasive Breast Carcinoma",
         "oncotree_code": "BRCA",
-        "therapy_name": "Neratinib + Capecitabine",
+        "therapy_name": "Capecitabine + Neratinib",
         "therapy_strategy": "ER signaling inhibition + Thymidylate synthase inhibitor",
         "therapy_type": "Combination therapy",
         "therapy_sensitivity": 1,
@@ -34226,7 +43850,29 @@
         "_deprecated": false,
         "assertion_id": 943,
         "feature_id": 943,
-        "source_id": 202
+        "source_id": 202,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C49094",
+                    "code": "C49094",
+                    "name": "Neratinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C1794",
+                    "code": "C1794",
+                    "name": "Capecitabine",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -34264,7 +43910,19 @@
         "_deprecated": false,
         "assertion_id": 944,
         "feature_id": 944,
-        "source_id": 273
+        "source_id": 273,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C64768",
+                    "code": "C64768",
+                    "name": "Vemurafenib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -34302,7 +43960,19 @@
         "_deprecated": false,
         "assertion_id": 945,
         "feature_id": 945,
-        "source_id": 273
+        "source_id": 273,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C64768",
+                    "code": "C64768",
+                    "name": "Vemurafenib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -34321,7 +43991,7 @@
         "context": "Locally advanced or metastatic disease which has progressed on or after platinum-based chemotherapy.",
         "oncotree_term": "Non-Small Cell Lung Cancer",
         "oncotree_code": "NSCLC",
-        "therapy_name": "Amivantamab-vmjw + Carboplatin + Pemetrexed",
+        "therapy_name": "Amivantamab + Carboplatin + Pemetrexed",
         "therapy_strategy": "EGFR inhibition + Platinum-based chemotherapy + Antifolate",
         "therapy_type": "Combination therapy",
         "therapy_sensitivity": 1,
@@ -34340,7 +44010,39 @@
         "_deprecated": false,
         "assertion_id": 946,
         "feature_id": 946,
-        "source_id": 274
+        "source_id": 274,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C124993",
+                    "code": "C124993",
+                    "name": "Amivantamab",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C1282",
+                    "code": "C1282",
+                    "name": "Carboplatin",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C61614",
+                    "code": "C61614",
+                    "name": "Pemetrexed",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -34378,7 +44080,39 @@
         "_deprecated": false,
         "assertion_id": 947,
         "feature_id": 947,
-        "source_id": 275
+        "source_id": 275,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C376",
+                    "code": "C376",
+                    "name": "Cisplatin",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C116377",
+                    "code": "C116377",
+                    "name": "Osimertinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C61614",
+                    "code": "C61614",
+                    "name": "Pemetrexed",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -34416,7 +44150,39 @@
         "_deprecated": false,
         "assertion_id": 948,
         "feature_id": 948,
-        "source_id": 275
+        "source_id": 275,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C376",
+                    "code": "C376",
+                    "name": "Cisplatin",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C116377",
+                    "code": "C116377",
+                    "name": "Osimertinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C61614",
+                    "code": "C61614",
+                    "name": "Pemetrexed",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -34454,7 +44220,19 @@
         "_deprecated": false,
         "assertion_id": 949,
         "feature_id": 949,
-        "source_id": 276
+        "source_id": 276,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C116377",
+                    "code": "C116377",
+                    "name": "Osimertinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -34492,7 +44270,19 @@
         "_deprecated": false,
         "assertion_id": 950,
         "feature_id": 950,
-        "source_id": 276
+        "source_id": 276,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C116377",
+                    "code": "C116377",
+                    "name": "Osimertinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -34530,7 +44320,19 @@
         "_deprecated": false,
         "assertion_id": 951,
         "feature_id": 951,
-        "source_id": 277
+        "source_id": 277,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C88314",
+                    "code": "C88314",
+                    "name": "Tepotinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -34568,7 +44370,19 @@
         "_deprecated": false,
         "assertion_id": 952,
         "feature_id": 952,
-        "source_id": 277
+        "source_id": 277,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C88314",
+                    "code": "C88314",
+                    "name": "Tepotinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Rearrangement",
@@ -34599,7 +44413,19 @@
         "_deprecated": false,
         "assertion_id": 953,
         "feature_id": 953,
-        "source_id": 278
+        "source_id": 278,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C74061",
+                    "code": "C74061",
+                    "name": "Crizotinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Rearrangement",
@@ -34630,7 +44456,19 @@
         "_deprecated": false,
         "assertion_id": 954,
         "feature_id": 954,
-        "source_id": 40
+        "source_id": 40,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C114984",
+                    "code": "C114984",
+                    "name": "Entrectinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Rearrangement",
@@ -34661,7 +44499,19 @@
         "_deprecated": false,
         "assertion_id": 955,
         "feature_id": 955,
-        "source_id": 271
+        "source_id": 271,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C133821",
+                    "code": "C133821",
+                    "name": "Repotrectinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -34700,7 +44550,29 @@
         "_deprecated": false,
         "assertion_id": 956,
         "feature_id": 956,
-        "source_id": 260
+        "source_id": 260,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C71744",
+                    "code": "C71744",
+                    "name": "Enzalutamide",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C95733",
+                    "code": "C95733",
+                    "name": "Talazoparib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Rearrangement",
@@ -34712,7 +44584,7 @@
         "context": "",
         "oncotree_term": "Acute Lymphoid Leukemia",
         "oncotree_code": "ALL",
-        "therapy_name": "Ponatinib + Chemotherapy",
+        "therapy_name": "Chemotherapy + Ponatinib",
         "therapy_strategy": "targets BCR-ABL + Chemotherapy",
         "therapy_type": "Combination therapy",
         "therapy_sensitivity": 1,
@@ -34732,7 +44604,29 @@
         "_deprecated": false,
         "assertion_id": 957,
         "feature_id": 957,
-        "source_id": 279
+        "source_id": 279,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C95777",
+                    "code": "C95777",
+                    "name": "Ponatinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C15632",
+                    "code": "C15632",
+                    "name": "Chemotherapy",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Rearrangement",
@@ -34764,7 +44658,19 @@
         "_deprecated": false,
         "assertion_id": 958,
         "feature_id": 958,
-        "source_id": 280
+        "source_id": 280,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C95777",
+                    "code": "C95777",
+                    "name": "Ponatinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Rearrangement",
@@ -34796,7 +44702,19 @@
         "_deprecated": false,
         "assertion_id": 959,
         "feature_id": 959,
-        "source_id": 280
+        "source_id": 280,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C95777",
+                    "code": "C95777",
+                    "name": "Ponatinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -34835,7 +44753,19 @@
         "_deprecated": false,
         "assertion_id": 960,
         "feature_id": 960,
-        "source_id": 280
+        "source_id": 280,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C95777",
+                    "code": "C95777",
+                    "name": "Ponatinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -34874,7 +44804,19 @@
         "_deprecated": false,
         "assertion_id": 961,
         "feature_id": 961,
-        "source_id": 280
+        "source_id": 280,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C95777",
+                    "code": "C95777",
+                    "name": "Ponatinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Rearrangement",
@@ -34905,7 +44847,19 @@
         "_deprecated": false,
         "assertion_id": 962,
         "feature_id": 962,
-        "source_id": 281
+        "source_id": 281,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C101790",
+                    "code": "C101790",
+                    "name": "Alectinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -34943,7 +44897,19 @@
         "_deprecated": false,
         "assertion_id": 963,
         "feature_id": 963,
-        "source_id": 282
+        "source_id": 282,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C106254",
+                    "code": "C106254",
+                    "name": "Tovorafenib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Rearrangement",
@@ -34974,7 +44940,19 @@
         "_deprecated": false,
         "assertion_id": 964,
         "feature_id": 964,
-        "source_id": 282
+        "source_id": 282,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C106254",
+                    "code": "C106254",
+                    "name": "Tovorafenib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Rearrangement",
@@ -35005,7 +44983,19 @@
         "_deprecated": false,
         "assertion_id": 965,
         "feature_id": 965,
-        "source_id": 282
+        "source_id": 282,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C106254",
+                    "code": "C106254",
+                    "name": "Tovorafenib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -35043,7 +45033,19 @@
         "_deprecated": false,
         "assertion_id": 966,
         "feature_id": 966,
-        "source_id": 283
+        "source_id": 283,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C65530",
+                    "code": "C65530",
+                    "name": "Erlotinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -35081,7 +45083,19 @@
         "_deprecated": false,
         "assertion_id": 967,
         "feature_id": 967,
-        "source_id": 283
+        "source_id": 283,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C65530",
+                    "code": "C65530",
+                    "name": "Erlotinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -35119,7 +45133,19 @@
         "_deprecated": false,
         "assertion_id": 968,
         "feature_id": 968,
-        "source_id": 284
+        "source_id": 284,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C1855",
+                    "code": "C1855",
+                    "name": "Gefitinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -35157,7 +45183,19 @@
         "_deprecated": false,
         "assertion_id": 969,
         "feature_id": 969,
-        "source_id": 284
+        "source_id": 284,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C1855",
+                    "code": "C1855",
+                    "name": "Gefitinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Rearrangement",
@@ -35188,7 +45226,19 @@
         "_deprecated": false,
         "assertion_id": 970,
         "feature_id": 970,
-        "source_id": 285
+        "source_id": 285,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C133821",
+                    "code": "C133821",
+                    "name": "Repotrectinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Rearrangement",
@@ -35219,7 +45269,19 @@
         "_deprecated": false,
         "assertion_id": 971,
         "feature_id": 971,
-        "source_id": 285
+        "source_id": 285,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C133821",
+                    "code": "C133821",
+                    "name": "Repotrectinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Rearrangement",
@@ -35250,7 +45312,19 @@
         "_deprecated": false,
         "assertion_id": 972,
         "feature_id": 972,
-        "source_id": 285
+        "source_id": 285,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C133821",
+                    "code": "C133821",
+                    "name": "Repotrectinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -35288,7 +45362,29 @@
         "_deprecated": false,
         "assertion_id": 973,
         "feature_id": 973,
-        "source_id": 286
+        "source_id": 286,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C157493",
+                    "code": "C157493",
+                    "name": "Adagrasib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C1723",
+                    "code": "C1723",
+                    "name": "Cetuximab",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -35326,7 +45422,19 @@
         "_deprecated": false,
         "assertion_id": 974,
         "feature_id": 974,
-        "source_id": 287
+        "source_id": 287,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C152914",
+                    "code": "C152914",
+                    "name": "Vorasidenib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -35364,7 +45472,19 @@
         "_deprecated": false,
         "assertion_id": 975,
         "feature_id": 975,
-        "source_id": 287
+        "source_id": 287,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C152914",
+                    "code": "C152914",
+                    "name": "Vorasidenib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -35402,7 +45522,19 @@
         "_deprecated": false,
         "assertion_id": 976,
         "feature_id": 976,
-        "source_id": 287
+        "source_id": 287,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C152914",
+                    "code": "C152914",
+                    "name": "Vorasidenib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -35440,7 +45572,19 @@
         "_deprecated": false,
         "assertion_id": 977,
         "feature_id": 977,
-        "source_id": 287
+        "source_id": 287,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C152914",
+                    "code": "C152914",
+                    "name": "Vorasidenib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -35478,7 +45622,19 @@
         "_deprecated": false,
         "assertion_id": 978,
         "feature_id": 978,
-        "source_id": 287
+        "source_id": 287,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C152914",
+                    "code": "C152914",
+                    "name": "Vorasidenib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -35516,7 +45672,19 @@
         "_deprecated": false,
         "assertion_id": 979,
         "feature_id": 979,
-        "source_id": 287
+        "source_id": 287,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C152914",
+                    "code": "C152914",
+                    "name": "Vorasidenib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -35554,7 +45722,19 @@
         "_deprecated": false,
         "assertion_id": 980,
         "feature_id": 980,
-        "source_id": 287
+        "source_id": 287,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C152914",
+                    "code": "C152914",
+                    "name": "Vorasidenib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -35592,7 +45772,19 @@
         "_deprecated": false,
         "assertion_id": 981,
         "feature_id": 981,
-        "source_id": 287
+        "source_id": 287,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C152914",
+                    "code": "C152914",
+                    "name": "Vorasidenib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -35630,7 +45822,19 @@
         "_deprecated": false,
         "assertion_id": 982,
         "feature_id": 982,
-        "source_id": 287
+        "source_id": 287,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C152914",
+                    "code": "C152914",
+                    "name": "Vorasidenib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -35668,7 +45872,19 @@
         "_deprecated": false,
         "assertion_id": 983,
         "feature_id": 983,
-        "source_id": 287
+        "source_id": 287,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C152914",
+                    "code": "C152914",
+                    "name": "Vorasidenib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -35706,7 +45922,19 @@
         "_deprecated": false,
         "assertion_id": 984,
         "feature_id": 984,
-        "source_id": 287
+        "source_id": 287,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C152914",
+                    "code": "C152914",
+                    "name": "Vorasidenib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -35744,7 +45972,19 @@
         "_deprecated": false,
         "assertion_id": 985,
         "feature_id": 985,
-        "source_id": 287
+        "source_id": 287,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C152914",
+                    "code": "C152914",
+                    "name": "Vorasidenib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -35782,7 +46022,19 @@
         "_deprecated": false,
         "assertion_id": 986,
         "feature_id": 986,
-        "source_id": 287
+        "source_id": 287,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C152914",
+                    "code": "C152914",
+                    "name": "Vorasidenib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -35820,7 +46072,19 @@
         "_deprecated": false,
         "assertion_id": 987,
         "feature_id": 987,
-        "source_id": 287
+        "source_id": 287,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C152914",
+                    "code": "C152914",
+                    "name": "Vorasidenib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -35858,7 +46122,19 @@
         "_deprecated": false,
         "assertion_id": 988,
         "feature_id": 988,
-        "source_id": 287
+        "source_id": 287,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C152914",
+                    "code": "C152914",
+                    "name": "Vorasidenib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -35896,7 +46172,19 @@
         "_deprecated": false,
         "assertion_id": 989,
         "feature_id": 989,
-        "source_id": 287
+        "source_id": 287,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C152914",
+                    "code": "C152914",
+                    "name": "Vorasidenib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -35934,7 +46222,19 @@
         "_deprecated": false,
         "assertion_id": 990,
         "feature_id": 990,
-        "source_id": 287
+        "source_id": 287,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C152914",
+                    "code": "C152914",
+                    "name": "Vorasidenib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -35953,7 +46253,7 @@
         "context": "",
         "oncotree_term": "Non-Small Cell Lung Cancer",
         "oncotree_code": "NSCLC",
-        "therapy_name": "Amivantamab-vmjw + Lazertinib",
+        "therapy_name": "Amivantamab + Lazertinib",
         "therapy_strategy": "EGFR inhibition",
         "therapy_type": "Targeted therapy",
         "therapy_sensitivity": 1,
@@ -35972,7 +46272,29 @@
         "_deprecated": false,
         "assertion_id": 991,
         "feature_id": 991,
-        "source_id": 288
+        "source_id": 288,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C124993",
+                    "code": "C124993",
+                    "name": "Amivantamab",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C148147",
+                    "code": "C148147",
+                    "name": "Lazertinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -35991,7 +46313,7 @@
         "context": "",
         "oncotree_term": "Non-Small Cell Lung Cancer",
         "oncotree_code": "NSCLC",
-        "therapy_name": "Amivantamab-vmjw + Lazertinib",
+        "therapy_name": "Amivantamab + Lazertinib",
         "therapy_strategy": "EGFR inhibition",
         "therapy_type": "Targeted therapy",
         "therapy_sensitivity": 1,
@@ -36010,7 +46332,29 @@
         "_deprecated": false,
         "assertion_id": 992,
         "feature_id": 992,
-        "source_id": 288
+        "source_id": 288,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C124993",
+                    "code": "C124993",
+                    "name": "Amivantamab",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C148147",
+                    "code": "C148147",
+                    "name": "Lazertinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -36029,7 +46373,7 @@
         "context": "",
         "oncotree_term": "Non-Small Cell Lung Cancer",
         "oncotree_code": "NSCLC",
-        "therapy_name": "Amivantamab-vmjw + Carboplatin + Pemetrexed",
+        "therapy_name": "Amivantamab + Carboplatin + Pemetrexed",
         "therapy_strategy": "EGFR inhibition + Platinum-based chemotherapy + Antifolate",
         "therapy_type": "Combination therapy",
         "therapy_sensitivity": 1,
@@ -36048,7 +46392,39 @@
         "_deprecated": false,
         "assertion_id": 993,
         "feature_id": 993,
-        "source_id": 289
+        "source_id": 289,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C124993",
+                    "code": "C124993",
+                    "name": "Amivantamab",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C1282",
+                    "code": "C1282",
+                    "name": "Carboplatin",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C61614",
+                    "code": "C61614",
+                    "name": "Pemetrexed",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -36067,7 +46443,7 @@
         "context": "",
         "oncotree_term": "Non-Small Cell Lung Cancer",
         "oncotree_code": "NSCLC",
-        "therapy_name": "Amivantamab-vmjw + Carboplatin + Pemetrexed",
+        "therapy_name": "Amivantamab + Carboplatin + Pemetrexed",
         "therapy_strategy": "EGFR inhibition + Platinum-based chemotherapy + Antifolate",
         "therapy_type": "Combination therapy",
         "therapy_sensitivity": 1,
@@ -36086,7 +46462,39 @@
         "_deprecated": false,
         "assertion_id": 994,
         "feature_id": 994,
-        "source_id": 289
+        "source_id": 289,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C124993",
+                    "code": "C124993",
+                    "name": "Amivantamab",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C1282",
+                    "code": "C1282",
+                    "name": "Carboplatin",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C61614",
+                    "code": "C61614",
+                    "name": "Pemetrexed",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -36124,7 +46532,19 @@
         "_deprecated": false,
         "assertion_id": 995,
         "feature_id": 995,
-        "source_id": 290
+        "source_id": 290,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C116377",
+                    "code": "C116377",
+                    "name": "Osimertinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -36162,7 +46582,19 @@
         "_deprecated": false,
         "assertion_id": 996,
         "feature_id": 996,
-        "source_id": 290
+        "source_id": 290,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C116377",
+                    "code": "C116377",
+                    "name": "Osimertinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Rearrangement",
@@ -36193,7 +46625,19 @@
         "_deprecated": false,
         "assertion_id": 997,
         "feature_id": 997,
-        "source_id": 6
+        "source_id": 6,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C114494",
+                    "code": "C114494",
+                    "name": "Asciminib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Rearrangement",
@@ -36224,7 +46668,19 @@
         "_deprecated": false,
         "assertion_id": 998,
         "feature_id": 998,
-        "source_id": 6
+        "source_id": 6,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C114494",
+                    "code": "C114494",
+                    "name": "Asciminib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -36262,7 +46718,19 @@
         "_deprecated": false,
         "assertion_id": 999,
         "feature_id": 999,
-        "source_id": 6
+        "source_id": 6,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C114494",
+                    "code": "C114494",
+                    "name": "Asciminib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -36281,7 +46749,7 @@
         "context": "",
         "oncotree_term": "Invasive Breast Carcinoma",
         "oncotree_code": "BRCA",
-        "therapy_name": "Inavolisib + Fulvestrant + Palbociclib",
+        "therapy_name": "Fulvestrant + Inavolisib + Palbociclib",
         "therapy_strategy": "PI3K/AKT/mTOR inhibition + ER signaling inhibition + CDK4/6 inhibition",
         "therapy_type": "Combination therapy",
         "therapy_sensitivity": 1,
@@ -36300,7 +46768,39 @@
         "_deprecated": false,
         "assertion_id": 1000,
         "feature_id": 1000,
-        "source_id": 291
+        "source_id": 291,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C132166",
+                    "code": "C132166",
+                    "name": "Inavolisib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C1379",
+                    "code": "C1379",
+                    "name": "Fulvestrant",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C49176",
+                    "code": "C49176",
+                    "name": "Palbociclib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Rearrangement",
@@ -36331,7 +46831,19 @@
         "_deprecated": false,
         "assertion_id": 1001,
         "feature_id": 1001,
-        "source_id": 292
+        "source_id": 292,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C165776",
+                    "code": "C165776",
+                    "name": "Revumenib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Rearrangement",
@@ -36362,7 +46874,19 @@
         "_deprecated": false,
         "assertion_id": 1002,
         "feature_id": 1002,
-        "source_id": 292
+        "source_id": 292,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C165776",
+                    "code": "C165776",
+                    "name": "Revumenib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Rearrangement",
@@ -36374,7 +46898,7 @@
         "context": "",
         "oncotree_term": "Non-Small Cell Lung Cancer",
         "oncotree_code": "NSCLC",
-        "therapy_name": "Zenocutuzumab-zbco",
+        "therapy_name": "Zenocutuzumab",
         "therapy_strategy": "NRG1 inhibition",
         "therapy_type": "Targeted therapy",
         "therapy_sensitivity": 1,
@@ -36393,7 +46917,19 @@
         "_deprecated": false,
         "assertion_id": 1003,
         "feature_id": 1003,
-        "source_id": 293
+        "source_id": 293,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C152948",
+                    "code": "C152948",
+                    "name": "Zenocutuzumab",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Rearrangement",
@@ -36405,7 +46941,7 @@
         "context": "",
         "oncotree_term": "Pancreatic Adenocarcinoma",
         "oncotree_code": "PAAD",
-        "therapy_name": "Zenocutuzumab-zbco",
+        "therapy_name": "Zenocutuzumab",
         "therapy_strategy": "NRG1 inhibition",
         "therapy_type": "Targeted therapy",
         "therapy_sensitivity": 1,
@@ -36424,7 +46960,19 @@
         "_deprecated": false,
         "assertion_id": 1004,
         "feature_id": 1004,
-        "source_id": 293
+        "source_id": 293,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C152948",
+                    "code": "C152948",
+                    "name": "Zenocutuzumab",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Rearrangement",
@@ -36455,7 +47003,19 @@
         "_deprecated": false,
         "assertion_id": 1005,
         "feature_id": 1005,
-        "source_id": 294
+        "source_id": 294,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C102754",
+                    "code": "C102754",
+                    "name": "Ensartinib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -36474,7 +47034,7 @@
         "context": "Metastatic",
         "oncotree_term": "Colorectal Adenocarcinoma",
         "oncotree_code": "COADREAD",
-        "therapy_name": "Cetuximab + Encorafenib + Oxaplatin + 5-Fluorouracil",
+        "therapy_name": "Cetuximab + Encorafenib + Fluorouracil + Oxaliplatin",
         "therapy_strategy": "EGFR inhibition + B-RAF inhibition + Platinum-based chemotherapy + Thymidylate synthase inhibition",
         "therapy_type": "Combination therapy",
         "therapy_sensitivity": 1,
@@ -36493,7 +47053,49 @@
         "_deprecated": false,
         "assertion_id": 1006,
         "feature_id": 1006,
-        "source_id": 295
+        "source_id": 295,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C1723",
+                    "code": "C1723",
+                    "name": "Cetuximab",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C98283",
+                    "code": "C98283",
+                    "name": "Encorafenib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C1181",
+                    "code": "C1181",
+                    "name": "Oxaliplatin",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C505",
+                    "code": "C505",
+                    "name": "Fluorouracil",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     },
     {
         "feature_type": "Somatic Variant",
@@ -36531,6 +47133,28 @@
         "_deprecated": false,
         "assertion_id": 1007,
         "feature_id": 1007,
-        "source_id": 296
+        "source_id": 296,
+        "therapy_name_mappings": [
+            {
+                "coding": {
+                    "id": "ncit:C1857",
+                    "code": "C1857",
+                    "name": "Panitumumab",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            },
+            {
+                "coding": {
+                    "id": "ncit:C154287",
+                    "code": "C154287",
+                    "name": "Sotorasib",
+                    "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                    "systemVersion": "25.01d"
+                },
+                "relation": "exactMatch"
+            }
+        ]
     }
 ]


### PR DESCRIPTION
The current version of the database largely followed therapy naming conventions from the cited source for each record. Combination therapies are also represented as a single string at the moment, with ` + ` delineating each agent. Prior to this pull request, MOAlmanac has 176 `therapy_name` strings and 156 individual therapies (after deconstructing combination therapies). 

Individual therapies were mapped to the [NCI Thesaurus (NCIt)](https://evsexplore.semantics.cancer.gov/evsexplore/), replacing `therapy_name` with the NCIt Preferred Name. A new field, `therapy_name_mappings`, was added to each record as a list, with members populated as [ConceptMappings](https://va-ga4gh.readthedocs.io/en/latest/core-information-model/data-types.html#conceptmapping) from [GA4GH's Variant Annotation Specification (VA-Spec)](https://github.com/ga4gh/va-spec) to the NCIt code for the NCIt Preferred Name. This field will **not** be represented on [moalmanac.org](https://moalmanac.org) or through the API, and instead will be properly represented in the [next version of the database](https://github.com/vanallenlab/moalmanac-db/pulls/36) that will more closely follow VA-Spec recommendations.

Of the 156 individual therapies in MOAlmanac, 143 were mapped to NCIt. Of these, we were listing the NCIt Preferred Name as `therapy_name` for 31 of them and thus `therapy_name` was changed. 

An example record now for a therapeutic sensitivity relation that only involves 1 therapy is:
```json
{
    "feature_type": "Rearrangement",
    "gene1": "FIP1L1",
    "gene2": "PDGFRA",
    "rearrangement_type": "Fusion",
    "locus": "",
    "disease": "Chronic Eosinophilic Leukemia",
    "context": "",
    "oncotree_term": "Chronic Eosinophilic Leukemia, NOS",
    "oncotree_code": "CELNOS",
    "therapy_name": "Imatinib",
    "therapy_strategy": "PDGF-R inhibition",
    "therapy_type": "Targeted therapy",
    "therapy_sensitivity": 1,
    "therapy_resistance": "",
    "favorable_prognosis": "",
    "predictive_implication": "FDA-Approved",
    "description": "The U.S. Food and Drug Administration (FDA) granted approval for imatinib for adult patients with chronic eosinophilic leukemia (CEL) who have FIP1L1-PDGFRA fusions.",
    "source_type": "FDA",
    "citation": "Novartis Pharmaceuticals Corporation. Gleevec (imatinib) [package insert]. U.S. Food and Drug Administration website. https://www.accessdata.fda.gov/drugsatfda_docs/label/2020/021588s056s057lbl.pdf. Revised August 2020. Accessed November 12, 2020.",
    "url": "https://www.accessdata.fda.gov/drugsatfda_docs/label/2020/021588s056s057lbl.pdf",
    "doi": "",
    "pmid": "",
    "nct": "",
    "publication_date": "2020-08-01",
    "last_updated": "2020-11-12",
    "_deprecated": false,
    "assertion_id": 46,
    "feature_id": 46,
    "source_id": 3,
    "therapy_name_mappings": [
        {
            "coding": {
                "id": "ncit:C62035",
                "code": "C62035",
                "name": "Imatinib",
                "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
                "systemVersion": "25.01d"
            },
            "relation": "exactMatch"
        }
    ]
}
``` 

And an example record now for a therapeutic sensitivity relation that involves more than 1 therapy is:
```json
{
    "feature_type": "Copy Number",
    "gene": "ERBB2",
    "direction": "Amplification",
    "cytoband": "",
    "disease": "Breast Cancer",
    "context": "",
    "oncotree_term": "Invasive Breast Carcinoma",
    "oncotree_code": "BRCA",
    "therapy_name": "Pertuzumab + Trastuzumab",
    "therapy_strategy": "ER signaling inhibition",
    "therapy_type": "Combination therapy",
    "therapy_sensitivity": 1,
    "therapy_resistance": "",
    "favorable_prognosis": "",
    "predictive_implication": "FDA-Approved",
    "description": "The U.S. Food and Drug Administration (FDA) granted accelerated approval to pertuzumab for use in combination with trastuzumab and docetaxel for treatment of patients with HER2-positive metastatic breast cancer (MBC) who have not received prior anti-HER2 therapy or chemotherapy for metastatic disease and use in combination with trastuzumab and chemotherapy as: (1) neoadjuvant treatment of patients with HER2-positive, locally advanced, inflammatory, or early stage breast cancer (either greater than 2 cm in diameter or node positive) as part of a complete treatment regimen for early breast cancer. (2) adjuvant treatment of patients with HER2-positive early breast cancer at high risk of recurrence",
    "source_type": "FDA",
    "citation": "Genentech, Inc. Perjeta (pertuzumab) [package insert]. U.S. Food and Drug Administration website. https://www.accessdata.fda.gov/drugsatfda_docs/label/2020/125409s124lbl.pdf. Revised January 2020. Accessed November 12, 2020.",
    "url": "https://www.accessdata.fda.gov/drugsatfda_docs/label/2020/125409s124lbl.pdf",
    "doi": "",
    "pmid": "",
    "nct": "",
    "publication_date": "2020-01-01",
    "last_updated": "2023-10-05",
    "_deprecated": false,
    "assertion_id": 719,
    "feature_id": 719,
    "source_id": 203,
    "therapy_name_mappings": [
        {
        "coding": {
            "id": "ncit:C38692",
            "code": "C38692",
            "name": "Pertuzumab",
            "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
            "systemVersion": "25.01d"
        },
        "relation": "exactMatch"
        },
        {
        "coding": {
            "id": "ncit:C1647",
            "code": "C1647",
            "name": "Trastuzumab",
            "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
            "systemVersion": "25.01d"
        },
        "relation": "exactMatch"
        }
    ]
}
```

The 31 `therapy_name` values that were updated are:
| old `therapy_name` | new `therapy_name` | NCIt code |
|---|---|---|
| 5-Fluorouracil | Fluorouracil | C505 |
| AT7519 | CDK Inhibitor AT7519 | C64761 |
| AZ4547 | Fexagratinib | C88272 |
| AZD3759 | Zorifertinib | C118289 |
| AZD8186 | PI3Kbeta Inhibitor AZD8186 | C107684 |
| Ado-Trastuzumab Emtansine | Trastuzumab Emtansine | C82492 |
| Alkylating chemotherapy | Antineoplastic Alkylating Agent | C1590 |
| Amivantamab-vmjw | Amivantamab | C124993 |
| BAY 1895344 | Elimusertib | C146807 |
| Carbogen and nicotinamide  | Carbogen | C1038 |
| Dostarlimab-gxly | Dostarlimab | C126799 |
| EGF816 | Nazartinib | C115109 |
| Interferon-alpha | Interferon Alpha | C20494 |
| LOXO-292 | Selpercatinib | C134987 |
| MK-2206 | Akt Inhibitor MK2206 | C90581 |
| Margetuximab-cmkb | Margetuximab | C91733 |
| Neoadjuvant chemoradiation | Chemoradiotherapy | C94626 |
| Neoadjuvant chemotherapy | Chemotherapy | C15632 |
| Oxaplatin | Oxaliplatin | C1181 |
| PF-06747775 | Mavelertinib | C120307 |
| PU-H71 | Zelavespib | C101227 |
| Platinum | Platinum Compound | C1450 |
| Proton-based SBRT | Proton Stereotactic Body Radiation Therapy | C175032 |
| Radiation therapy | Radiation Therapy | C15313 |
| Radical radiotherapy | Radiation Therapy | C15313 |
| Rapamycin | Sirolimus | C1212 |
| SBRT | Stereotactic Body Radiation Therapy | C118286 |
| VX-680 | Tozasertib Lactate | C61319 |
| Zenocutuzumab-zbco | Zenocutuzumab | C152948 |
| radiotherapy | Radiation Therapy | C15313 |
| surgery | Surgery | C17173 |

We were unable to map 13 agents to NCIt. Of these, 11 were early investigative agents, 1 was a therapy category that did not have a direct mapping within NCIt, and one was a component of Phesgo. We left the latter as is because, while there is a NCIt concept for Hyaluronidase-zzxf/Pertuzumab/Trastuzumab (NCIt: C173339), the current database structure is for individual agents within a combination therapy, rather than the whole combination therapy.
| `therapy_name` | comment |
|---|---|
| FGFR1 inhibitor | therapy category  |
| Hyaluronidase-zzxf | This is a component of Phesgo |
| EPZ015666 | early investigative therapy |
| EXEL-8232 | early investigative therapy |
| JQ1 | early investigative therapy |
| KU0058684 | early investigative therapy |
| KU0058948 | early investigative therapy |
| Mito-CP | early investigative therapy |
| NSC59984 | early investigative therapy |
| PD173074 | early investigative therapy |
| SU11274 | early investigative therapy |
| U0126 | early investigative therapy |
| nutlin-3 | early investigative therapy |
