### PR TITLE
Expand upon approvals for abemaciclib in combination with endocrine therapy

### DIFF
--- a/referenced/contributions.json
+++ b/referenced/contributions.json
@@ -24,6 +24,6 @@
     "id": 3,
     "type": "Contribution",
     "agent_id": 0,
-    "description": "Added propositions and statements for FDA approval of abemaciclib in combination with endocrine therapy (tamoxifen or an aromatase inhibitor) for patients with HR+, HER2- breast cancer. Added additional propositions for combinations with letrozole, anastrozole, or exemestane per endocrine offerings within monarchE (NCT03155997)."
+    "description": "Added propositions and statements for FDA approval of abemaciclib in combination with endocrine therapy (tamoxifen or an aromatase inhibitor) for patients with HR+, HER2- breast cancer. Additional propositions are for combinations with letrozole, anastrozole, or exemestane per endocrine offerings within monarchE (NCT03155997)."
   }
 ]

--- a/referenced/contributions.json
+++ b/referenced/contributions.json
@@ -24,6 +24,6 @@
     "id": 3,
     "type": "Contribution",
     "agent_id": 0,
-    "description": "Added propositions and statements for FDA approval of abemaciclib in combination with endocrine therapy (tamoxifen or an aromatase inhibitor) for patients with HR+, HER2- breast cancer. Additional propositions are for combinations with letrozole, anastrozole, or exemestane per endocrine offerings within monarchE (NCT03155997)."
+    "description": "Added propositions and statements for approval of abemaciclib in combination with endocrine therapy (tamoxifen or an aromatase inhibitor) for patients with HR+, HER2- breast cancer. Additional propositions are for combinations with letrozole, anastrozole, or exemestane per endocrine offerings within monarchE (NCT03155997)."
   }
 ]

--- a/referenced/contributions.json
+++ b/referenced/contributions.json
@@ -19,5 +19,11 @@
     "agent_id": 0,
     "description": "April 2025 database release, FDA provided regular approval to pembrolizumab in combination with trastuzumab, fluoropyrimidine- and platinum-containing chemotherapy for patients with gastric or gastroesophageal junction (GEJ) adenocracinoma.",
     "date": "2025-04-01"
+  },
+  {
+    "id": 3,
+    "type": "Contribution",
+    "agent_id": 0,
+    "description": "Added propositions and statements for FDA approval of abemaciclib in combination with endocrine therapy (tamoxifen or an aromatase inhibitor) for patients with HR+, HER2- breast cancer. Added additional propositions for combinations with letrozole, anastrozole, or exemestane per endocrine offerings within monarchE (NCT03155997)."
   }
 ]

--- a/referenced/propositions.json
+++ b/referenced/propositions.json
@@ -683,16 +683,6 @@
         "subjectVariant": {}
     },
     {
-        "id": 44,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [],
-        "conditionQualifier_id": 0,
-        "therapies": [],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
         "id": 45,
         "type": "VariantTherapeuticResponseProposition",
         "predicate": "predictSensitivityTo",
@@ -12707,6 +12697,153 @@
         "conditionQualifier_id": 9,
         "therapies": [
             40
+        ],
+        "objectTherapeutic": {},
+        "subjectVariant": {}
+    },
+    {
+        "id": 830,
+        "type": "VariantTherapeuticResponseProposition",
+        "predicate": "predictSensitivityTo",
+        "biomarkers": [
+            1,
+            2,
+            3
+        ],
+        "conditionQualifier_id": 9,
+        "therapies": [
+            99,
+            40
+        ],
+        "objectTherapeutic": {},
+        "subjectVariant": {}
+    },
+    {
+        "id": 831,
+        "type": "VariantTherapeuticResponseProposition",
+        "predicate": "predictSensitivityTo",
+        "biomarkers": [
+            1,
+            2
+        ],
+        "conditionQualifier_id": 9,
+        "therapies": [
+            99,
+            40
+        ],
+        "objectTherapeutic": {},
+        "subjectVariant": {}
+    },
+    {
+        "id": 832,
+        "type": "VariantTherapeuticResponseProposition",
+        "predicate": "predictSensitivityTo",
+        "biomarkers": [
+            2,
+            3
+        ],
+        "conditionQualifier_id": 9,
+        "therapies": [
+            99,
+            40
+        ],
+        "objectTherapeutic": {},
+        "subjectVariant": {}
+    },
+    {
+        "id": 833,
+        "type": "VariantTherapeuticResponseProposition",
+        "predicate": "predictSensitivityTo",
+        "biomarkers": [
+            1,
+            2,
+            3
+        ],
+        "conditionQualifier_id": 9,
+        "therapies": [
+            99,
+            36
+        ],
+        "objectTherapeutic": {},
+        "subjectVariant": {}
+    },
+    {
+        "id": 834,
+        "type": "VariantTherapeuticResponseProposition",
+        "predicate": "predictSensitivityTo",
+        "biomarkers": [
+            1,
+            2
+        ],
+        "conditionQualifier_id": 9,
+        "therapies": [
+            99,
+            36
+        ],
+        "objectTherapeutic": {},
+        "subjectVariant": {}
+    },
+    {
+        "id": 835,
+        "type": "VariantTherapeuticResponseProposition",
+        "predicate": "predictSensitivityTo",
+        "biomarkers": [
+            2,
+            3
+        ],
+        "conditionQualifier_id": 9,
+        "therapies": [
+            99,
+            36
+        ],
+        "objectTherapeutic": {},
+        "subjectVariant": {}
+    },
+    {
+        "id": 836,
+        "type": "VariantTherapeuticResponseProposition",
+        "predicate": "predictSensitivityTo",
+        "biomarkers": [
+            1,
+            2,
+            3
+        ],
+        "conditionQualifier_id": 9,
+        "therapies": [
+            99,
+            5
+        ],
+        "objectTherapeutic": {},
+        "subjectVariant": {}
+    },
+    {
+        "id": 837,
+        "type": "VariantTherapeuticResponseProposition",
+        "predicate": "predictSensitivityTo",
+        "biomarkers": [
+            1,
+            2
+        ],
+        "conditionQualifier_id": 9,
+        "therapies": [
+            99,
+            5
+        ],
+        "objectTherapeutic": {},
+        "subjectVariant": {}
+    },
+    {
+        "id": 838,
+        "type": "VariantTherapeuticResponseProposition",
+        "predicate": "predictSensitivityTo",
+        "biomarkers": [
+            2,
+            3
+        ],
+        "conditionQualifier_id": 9,
+        "therapies": [
+            99,
+            5
         ],
         "objectTherapeutic": {},
         "subjectVariant": {}

--- a/referenced/propositions.json
+++ b/referenced/propositions.json
@@ -12103,7 +12103,10 @@
             3
         ],
         "conditionQualifier_id": 9,
-        "therapies": [],
+        "therapies": [
+            99,
+            5
+        ],
         "objectTherapeutic": {},
         "subjectVariant": {}
     },
@@ -12116,7 +12119,10 @@
             2
         ],
         "conditionQualifier_id": 9,
-        "therapies": [],
+        "therapies": [
+            99,
+            5
+        ],
         "objectTherapeutic": {},
         "subjectVariant": {}
     },
@@ -12129,7 +12135,10 @@
             3
         ],
         "conditionQualifier_id": 9,
-        "therapies": [],
+        "therapies": [
+            99,
+            5
+        ],
         "objectTherapeutic": {},
         "subjectVariant": {}
     },
@@ -12795,55 +12804,6 @@
         "therapies": [
             99,
             36
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 836,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            1,
-            2,
-            3
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            99,
-            5
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 837,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            1,
-            2
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            99,
-            5
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 838,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            2,
-            3
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            99,
-            5
         ],
         "objectTherapeutic": {},
         "subjectVariant": {}

--- a/referenced/statements.json
+++ b/referenced/statements.json
@@ -9331,7 +9331,7 @@
     "reportedIn": [
       0
     ],
-    "proposition_id": 836,
+    "proposition_id": 792,
     "direction": "supports",
     "strength_id": 0,
     "indication_id": 0
@@ -9347,7 +9347,7 @@
     "reportedIn": [
       0
     ],
-    "proposition_id": 837,
+    "proposition_id": 793,
     "direction": "supports",
     "strength_id": 0,
     "indication_id": 0
@@ -9363,7 +9363,7 @@
     "reportedIn": [
       0
     ],
-    "proposition_id": 838,
+    "proposition_id": 794,
     "direction": "supports",
     "strength_id": 0,
     "indication_id": 0

--- a/referenced/statements.json
+++ b/referenced/statements.json
@@ -709,12 +709,13 @@
     "type": "Statement",
     "description": "The U.S. Food and Drug Administration (FDA) granted approval to abemaciclib in combination with endocrine therapy (tamoxifen or an aromatase inhibitor) for the adjuvant treatment of adult patients with hormone receptor (HR)-positive, human epidermal growth factor 2 (HER2)-negative, node positive, early breast cancer at high risk of recurrence. This indication is based on the monarchE (NCT03155997) clinical trial, which was a randomized (1:1), open-label, two cohort, multicenter study. Initial endocrine therapy received by patients included letrozole (39%), tamoxifen (31%), anastrozole (22%), or exemestane (8%).",
     "contributions": [
-      0
+      0,
+      3
     ],
     "reportedIn": [
       0
     ],
-    "proposition_id": 44,
+    "proposition_id": 830,
     "direction": "supports",
     "strength_id": 0,
     "indication_id": 0
@@ -1489,12 +1490,13 @@
     "type": "Statement",
     "description": "The U.S. Food and Drug Administration (FDA) granted approval to abemaciclib in combination with endocrine therapy (tamoxifen or an aromatase inhibitor) for the adjuvant treatment of adult patients with hormone receptor (HR)-positive, human epidermal growth factor 2 (HER2)-negative, node positive, early breast cancer at high risk of recurrence. This indication is based on the monarchE (NCT03155997) clinical trial, which was a randomized (1:1), open-label, two cohort, multicenter study. Initial endocrine therapy received by patients included letrozole (39%), tamoxifen (31%), anastrozole (22%), or exemestane (8%).",
     "contributions": [
-      0
+      0,
+      3
     ],
     "reportedIn": [
       0
     ],
-    "proposition_id": 44,
+    "proposition_id": 831,
     "direction": "supports",
     "strength_id": 0,
     "indication_id": 0
@@ -9253,5 +9255,117 @@
     "direction": "supports",
     "strength_id": 0,
     "indication_id": 229
+  },
+  {
+    "id": 617,
+    "type": "Statement",
+    "description": "The U.S. Food and Drug Administration (FDA) granted approval to abemaciclib in combination with endocrine therapy (tamoxifen or an aromatase inhibitor) for the adjuvant treatment of adult patients with hormone receptor (HR)-positive, human epidermal growth factor 2 (HER2)-negative, node positive, early breast cancer at high risk of recurrence. This indication is based on the monarchE (NCT03155997) clinical trial, which was a randomized (1:1), open-label, two cohort, multicenter study. Initial endocrine therapy received by patients included letrozole (39%), tamoxifen (31%), anastrozole (22%), or exemestane (8%).",
+    "contributions": [
+      0,
+      3
+    ],
+    "reportedIn": [
+      0
+    ],
+    "proposition_id": 832,
+    "direction": "supports",
+    "strength_id": 0,
+    "indication_id": 0
+  },
+  {
+    "id": 618,
+    "type": "Statement",
+    "description": "The U.S. Food and Drug Administration (FDA) granted approval to abemaciclib in combination with endocrine therapy (tamoxifen or an aromatase inhibitor) for the adjuvant treatment of adult patients with hormone receptor (HR)-positive, human epidermal growth factor 2 (HER2)-negative, node positive, early breast cancer at high risk of recurrence. This indication is based on the monarchE (NCT03155997) clinical trial, which was a randomized (1:1), open-label, two cohort, multicenter study. Initial endocrine therapy received by patients included letrozole (39%), tamoxifen (31%), anastrozole (22%), or exemestane (8%).",
+    "contributions": [
+      0,
+      3
+    ],
+    "reportedIn": [
+      0
+    ],
+    "proposition_id": 833,
+    "direction": "supports",
+    "strength_id": 0,
+    "indication_id": 0
+  },
+  {
+    "id": 619,
+    "type": "Statement",
+    "description": "The U.S. Food and Drug Administration (FDA) granted approval to abemaciclib in combination with endocrine therapy (tamoxifen or an aromatase inhibitor) for the adjuvant treatment of adult patients with hormone receptor (HR)-positive, human epidermal growth factor 2 (HER2)-negative, node positive, early breast cancer at high risk of recurrence. This indication is based on the monarchE (NCT03155997) clinical trial, which was a randomized (1:1), open-label, two cohort, multicenter study. Initial endocrine therapy received by patients included letrozole (39%), tamoxifen (31%), anastrozole (22%), or exemestane (8%).",
+    "contributions": [
+      0,
+      3
+    ],
+    "reportedIn": [
+      0
+    ],
+    "proposition_id": 834,
+    "direction": "supports",
+    "strength_id": 0,
+    "indication_id": 0
+  },
+  {
+    "id": 620,
+    "type": "Statement",
+    "description": "The U.S. Food and Drug Administration (FDA) granted approval to abemaciclib in combination with endocrine therapy (tamoxifen or an aromatase inhibitor) for the adjuvant treatment of adult patients with hormone receptor (HR)-positive, human epidermal growth factor 2 (HER2)-negative, node positive, early breast cancer at high risk of recurrence. This indication is based on the monarchE (NCT03155997) clinical trial, which was a randomized (1:1), open-label, two cohort, multicenter study. Initial endocrine therapy received by patients included letrozole (39%), tamoxifen (31%), anastrozole (22%), or exemestane (8%).",
+    "contributions": [
+      0,
+      3
+    ],
+    "reportedIn": [
+      0
+    ],
+    "proposition_id": 835,
+    "direction": "supports",
+    "strength_id": 0,
+    "indication_id": 0
+  },
+  {
+    "id": 621,
+    "type": "Statement",
+    "description": "The U.S. Food and Drug Administration (FDA) granted approval to abemaciclib in combination with endocrine therapy (tamoxifen or an aromatase inhibitor) for the adjuvant treatment of adult patients with hormone receptor (HR)-positive, human epidermal growth factor 2 (HER2)-negative, node positive, early breast cancer at high risk of recurrence. This indication is based on the monarchE (NCT03155997) clinical trial, which was a randomized (1:1), open-label, two cohort, multicenter study. Initial endocrine therapy received by patients included letrozole (39%), tamoxifen (31%), anastrozole (22%), or exemestane (8%).",
+    "contributions": [
+      0,
+      3
+    ],
+    "reportedIn": [
+      0
+    ],
+    "proposition_id": 836,
+    "direction": "supports",
+    "strength_id": 0,
+    "indication_id": 0
+  },
+  {
+    "id": 622,
+    "type": "Statement",
+    "description": "The U.S. Food and Drug Administration (FDA) granted approval to abemaciclib in combination with endocrine therapy (tamoxifen or an aromatase inhibitor) for the adjuvant treatment of adult patients with hormone receptor (HR)-positive, human epidermal growth factor 2 (HER2)-negative, node positive, early breast cancer at high risk of recurrence. This indication is based on the monarchE (NCT03155997) clinical trial, which was a randomized (1:1), open-label, two cohort, multicenter study. Initial endocrine therapy received by patients included letrozole (39%), tamoxifen (31%), anastrozole (22%), or exemestane (8%).",
+    "contributions": [
+      0,
+      3
+    ],
+    "reportedIn": [
+      0
+    ],
+    "proposition_id": 837,
+    "direction": "supports",
+    "strength_id": 0,
+    "indication_id": 0
+  },
+  {
+    "id": 623,
+    "type": "Statement",
+    "description": "The U.S. Food and Drug Administration (FDA) granted approval to abemaciclib in combination with endocrine therapy (tamoxifen or an aromatase inhibitor) for the adjuvant treatment of adult patients with hormone receptor (HR)-positive, human epidermal growth factor 2 (HER2)-negative, node positive, early breast cancer at high risk of recurrence. This indication is based on the monarchE (NCT03155997) clinical trial, which was a randomized (1:1), open-label, two cohort, multicenter study. Initial endocrine therapy received by patients included letrozole (39%), tamoxifen (31%), anastrozole (22%), or exemestane (8%).",
+    "contributions": [
+      0,
+      3
+    ],
+    "reportedIn": [
+      0
+    ],
+    "proposition_id": 838,
+    "direction": "supports",
+    "strength_id": 0,
+    "indication_id": 0
   }
 ]


### PR DESCRIPTION
## Overview
Added database entries for abemaciclib in combination with endocrine therapy for patients with HR+, HER2- breast cancer.

## Database content updates
Added database entries for abemaciclib in combination with endocrine therapy for patients with HR+, HER2- breast cancer. Within the underlying clinical trial, monarchE (NCT03155997), initial endocrine therapy received by patients included letrozole (39% of patients), tamoxifen (31%), anastrozole (22%), or exemestane (8%).

**Added entries**:
- (FDA) 9 propositions, and corresponding statements, were added for abemaciclib in combination with letrozole, anastrozole, and exemestane for the treatment of patients with HR+, HER2- breast cancer 

## Checklist
- [x] All files changed have been reviewed.
- [x] All relevant documentation has been updated.
- [ ] All unit tests have passed.
