### PR TITLE
Represent therapies with therapy groups

### DIFF
--- a/docs/referenced-schema-draft-about.md
+++ b/docs/referenced-schema-draft-about.md
@@ -409,19 +409,21 @@ At the moment, this version of moalmanac-db is only leveraging [Variant Therapeu
 Each record is a dictionary with the following fields:
 - `id` (int): an integer id for the record.
 - `type` (str): "VariantTherapeuticResponseProposition", and reflects the type of proposition.
-- `predicate` (str): "predictSensitivityTo", the relationship between the subject and object of the proposition. 
-- `name` (str): a human readable label for the proposition, not currently used.
+- `predicate` (str): "predictSensitivityTo", the relationship between the subject and object of the proposition.
 - `biomarkers` (list[int]): a list where each element is an `id` referenced within [biomarkers](#biomarkersjson). 
-- `conditionQualifier_id` (int): the `id` referenced within [diseases](diseasesjson). 
+- `conditionQualifier_id` (int): the `id` referenced within [diseases](#diseasesjson).
+- `therapy_id` (int): the `id` referenced within [therapies](#therapiesjson) or null, if the proposition references a [therapygroup](#therapy_groupsjson).
+- `therapy_group_id` (int): the `id` referenced within [therapy_groups](#therapy_groupsjson) or null, if the proposition references a [therapy](#therapiesjson).
 - `objectTherapeutic`: (list[int]): a list where each element is an `id` referenced within [therapies](#therapiesjson). 
 
-Biomarkers and therapies are intended to be represented using the fields `objectTherapeutic` and `subjectVariant`, respectively, but at the moment they are both listed in arrays with implied AND logic. For biomarkers, cat-vrs is currently exploring [how to model groups of variants](https://github.com/ga4gh/cat-vrs/issues/92). For therapies, va-spec recommends modeling groups of more than one therapy as a [therapy group](https://va-ga4gh.readthedocs.io/en/1.0.0-ballot.2024-11/core-information-model/entities/domain-entities/therapeutics/therapy-group.html), and [dereference.py](../utils/dereference.py) needs to be updated to reflect this change.
+Biomarkers are intended to be represented using the field `subjectVariant`, but at the moment they are listed as arrays with implied AND logic. Cat-vrs is currently exploring [how to model groups of variants](https://github.com/ga4gh/cat-vrs/issues/92).
 
 When dereferenced, several fields will update:
 - `biomarkers` will still be called `biomarkers`, but each member will be replaced with the relevant record from [biomarkers](#biomarkersjson).
 - `conditionQualifier_id` will be replaced with `conditionQualifier` and it will contain the relevant record from [diseases](#diseasesjson).
-- `objectTherapeutic` will still be called `objectTherapeutic` and its value will depend on the length of the list elements. If length 1, the element will be replaced with the relevant record from [therapies](#therapiesjson). If more than one element is present, the object will be modeled as a [Therapy Group](https://va-ga4gh.readthedocs.io/en/latest/core-information-model/entities/domain-entities/therapeutics/therapy-group.html), using `AND` as a `membershipOperator`. 
+- `therapy_id` and `therapy_group_id` will both be replaced with `objectTherapeutic` and its value will depend on if the proposition references a record from [therapies](#therapiesjson), using the value from the `therapy_id` key, or [therapy_groups](#therapy_groupsjson), using the value from the `therapy_group_id` key.
 
+An example record from [propositions.json](../referenced/propositions.json):
 ```
 [  
   {    
@@ -433,11 +435,181 @@ When dereferenced, several fields will update:
       2  
     ],  
     "conditionQualifier_id": 9,  
-    "objectTherapeutic": [  
-      99,  
-      119  
+    "subjectVariant": {}, 
+    "therapy_id": null,
+    "therapy_group_id": 0
+  },
+  ...
+]
+```
+
+An example record from [propositions.json](../referenced/propositions.json), after dereferencing:
+```
+[
+  {    
+    "id": 0,  
+    "type": "VariantTherapeuticResponseProposition",  
+    "predicate": "predictSensitivityTo",  
+    "biomarkers": [  
+      {
+        "id": 1,
+        "type": "CategoricalVariant",
+        "name": "ER positive",
+        "extensions": [
+          {
+            "name": "biomarker_type",
+            "value": "Protein expression"
+          },
+          {
+            "name": "marker",
+            "value": "Estrogen receptor (ER)"
+          },
+          {
+            "name": "unit",
+            "value": "status"
+          },
+          {
+            "name": "equality",
+            "value": "="
+          },
+          {
+            "name": "value",
+            "value": "Positive"
+          },
+          {
+            "name": "_present",
+            "value": true
+          }
+        ]
+      },
+      {
+        "id": 2,
+        "type": "CategoricalVariant",
+        "name": "HER2-negative",
+        "extensions": [
+          {
+            "name": "biomarker_type",
+            "value": "Protein expression"
+          },
+          {
+            "name": "marker",
+            "value": "Human epidermal growth factor receptor 2 (HER2)"
+          },
+          {
+            "name": "unit",
+            "value": "status"
+          },
+          {
+            "name": "equality",
+            "value": "="
+          },
+          {
+            "name": "value",
+            "value": "Negative"
+          },
+          {
+            "name": "_present",
+            "value": true
+          }
+        ]
+      } 
     ],  
-    "subjectVariant": ""  
+    "conditionQualifier_id": {
+      "id": 9,
+      "conceptType": "Disease",
+      "name": "Invasive Breast Carcinoma",
+      "primaryCode": "oncotree:BRCA",
+      "mappings": [
+        {
+          "coding": {
+            "id": "oncotree:BRCA",
+            "code": "BRCA",
+            "name": "Invasive Breast Carcinoma",
+            "system": "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=",
+            "systemVersion": "oncotree_2021_11_02"
+          },
+          "relation": "exactMatch"
+        }
+      ],
+      "extensions": [
+        {
+          "name": "solid_tumor",
+          "value": true,
+          "description": "Boolean value for if this tumor type is categorized as a solid tumor."
+        }
+      ]
+    },  
+    "subjectVariant": {}, 
+    "objectTherapeutic": {
+      "id": 0,
+      "membershipOperator": "AND",
+      "therapies": [
+        {
+          "id": 99,
+          "conceptType": "Drug",
+          "name": "Abemaciclib",
+          "primaryCode": "ncit:C97660",
+          "mappings": [
+            {
+              "coding": {
+                "id": "ncit:C97660",
+                "code": "C97660",
+                "name": "Abemaciclib",
+                "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                "systemVersion": "25.01d"
+              },
+              "relation": "exactMatch"
+            }
+          ],
+          "extensions": [
+            {
+              "name": "therapy_strategy",
+              "value": [
+                "CDK4/6 inhibition"
+              ],
+              "description": "Associated therapeutic strategy or mechanism of action of the therapy."
+            },
+            {
+              "name": "therapy_type",
+              "value": "Targeted therapy",
+              "description": "Type of cancer treatment from cancer.gov: https://www.cancer.gov/about-cancer/treatment/types"
+            }
+          ]
+        },
+        {
+          "id": 119,
+          "conceptType": "Drug",
+          "name": "Tamoxifen",
+          "primaryCode": "ncit:C62078",
+          "mappings": [
+            {
+              "coding": {
+                "id": "ncit:C62078",
+                "code": "C62078",
+                "name": "Tamoxifen",
+                "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+                "systemVersion": "25.01d"
+              },
+              "relation": "exactMatch"
+            }
+          ],
+          "extensions": [
+            {
+              "name": "therapy_strategy",
+              "value": [
+                "Estrogen receptor inhibition"
+              ],
+              "description": "Associated therapeutic strategy or mechanism of action of the therapy."
+            },
+            {
+              "name": "therapy_type",
+              "value": "Hormone therapy",
+              "description": "Type of cancer treatment from cancer.gov: https://www.cancer.gov/about-cancer/treatment/types"
+            }
+          ]
+        }
+      ]
+    }
   },
   ...
 ]
@@ -506,11 +678,9 @@ Each record within `mappings` will contain a `coding` and `relation`. The `codin
 
 [Return to Table of Contents](#table-of-contents)
 ## [therapies.json](../referenced/therapies.json)
-Therapies are the therapeutics associated with therapeutic sensitivity propositions. Like biomarkers, all therapies are currently associated with statements as arrays with AND criteria implicitly joining them. Within [Variant Therapeutic Response Propositions](https://va-ga4gh.readthedocs.io/en/1.0.0-ballot.2024-11/base-profiles/proposition-profiles.html#variant-therapeutic-response-proposition), only one object is accepted within the `objectTherapeutic` field and va-spec manages this by expecting a [single therapy](https://va-ga4gh.readthedocs.io/en/1.0.0-ballot.2024-11/core-information-model/entities/domain-entities/therapeutics/drug.html) or a [therapy group](https://va-ga4gh.readthedocs.io/en/1.0.0-ballot.2024-11/core-information-model/entities/domain-entities/therapeutics/therapy-group.html) object. 
+Therapies are the therapeutics associated with therapeutic sensitivity propositions. 
 
-Currently, mappings used for therapies are from the [NCI Enterprise Vocabulary Services](https://evsexplore.semantics.cancer.gov/evsexplore/). Extensions used are `therapy_strategy`, from the current version of the database, and `therapy_type`, which is the [type of cancer treatment from cancer.gov](https://www.cancer.gov/about-cancer/treatment/types). 
-
-At the moment [dereference.py](../utils/dereference.py) does not format therapies into a therapy group if more than one therapy is listed under `therapies`. 
+Currently, mappings used for therapies are from the [NCI Enterprise Vocabulary Services](https://evsexplore.semantics.cancer.gov/evsexplore/). Extensions used are `therapy_strategy`, from the current version of the database, and `therapy_type`, which is the [type of cancer treatment from cancer.gov](https://www.cancer.gov/about-cancer/treatment/types).
 
 Each record is a dictionary with the fields:
 - `id` (int): an integer id for the record.
@@ -526,4 +696,142 @@ Each record within `mappings` will contain a `coding` and `relation`. The `codin
 - `name` (str): a human readable name for the concept in the external system.
 - `system` (str): a url for the external system.
 
+An example record from [therapies.json](../referenced/therapies.json):
+```
+[
+  {
+    "id": 0,
+    "conceptType": "Drug",
+    "name": "Brentuximab Vedotin",
+    "primaryCode": "ncit:C66944",
+    "mappings": [
+      {
+        "coding": {
+          "id": "ncit:C66944",
+          "code": "C66944",
+          "name": "Brentuximab Vedotin",
+          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+          "systemVersion": "25.01d"
+        },
+        "relation": "exactMatch"
+      }
+    ],
+    "extensions": [
+      {
+        "name": "therapy_strategy",
+        "value": [
+          "target CD30 antigens"
+        ],
+        "description": "Associated therapeutic strategy or mechanism of action of the therapy."
+      },
+      {
+        "name": "therapy_type",
+        "value": "Targeted therapy",
+        "description": "Type of cancer treatment from cancer.gov: https://www.cancer.gov/about-cancer/treatment/types"
+      }
+    ]
+  },
+  ...
+]
+```
+[Return to Table of Contents](#table-of-contents)
+## [therapy_groups.json](../referenced/therapy_groups.json)
+Therapy groups are the sets of [therapies](#therapiesjson) associated with therapeutic sensitivity propositions. Within [Variant Therapeutic Response Propositions](https://va-ga4gh.readthedocs.io/en/1.0.0-ballot.2024-11/base-profiles/proposition-profiles.html#variant-therapeutic-response-proposition), only one object is accepted within the `objectTherapeutic` field and va-spec manages this by expecting a [single therapy](https://va-ga4gh.readthedocs.io/en/1.0.0-ballot.2024-11/core-information-model/entities/domain-entities/therapeutics/drug.html) or a [therapy group](https://va-ga4gh.readthedocs.io/en/1.0.0-ballot.2024-11/core-information-model/entities/domain-entities/therapeutics/therapy-group.html) object. 
+
+Each record is a dictionary with the fields:
+- `id` (int): an integer id for the record.
+- `membershipOperator` (str): either "AND" or "OR"
+- `therapies` (list[int]): a list where each element is an `id` referenced within [therapies](#therapiesjson).
+
+An example record from [therapy_groups.json](../referenced/therapy_groups.json):
+```
+[
+  {
+    "id": 0,
+    "membershipOperator": "AND",
+    "therapies": [
+      99,
+      119
+    ]
+  },
+  ...
+]
+```
+
+An example record from [therapy_groups.json](../referenced/therapy_groups.json), after dereferencing:
+```
+[
+  {
+    "id": 0,
+    "membershipOperator": "AND",
+    "therapies": [
+      {
+        "id": 99,
+        "conceptType": "Drug",
+        "name": "Abemaciclib",
+        "primaryCode": "ncit:C97660",
+        "mappings": [
+          {
+            "coding": {
+              "id": "ncit:C97660",
+              "code": "C97660",
+              "name": "Abemaciclib",
+              "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+              "systemVersion": "25.01d"
+            },
+            "relation": "exactMatch"
+          }
+        ],
+        "extensions": [
+          {
+            "name": "therapy_strategy",
+            "value": [
+              "CDK4/6 inhibition"
+            ],
+            "description": "Associated therapeutic strategy or mechanism of action of the therapy."
+          },
+          {
+            "name": "therapy_type",
+            "value": "Targeted therapy",
+            "description": "Type of cancer treatment from cancer.gov: https://www.cancer.gov/about-cancer/treatment/types"
+          }
+        ]
+      },
+      {
+        "id": 119,
+        "conceptType": "Drug",
+        "name": "Tamoxifen",
+        "primaryCode": "ncit:C62078",
+        "mappings": [
+          {
+            "coding": {
+              "id": "ncit:C62078",
+              "code": "C62078",
+              "name": "Tamoxifen",
+              "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
+              "systemVersion": "25.01d"
+            },
+            "relation": "exactMatch"
+          }
+        ],
+        "extensions": [
+          {
+            "name": "therapy_strategy",
+            "value": [
+              "Estrogen receptor inhibition"
+            ],
+            "description": "Associated therapeutic strategy or mechanism of action of the therapy."
+          },
+          {
+            "name": "therapy_type",
+            "value": "Hormone therapy",
+            "description": "Type of cancer treatment from cancer.gov: https://www.cancer.gov/about-cancer/treatment/types"
+          }
+        ]
+      }
+    ]
+  }
+  ...
+]
+```
 [Return to Table of Contents](#table-of-contents)

--- a/docs/referenced-schema-draft-about.md
+++ b/docs/referenced-schema-draft-about.md
@@ -413,14 +413,14 @@ Each record is a dictionary with the following fields:
 - `name` (str): a human readable label for the proposition, not currently used.
 - `biomarkers` (list[int]): a list where each element is an `id` referenced within [biomarkers](#biomarkersjson). 
 - `conditionQualifier_id` (int): the `id` referenced within [diseases](diseasesjson). 
-- `therapies`: (list[int]): a list where each element is an `id` referenced within [therapies](#therapiesjson). 
+- `objectTherapeutic`: (list[int]): a list where each element is an `id` referenced within [therapies](#therapiesjson). 
 
 Biomarkers and therapies are intended to be represented using the fields `objectTherapeutic` and `subjectVariant`, respectively, but at the moment they are both listed in arrays with implied AND logic. For biomarkers, cat-vrs is currently exploring [how to model groups of variants](https://github.com/ga4gh/cat-vrs/issues/92). For therapies, va-spec recommends modeling groups of more than one therapy as a [therapy group](https://va-ga4gh.readthedocs.io/en/1.0.0-ballot.2024-11/core-information-model/entities/domain-entities/therapeutics/therapy-group.html), and [dereference.py](../utils/dereference.py) needs to be updated to reflect this change.
 
 When dereferenced, several fields will update:
 - `biomarkers` will still be called `biomarkers`, but each member will be replaced with the relevant record from [biomarkers](#biomarkersjson).
 - `conditionQualifier_id` will be replaced with `conditionQualifier` and it will contain the relevant record from [diseases](#diseasesjson).
-- `thearpies` will still be called `thearpies`, but each member will be replaced with the relevant record from [therapies](#therapiesjson).
+- `objectTherapeutic` will still be called `objectTherapeutic` and its value will depend on the length of the list elements. If length 1, the element will be replaced with the relevant record from [therapies](#therapiesjson). If more than one element is present, the object will be modeled as a [Therapy Group](https://va-ga4gh.readthedocs.io/en/latest/core-information-model/entities/domain-entities/therapeutics/therapy-group.html), using `AND` as a `membershipOperator`. 
 
 ```
 [  
@@ -433,11 +433,10 @@ When dereferenced, several fields will update:
       2  
     ],  
     "conditionQualifier_id": 9,  
-    "therapies": [  
+    "objectTherapeutic": [  
       99,  
       119  
     ],  
-    "objectTherapeutic": "",  
     "subjectVariant": ""  
   },
   ...

--- a/docs/referenced-schema-draft-about.md
+++ b/docs/referenced-schema-draft-about.md
@@ -1,5 +1,5 @@
 # Molecular Oncology Almanac db 2.0.0 (draft)
-We are in the process of refactoring and updating moalmanac db to align with [GA4GH's Variant Annotation Specification (va-spec)](https://github.com/ga4gh/va-spec) and [Categorical Variant Representation Specification (Cat-VRS)](https://github.com/ga4gh/cat-vrs). Both of these specifications are in development and are following the [GA4GH Genomic Knowledge Standards (gks) Maturity Model](https://cat-vrs.readthedocs.io/en/latest/appendices/maturity_model.html). As components of each specification moves from draft to trial and to normative maturity we will update our schema to align with their recommendations. At the moment, this version of our data schema does _not_ comply with either format. 
+We are in the process of refactoring and updating moalmanac db to align with [GA4GH's Variant Annotation Specification (va-spec)](https://github.com/ga4gh/va-spec) and [Categorical Variant Representation Specification (Cat-VRS)](https://github.com/ga4gh/cat-vrs). Both of these specifications are in development and are following the [GA4GH Genomic Knowledge Standards (GKS) Maturity Model](https://cat-vrs.readthedocs.io/en/latest/appendices/maturity_model.html). As components of each specification moves from draft to trial and to normative maturity we will update our schema to align with their recommendations. At the moment, this version of our data schema does _not_ comply with either format. 
 
 ![in progress relationships between referenced files](assets/moalmanac-db-schema-diagram.svg)
 
@@ -22,6 +22,7 @@ Here, we'll start preliminary documentation of our interpretation of both of the
   - [statements.json](#statementsjson)
   - [strengths.json](#strengthsjson)
   - [therapies.json](#therapiesjson)
+  - [therapy_groups.json](#therapy_groupsjson)
 # Why are we making these changes?
 Most importantly, we are making this change because our current schema is something that we "just made up" throughout our original development. There is now an increasing emphasis within the field on interoperability and data standards, and we want moalmanac to both communicate with other services as well as possible while providing the most value to our users. Representing our database content within a widely used specification will increase the utility of our service.
 
@@ -35,7 +36,7 @@ VA-Spec supports a wide array of [proposition types](https://va-ga4gh.readthedoc
 
 **Extensions** are a way to capture information that are not directly supported by their data model. They will always have the fields `name`, `value`, and `description`. For example, our model for [diseases](#diseasesjson) has an extension that specifies if the cancer type is categorized as a solid tumor or not. 
 ```
-extensions [
+"extensions": [
   {
     "name": "solid_tumor",
 	"value": true,
@@ -165,7 +166,7 @@ When dereferenced, the field `agent_id` will be replaced with `agent` and it wil
 ```
 [Return to Table of Contents](#table-of-contents)
 ## [diseases.json](../referenced/diseases.json)
-Diseases and cancer types are categorized within va-spec under [Condition](https://va-ga4gh.readthedocs.io/en/1.0.0-ballot.2024-11/core-information-model/entities/domain-entities/conditions/index.html) and is represented as a [mappable concept](https://github.com/ga4gh/va-spec/blob/1.0.0-ballot.2024-11/schema/va-spec/base/json/Condition). We currently have mappings to [OncoTree](https://oncotree.mskcc.org/?version=oncotree_latest_stable&field=NAME)  with plans to expand to [NCI Enterprise Vocabulary Services](https://evsexplore.semantics.cancer.gov/evsexplore/). Extensions for diseases are a boolean to state if the cancer type is a solid tumor or not.
+[Diseases and cancer types](https://va-ga4gh.readthedocs.io/en/1.0.0-ballot.2024-11/core-information-model/entities/domain-entities/conditions/disease.html) are categorized within va-spec under [Condition](https://va-ga4gh.readthedocs.io/en/1.0.0-ballot.2024-11/core-information-model/entities/domain-entities/conditions/index.html) and is represented as a [mappable concept](https://github.com/ga4gh/va-spec/blob/1.0.0-ballot.2024-11/schema/va-spec/base/json/Condition). We currently have mappings to [OncoTree](https://oncotree.mskcc.org/?version=oncotree_latest_stable&field=NAME)  with plans to expand to [NCI Enterprise Vocabulary Services](https://evsexplore.semantics.cancer.gov/evsexplore/). Extensions for diseases are a boolean to state if the cancer type is a solid tumor or not.
 
 Each record is a dictionary with the fields:
 - `id` (int): an integer id for the record.
@@ -213,7 +214,7 @@ Each record within `mappings` will contain a `coding` and `relation`. The `codin
 ```
 [Return to Table of Contents](#table-of-contents)
 ## [documents.json](../referenced/documents.json)
-Published documents that we derive relationships from are contained within this referenced data type. [Document is a core Information Entity within va-spec](https://va-ga4gh.readthedocs.io/en/1.0.0-ballot.2024-11/core-information-model/entities/information-entities/document.html). This data type currently has several fields that should be converted to extensions. Each record is a dictionary with the fields: 
+[Documents](https://va-ga4gh.readthedocs.io/en/1.0.0-ballot.2024-11/core-information-model/entities/information-entities/document.html) are published documents that we derive database content from. This data type currently has several fields that should be converted to extensions. Each record is a dictionary with the fields: 
 - `id` (int): an integer id for the record.
 - `type` (str): must be "Document".
 - `subtype` (str): a specific type of document. At the moment, moalmanac-db only uses subtype of `Regulatory approval` or `Publication`. 
@@ -229,9 +230,7 @@ Published documents that we derive relationships from are contained within this 
 - `publication_date` (str): the date that this version of the document was published, in [ISO 8601, Y-m-d, format](https://en.wikipedia.org/wiki/ISO_8601). 
 - `url` (str): the url to access this version of the document.
 - `url_drug` (str): the url for the document's referenced drug through [Drugs@FDA](https://www.accessdata.fda.gov/scripts/cder/daf/index.cfm). 
-- `application_number` (int): the application number for the document's referenced drug through [Drugs@FDA](https://www.accessdata.fda.gov/scripts/cder/daf/index.cfm). 
-
-date of when the database was last updated, in [ISO 8601, Y-m-d, format](https://en.wikipedia.org/wiki/ISO_8601). 
+- `application_number` (int): the application number for the document's referenced drug through [Drugs@FDA](https://www.accessdata.fda.gov/scripts/cder/daf/index.cfm).
 
 For documents of the subtype `Regulatory approval`, `name` is specified as:
 ```
@@ -616,7 +615,7 @@ An example record from [propositions.json](../referenced/propositions.json), aft
 ```
 [Return to Table of Contents](#table-of-contents)
 ## [statements.json](../referenced/statementsjson)
-[Statements](https://va-ga4gh.readthedocs.io/en/1.0.0-ballot.2024-11/core-information-model/entities/information-entities/statement.html) are a core Information Entity within va-spec. Each statement contains one [proposition](#propositionsjson) and provides additional information around the proposition; such as a citation for it, direction of the proposition (supports or disputes), and the evidence associated with the proposition. 
+[Statements](https://va-ga4gh.readthedocs.io/en/1.0.0-ballot.2024-11/core-information-model/entities/information-entities/statement.html) are a core Information Entity within va-spec. Each statement contains one [proposition](#propositionsjson) and provides additional information around the proposition such as a citation for it, direction of the proposition (supports or disputes), and the evidence associated with the proposition. 
 
 Each record is a dictionary with the following fields:
 - `id` (int): an integer id for the record.

--- a/referenced/about.json
+++ b/referenced/about.json
@@ -4,5 +4,5 @@
   "license": "GPL-2.0",
   "release": "draft",
   "url": "https://moalmanac.org",
-  "last_updated": "2025-02-27"
+  "last_updated": "2025-04-03"
 }

--- a/referenced/organizations.json
+++ b/referenced/organizations.json
@@ -4,6 +4,6 @@
     "name": "Food and Drug Administration",
     "description": "Regulatory agency that approves drugs for use in the United States.",
     "url": "https://www.accessdata.fda.gov/scripts/cder/daf/index.cfm",
-    "last_updated": "2025-01-10"
+    "last_updated": "2025-04-03"
   }
 ]

--- a/referenced/propositions.json
+++ b/referenced/propositions.json
@@ -8,11 +8,9 @@
       2
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      99,
-      119
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 0
   },
   {
     "id": 1,
@@ -23,11 +21,9 @@
       3
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      99,
-      119
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 0
   },
   {
     "id": 2,
@@ -39,11 +35,9 @@
       3
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      99,
-      119
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 0
   },
   {
     "id": 3,
@@ -54,11 +48,9 @@
       2
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      36,
-      99
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 1
   },
   {
     "id": 4,
@@ -69,11 +61,9 @@
       3
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      36,
-      99
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 1
   },
   {
     "id": 5,
@@ -85,11 +75,9 @@
       3
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      36,
-      99
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 1
   },
   {
     "id": 6,
@@ -100,11 +88,9 @@
       2
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      40,
-      99
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 2
   },
   {
     "id": 7,
@@ -115,11 +101,9 @@
       3
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      40,
-      99
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 2
   },
   {
     "id": 8,
@@ -131,11 +115,9 @@
       3
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      40,
-      99
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 2
   },
   {
     "id": 9,
@@ -146,11 +128,9 @@
       2
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      30,
-      99
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 3
   },
   {
     "id": 10,
@@ -161,11 +141,9 @@
       3
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      30,
-      99
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 3
   },
   {
     "id": 11,
@@ -177,11 +155,9 @@
       3
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      30,
-      99
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 3
   },
   {
     "id": 12,
@@ -192,10 +168,9 @@
       2
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      99
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 99,
+    "therapy_group_id": null
   },
   {
     "id": 13,
@@ -206,10 +181,9 @@
       3
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      99
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 99,
+    "therapy_group_id": null
   },
   {
     "id": 14,
@@ -221,10 +195,9 @@
       3
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      99
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 99,
+    "therapy_group_id": null
   },
   {
     "id": 15,
@@ -234,12 +207,9 @@
       4
     ],
     "conditionQualifier_id": 55,
-    "objectTherapeutic": [
-      7,
-      6,
-      122
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 4
   },
   {
     "id": 16,
@@ -249,12 +219,9 @@
       5
     ],
     "conditionQualifier_id": 55,
-    "objectTherapeutic": [
-      7,
-      6,
-      122
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 4
   },
   {
     "id": 17,
@@ -264,12 +231,9 @@
       6
     ],
     "conditionQualifier_id": 55,
-    "objectTherapeutic": [
-      7,
-      6,
-      122
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 4
   },
   {
     "id": 18,
@@ -279,12 +243,9 @@
       7
     ],
     "conditionQualifier_id": 55,
-    "objectTherapeutic": [
-      7,
-      6,
-      122
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 4
   },
   {
     "id": 19,
@@ -294,10 +255,9 @@
       45
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      54
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 54,
+    "therapy_group_id": null
   },
   {
     "id": 20,
@@ -307,10 +267,9 @@
       20
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      52
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 52,
+    "therapy_group_id": null
   },
   {
     "id": 21,
@@ -320,10 +279,9 @@
       72
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      34
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 34,
+    "therapy_group_id": null
   },
   {
     "id": 22,
@@ -333,10 +291,9 @@
       8
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      9
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 9,
+    "therapy_group_id": null
   },
   {
     "id": 23,
@@ -348,11 +305,9 @@
       59
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      77,
-      30
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 5
   },
   {
     "id": 24,
@@ -364,11 +319,9 @@
       59
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      77,
-      30
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 5
   },
   {
     "id": 25,
@@ -381,11 +334,9 @@
       59
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      77,
-      30
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 5
   },
   {
     "id": 26,
@@ -395,12 +346,9 @@
       86
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      37,
-      49,
-      108
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 6
   },
   {
     "id": 27,
@@ -410,10 +358,9 @@
       86
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      108
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 108,
+    "therapy_group_id": null
   },
   {
     "id": 28,
@@ -423,10 +370,9 @@
       79
     ],
     "conditionQualifier_id": 10,
-    "objectTherapeutic": [
-      93
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 93,
+    "therapy_group_id": null
   },
   {
     "id": 29,
@@ -436,10 +382,9 @@
       12
     ],
     "conditionQualifier_id": 13,
-    "objectTherapeutic": [
-      83
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 83,
+    "therapy_group_id": null
   },
   {
     "id": 30,
@@ -450,10 +395,9 @@
       32
     ],
     "conditionQualifier_id": 13,
-    "objectTherapeutic": [
-      83
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 83,
+    "therapy_group_id": null
   },
   {
     "id": 31,
@@ -463,10 +407,9 @@
       33
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      89
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 89,
+    "therapy_group_id": null
   },
   {
     "id": 32,
@@ -476,10 +419,9 @@
       39
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      89
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 89,
+    "therapy_group_id": null
   },
   {
     "id": 33,
@@ -489,10 +431,9 @@
       73
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      89
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 89,
+    "therapy_group_id": null
   },
   {
     "id": 34,
@@ -503,13 +444,9 @@
       35
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      89,
-      11,
-      35,
-      37
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 7
   },
   {
     "id": 35,
@@ -520,12 +457,9 @@
       35
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      89,
-      35,
-      37
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 8
   },
   {
     "id": 36,
@@ -535,10 +469,9 @@
       72
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      89
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 89,
+    "therapy_group_id": null
   },
   {
     "id": 37,
@@ -548,10 +481,9 @@
       8
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      89
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 89,
+    "therapy_group_id": null
   },
   {
     "id": 38,
@@ -561,12 +493,9 @@
       16
     ],
     "conditionQualifier_id": 40,
-    "objectTherapeutic": [
-      89,
-      21,
-      22
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 9
   },
   {
     "id": 39,
@@ -576,12 +505,9 @@
       17
     ],
     "conditionQualifier_id": 40,
-    "objectTherapeutic": [
-      89,
-      21,
-      22
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 9
   },
   {
     "id": 40,
@@ -591,10 +517,9 @@
       11
     ],
     "conditionQualifier_id": 22,
-    "objectTherapeutic": [
-      13
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 13,
+    "therapy_group_id": null
   },
   {
     "id": 41,
@@ -604,11 +529,9 @@
       16
     ],
     "conditionQualifier_id": 40,
-    "objectTherapeutic": [
-      17,
-      18
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 10
   },
   {
     "id": 42,
@@ -618,11 +541,9 @@
       17
     ],
     "conditionQualifier_id": 40,
-    "objectTherapeutic": [
-      17,
-      18
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 10
   },
   {
     "id": 43,
@@ -632,11 +553,9 @@
       16
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      17,
-      18
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 10
   },
   {
     "id": 45,
@@ -646,10 +565,9 @@
       14
     ],
     "conditionQualifier_id": 0,
-    "objectTherapeutic": [
-      15
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 15,
+    "therapy_group_id": null
   },
   {
     "id": 46,
@@ -660,10 +578,9 @@
       15
     ],
     "conditionQualifier_id": 0,
-    "objectTherapeutic": [
-      15
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 15,
+    "therapy_group_id": null
   },
   {
     "id": 47,
@@ -673,10 +590,9 @@
       12
     ],
     "conditionQualifier_id": 13,
-    "objectTherapeutic": [
-      16
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 16,
+    "therapy_group_id": null
   },
   {
     "id": 48,
@@ -686,13 +602,9 @@
       0
     ],
     "conditionQualifier_id": 3,
-    "objectTherapeutic": [
-      0,
-      59,
-      2,
-      122
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 11
   },
   {
     "id": 49,
@@ -702,10 +614,9 @@
       0
     ],
     "conditionQualifier_id": 3,
-    "objectTherapeutic": [
-      0
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 0,
+    "therapy_group_id": null
   },
   {
     "id": 50,
@@ -715,10 +626,9 @@
       8
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      10
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 10,
+    "therapy_group_id": null
   },
   {
     "id": 51,
@@ -728,10 +638,9 @@
       20
     ],
     "conditionQualifier_id": 2,
-    "objectTherapeutic": [
-      38
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 38,
+    "therapy_group_id": null
   },
   {
     "id": 52,
@@ -743,11 +652,9 @@
       59
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      109,
-      30
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 12
   },
   {
     "id": 53,
@@ -759,11 +666,9 @@
       59
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      109,
-      30
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 12
   },
   {
     "id": 54,
@@ -776,11 +681,9 @@
       59
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      109,
-      30
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 12
   },
   {
     "id": 55,
@@ -792,11 +695,9 @@
       90
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      109,
-      30
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 12
   },
   {
     "id": 56,
@@ -808,11 +709,9 @@
       90
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      109,
-      30
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 12
   },
   {
     "id": 57,
@@ -825,11 +724,9 @@
       90
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      109,
-      30
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 12
   },
   {
     "id": 58,
@@ -841,11 +738,9 @@
       89
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      109,
-      30
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 12
   },
   {
     "id": 59,
@@ -857,11 +752,9 @@
       89
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      109,
-      30
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 12
   },
   {
     "id": 60,
@@ -874,11 +767,9 @@
       89
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      109,
-      30
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 12
   },
   {
     "id": 61,
@@ -890,11 +781,9 @@
       91
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      109,
-      30
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 12
   },
   {
     "id": 62,
@@ -906,11 +795,9 @@
       91
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      109,
-      30
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 12
   },
   {
     "id": 63,
@@ -923,11 +810,9 @@
       91
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      109,
-      30
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 12
   },
   {
     "id": 64,
@@ -939,11 +824,9 @@
       92
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      109,
-      30
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 12
   },
   {
     "id": 65,
@@ -955,11 +838,9 @@
       92
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      109,
-      30
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 12
   },
   {
     "id": 66,
@@ -972,11 +853,9 @@
       92
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      109,
-      30
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 12
   },
   {
     "id": 67,
@@ -988,11 +867,9 @@
       93
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      109,
-      30
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 12
   },
   {
     "id": 68,
@@ -1004,11 +881,9 @@
       93
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      109,
-      30
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 12
   },
   {
     "id": 69,
@@ -1021,11 +896,9 @@
       93
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      109,
-      30
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 12
   },
   {
     "id": 70,
@@ -1037,11 +910,9 @@
       94
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      109,
-      30
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 12
   },
   {
     "id": 71,
@@ -1053,11 +924,9 @@
       94
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      109,
-      30
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 12
   },
   {
     "id": 72,
@@ -1070,11 +939,9 @@
       94
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      109,
-      30
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 12
   },
   {
     "id": 73,
@@ -1084,10 +951,9 @@
       67
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      85
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 85,
+    "therapy_group_id": null
   },
   {
     "id": 74,
@@ -1097,10 +963,9 @@
       68
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      85
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 85,
+    "therapy_group_id": null
   },
   {
     "id": 75,
@@ -1112,12 +977,9 @@
       46
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      37,
-      55,
-      49
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 13
   },
   {
     "id": 76,
@@ -1130,10 +992,9 @@
       39
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      55
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 55,
+    "therapy_group_id": null
   },
   {
     "id": 77,
@@ -1143,10 +1004,9 @@
       8
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      106
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 106,
+    "therapy_group_id": null
   },
   {
     "id": 78,
@@ -1157,12 +1017,9 @@
       25
     ],
     "conditionQualifier_id": 15,
-    "objectTherapeutic": [
-      19,
-      27,
-      29
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 14
   },
   {
     "id": 79,
@@ -1173,11 +1030,9 @@
       25
     ],
     "conditionQualifier_id": 15,
-    "objectTherapeutic": [
-      19,
-      27
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 15
   },
   {
     "id": 80,
@@ -1188,10 +1043,9 @@
       25
     ],
     "conditionQualifier_id": 15,
-    "objectTherapeutic": [
-      19
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 19,
+    "therapy_group_id": null
   },
   {
     "id": 81,
@@ -1201,11 +1055,9 @@
       16
     ],
     "conditionQualifier_id": 15,
-    "objectTherapeutic": [
-      18,
-      19
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 16
   },
   {
     "id": 82,
@@ -1215,11 +1067,9 @@
       16
     ],
     "conditionQualifier_id": 40,
-    "objectTherapeutic": [
-      21,
-      22
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 17
   },
   {
     "id": 83,
@@ -1229,11 +1079,9 @@
       17
     ],
     "conditionQualifier_id": 40,
-    "objectTherapeutic": [
-      21,
-      22
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 17
   },
   {
     "id": 84,
@@ -1243,10 +1091,9 @@
       8
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      102
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 102,
+    "therapy_group_id": null
   },
   {
     "id": 85,
@@ -1256,10 +1103,9 @@
       62
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      102
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 102,
+    "therapy_group_id": null
   },
   {
     "id": 86,
@@ -1269,10 +1115,9 @@
       8
     ],
     "conditionQualifier_id": 3,
-    "objectTherapeutic": [
-      102
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 102,
+    "therapy_group_id": null
   },
   {
     "id": 87,
@@ -1282,10 +1127,9 @@
       8
     ],
     "conditionQualifier_id": 28,
-    "objectTherapeutic": [
-      102
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 102,
+    "therapy_group_id": null
   },
   {
     "id": 88,
@@ -1295,10 +1139,9 @@
       16
     ],
     "conditionQualifier_id": 40,
-    "objectTherapeutic": [
-      67
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 67,
+    "therapy_group_id": null
   },
   {
     "id": 89,
@@ -1308,11 +1151,9 @@
       16
     ],
     "conditionQualifier_id": 40,
-    "objectTherapeutic": [
-      67,
-      66
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 18
   },
   {
     "id": 90,
@@ -1322,11 +1163,9 @@
       17
     ],
     "conditionQualifier_id": 40,
-    "objectTherapeutic": [
-      67,
-      66
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 18
   },
   {
     "id": 91,
@@ -1336,11 +1175,9 @@
       16
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      67,
-      66
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 18
   },
   {
     "id": 92,
@@ -1350,11 +1187,9 @@
       16
     ],
     "conditionQualifier_id": 4,
-    "objectTherapeutic": [
-      67,
-      66
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 18
   },
   {
     "id": 93,
@@ -1364,11 +1199,9 @@
       16
     ],
     "conditionQualifier_id": 5,
-    "objectTherapeutic": [
-      67,
-      66
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 18
   },
   {
     "id": 94,
@@ -1378,11 +1211,9 @@
       16
     ],
     "conditionQualifier_id": 35,
-    "objectTherapeutic": [
-      67,
-      66
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 18
   },
   {
     "id": 95,
@@ -1392,10 +1223,9 @@
       10
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      101
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 101,
+    "therapy_group_id": null
   },
   {
     "id": 96,
@@ -1405,10 +1235,9 @@
       9
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      101
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 101,
+    "therapy_group_id": null
   },
   {
     "id": 97,
@@ -1418,10 +1247,9 @@
       12
     ],
     "conditionQualifier_id": 13,
-    "objectTherapeutic": [
-      84
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 84,
+    "therapy_group_id": null
   },
   {
     "id": 98,
@@ -1431,10 +1259,9 @@
       12
     ],
     "conditionQualifier_id": 71,
-    "objectTherapeutic": [
-      84
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 84,
+    "therapy_group_id": null
   },
   {
     "id": 99,
@@ -1444,10 +1271,9 @@
       12
     ],
     "conditionQualifier_id": 0,
-    "objectTherapeutic": [
-      84
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 84,
+    "therapy_group_id": null
   },
   {
     "id": 100,
@@ -1457,12 +1283,9 @@
       36
     ],
     "conditionQualifier_id": 18,
-    "objectTherapeutic": [
-      37,
-      47,
-      35
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 19
   },
   {
     "id": 101,
@@ -1472,12 +1295,9 @@
       38
     ],
     "conditionQualifier_id": 18,
-    "objectTherapeutic": [
-      37,
-      47,
-      35
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 19
   },
   {
     "id": 102,
@@ -1487,10 +1307,9 @@
       36
     ],
     "conditionQualifier_id": 18,
-    "objectTherapeutic": [
-      47
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 47,
+    "therapy_group_id": null
   },
   {
     "id": 103,
@@ -1500,10 +1319,9 @@
       36
     ],
     "conditionQualifier_id": 5,
-    "objectTherapeutic": [
-      47
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 47,
+    "therapy_group_id": null
   },
   {
     "id": 104,
@@ -1514,13 +1332,9 @@
       35
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      44,
-      45,
-      49,
-      37
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 20
   },
   {
     "id": 105,
@@ -1531,13 +1345,9 @@
       35
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      44,
-      45,
-      49,
-      39
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 21
   },
   {
     "id": 106,
@@ -1548,13 +1358,9 @@
       35
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      44,
-      45,
-      50,
-      37
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 22
   },
   {
     "id": 107,
@@ -1565,13 +1371,9 @@
       35
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      44,
-      45,
-      50,
-      39
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 23
   },
   {
     "id": 108,
@@ -1582,13 +1384,9 @@
       35
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      44,
-      45,
-      51,
-      37
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 24
   },
   {
     "id": 109,
@@ -1598,12 +1396,9 @@
       36
     ],
     "conditionQualifier_id": 18,
-    "objectTherapeutic": [
-      37,
-      44,
-      35
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 25
   },
   {
     "id": 110,
@@ -1615,10 +1410,9 @@
       58
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      74
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 74,
+    "therapy_group_id": null
   },
   {
     "id": 111,
@@ -1628,10 +1422,9 @@
       107
     ],
     "conditionQualifier_id": 1,
-    "objectTherapeutic": [
-      126
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 126,
+    "therapy_group_id": null
   },
   {
     "id": 112,
@@ -1641,10 +1434,9 @@
       108
     ],
     "conditionQualifier_id": 1,
-    "objectTherapeutic": [
-      126
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 126,
+    "therapy_group_id": null
   },
   {
     "id": 113,
@@ -1654,10 +1446,9 @@
       109
     ],
     "conditionQualifier_id": 1,
-    "objectTherapeutic": [
-      126
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 126,
+    "therapy_group_id": null
   },
   {
     "id": 114,
@@ -1667,10 +1458,9 @@
       110
     ],
     "conditionQualifier_id": 1,
-    "objectTherapeutic": [
-      126
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 126,
+    "therapy_group_id": null
   },
   {
     "id": 115,
@@ -1680,10 +1470,9 @@
       111
     ],
     "conditionQualifier_id": 1,
-    "objectTherapeutic": [
-      126
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 126,
+    "therapy_group_id": null
   },
   {
     "id": 116,
@@ -1693,10 +1482,9 @@
       112
     ],
     "conditionQualifier_id": 1,
-    "objectTherapeutic": [
-      126
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 126,
+    "therapy_group_id": null
   },
   {
     "id": 117,
@@ -1706,10 +1494,9 @@
       113
     ],
     "conditionQualifier_id": 1,
-    "objectTherapeutic": [
-      126
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 126,
+    "therapy_group_id": null
   },
   {
     "id": 118,
@@ -1719,10 +1506,9 @@
       114
     ],
     "conditionQualifier_id": 1,
-    "objectTherapeutic": [
-      126
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 126,
+    "therapy_group_id": null
   },
   {
     "id": 119,
@@ -1732,10 +1518,9 @@
       115
     ],
     "conditionQualifier_id": 1,
-    "objectTherapeutic": [
-      126
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 126,
+    "therapy_group_id": null
   },
   {
     "id": 120,
@@ -1745,10 +1530,9 @@
       62
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      80
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 80,
+    "therapy_group_id": null
   },
   {
     "id": 121,
@@ -1758,10 +1542,9 @@
       63
     ],
     "conditionQualifier_id": 5,
-    "objectTherapeutic": [
-      80
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 80,
+    "therapy_group_id": null
   },
   {
     "id": 122,
@@ -1771,10 +1554,9 @@
       64
     ],
     "conditionQualifier_id": 5,
-    "objectTherapeutic": [
-      80
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 80,
+    "therapy_group_id": null
   },
   {
     "id": 123,
@@ -1784,10 +1566,9 @@
       65
     ],
     "conditionQualifier_id": 5,
-    "objectTherapeutic": [
-      80
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 80,
+    "therapy_group_id": null
   },
   {
     "id": 124,
@@ -1797,10 +1578,9 @@
       99
     ],
     "conditionQualifier_id": 8,
-    "objectTherapeutic": [
-      110
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 110,
+    "therapy_group_id": null
   },
   {
     "id": 125,
@@ -1810,10 +1590,9 @@
       100
     ],
     "conditionQualifier_id": 8,
-    "objectTherapeutic": [
-      110
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 110,
+    "therapy_group_id": null
   },
   {
     "id": 126,
@@ -1823,10 +1602,9 @@
       101
     ],
     "conditionQualifier_id": 8,
-    "objectTherapeutic": [
-      110
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 110,
+    "therapy_group_id": null
   },
   {
     "id": 127,
@@ -1836,10 +1614,9 @@
       102
     ],
     "conditionQualifier_id": 8,
-    "objectTherapeutic": [
-      110
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 110,
+    "therapy_group_id": null
   },
   {
     "id": 128,
@@ -1849,10 +1626,9 @@
       97
     ],
     "conditionQualifier_id": 8,
-    "objectTherapeutic": [
-      110
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 110,
+    "therapy_group_id": null
   },
   {
     "id": 129,
@@ -1862,10 +1638,9 @@
       10
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      12
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 12,
+    "therapy_group_id": null
   },
   {
     "id": 130,
@@ -1875,10 +1650,9 @@
       9
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      12
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 12,
+    "therapy_group_id": null
   },
   {
     "id": 131,
@@ -1889,11 +1663,9 @@
       2
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      4,
-      5
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 26
   },
   {
     "id": 132,
@@ -1904,11 +1676,9 @@
       3
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      4,
-      5
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 26
   },
   {
     "id": 133,
@@ -1920,11 +1690,9 @@
       3
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      4,
-      5
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 26
   },
   {
     "id": 134,
@@ -1935,10 +1703,9 @@
       2
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      30
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 30,
+    "therapy_group_id": null
   },
   {
     "id": 135,
@@ -1949,10 +1716,9 @@
       3
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      30
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 30,
+    "therapy_group_id": null
   },
   {
     "id": 136,
@@ -1964,10 +1730,9 @@
       3
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      30
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 30,
+    "therapy_group_id": null
   },
   {
     "id": 137,
@@ -1977,10 +1742,9 @@
       1
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      30
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 30,
+    "therapy_group_id": null
   },
   {
     "id": 138,
@@ -1990,10 +1754,9 @@
       3
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      30
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 30,
+    "therapy_group_id": null
   },
   {
     "id": 139,
@@ -2004,10 +1767,9 @@
       3
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      30
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 30,
+    "therapy_group_id": null
   },
   {
     "id": 140,
@@ -2018,11 +1780,9 @@
       2
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      30,
-      53
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 27
   },
   {
     "id": 141,
@@ -2033,11 +1793,9 @@
       3
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      30,
-      53
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 27
   },
   {
     "id": 142,
@@ -2049,11 +1807,9 @@
       3
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      30,
-      53
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 27
   },
   {
     "id": 143,
@@ -2064,11 +1820,9 @@
       2
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      30,
-      31
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 28
   },
   {
     "id": 144,
@@ -2079,11 +1833,9 @@
       3
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      30,
-      31
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 28
   },
   {
     "id": 145,
@@ -2095,11 +1847,9 @@
       3
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      30,
-      31
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 28
   },
   {
     "id": 146,
@@ -2109,10 +1859,9 @@
       52
     ],
     "conditionQualifier_id": 29,
-    "objectTherapeutic": [
-      58
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 58,
+    "therapy_group_id": null
   },
   {
     "id": 147,
@@ -2122,10 +1871,9 @@
       10
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      33
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 33,
+    "therapy_group_id": null
   },
   {
     "id": 148,
@@ -2135,10 +1883,9 @@
       9
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      33
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 33,
+    "therapy_group_id": null
   },
   {
     "id": 149,
@@ -2148,10 +1895,9 @@
       55
     ],
     "conditionQualifier_id": 0,
-    "objectTherapeutic": [
-      69
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 69,
+    "therapy_group_id": null
   },
   {
     "id": 150,
@@ -2161,10 +1907,9 @@
       66
     ],
     "conditionQualifier_id": 0,
-    "objectTherapeutic": [
-      104
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 104,
+    "therapy_group_id": null
   },
   {
     "id": 151,
@@ -2174,10 +1919,9 @@
       85
     ],
     "conditionQualifier_id": 0,
-    "objectTherapeutic": [
-      104
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 104,
+    "therapy_group_id": null
   },
   {
     "id": 152,
@@ -2187,10 +1931,9 @@
       116
     ],
     "conditionQualifier_id": 0,
-    "objectTherapeutic": [
-      104
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 104,
+    "therapy_group_id": null
   },
   {
     "id": 153,
@@ -2200,10 +1943,9 @@
       117
     ],
     "conditionQualifier_id": 0,
-    "objectTherapeutic": [
-      104
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 104,
+    "therapy_group_id": null
   },
   {
     "id": 154,
@@ -2213,10 +1955,9 @@
       118
     ],
     "conditionQualifier_id": 0,
-    "objectTherapeutic": [
-      104
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 104,
+    "therapy_group_id": null
   },
   {
     "id": 155,
@@ -2226,10 +1967,9 @@
       119
     ],
     "conditionQualifier_id": 0,
-    "objectTherapeutic": [
-      104
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 104,
+    "therapy_group_id": null
   },
   {
     "id": 156,
@@ -2239,10 +1979,9 @@
       120
     ],
     "conditionQualifier_id": 0,
-    "objectTherapeutic": [
-      104
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 104,
+    "therapy_group_id": null
   },
   {
     "id": 157,
@@ -2252,10 +1991,9 @@
       121
     ],
     "conditionQualifier_id": 0,
-    "objectTherapeutic": [
-      104
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 104,
+    "therapy_group_id": null
   },
   {
     "id": 158,
@@ -2265,10 +2003,9 @@
       12
     ],
     "conditionQualifier_id": 13,
-    "objectTherapeutic": [
-      41
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 41,
+    "therapy_group_id": null
   },
   {
     "id": 159,
@@ -2278,10 +2015,9 @@
       12
     ],
     "conditionQualifier_id": 71,
-    "objectTherapeutic": [
-      41
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 41,
+    "therapy_group_id": null
   },
   {
     "id": 160,
@@ -2291,10 +2027,9 @@
       12
     ],
     "conditionQualifier_id": 0,
-    "objectTherapeutic": [
-      41
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 41,
+    "therapy_group_id": null
   },
   {
     "id": 161,
@@ -2304,10 +2039,9 @@
       28
     ],
     "conditionQualifier_id": 43,
-    "objectTherapeutic": [
-      41
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 41,
+    "therapy_group_id": null
   },
   {
     "id": 162,
@@ -2317,10 +2051,9 @@
       29
     ],
     "conditionQualifier_id": 43,
-    "objectTherapeutic": [
-      41
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 41,
+    "therapy_group_id": null
   },
   {
     "id": 163,
@@ -2330,10 +2063,9 @@
       122
     ],
     "conditionQualifier_id": 42,
-    "objectTherapeutic": [
-      41
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 41,
+    "therapy_group_id": null
   },
   {
     "id": 164,
@@ -2343,10 +2075,9 @@
       30
     ],
     "conditionQualifier_id": 12,
-    "objectTherapeutic": [
-      41
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 41,
+    "therapy_group_id": null
   },
   {
     "id": 165,
@@ -2356,10 +2087,9 @@
       31
     ],
     "conditionQualifier_id": 22,
-    "objectTherapeutic": [
-      41
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 41,
+    "therapy_group_id": null
   },
   {
     "id": 166,
@@ -2369,10 +2099,9 @@
       30
     ],
     "conditionQualifier_id": 22,
-    "objectTherapeutic": [
-      41
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 41,
+    "therapy_group_id": null
   },
   {
     "id": 167,
@@ -2382,10 +2111,9 @@
       52
     ],
     "conditionQualifier_id": 11,
-    "objectTherapeutic": [
-      127
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 127,
+    "therapy_group_id": null
   },
   {
     "id": 168,
@@ -2395,10 +2123,9 @@
       13
     ],
     "conditionQualifier_id": 0,
-    "objectTherapeutic": [
-      14
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 14,
+    "therapy_group_id": null
   },
   {
     "id": 169,
@@ -2408,11 +2135,9 @@
       38
     ],
     "conditionQualifier_id": 15,
-    "objectTherapeutic": [
-      71,
-      72
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 29
   },
   {
     "id": 170,
@@ -2422,11 +2147,9 @@
       37
     ],
     "conditionQualifier_id": 15,
-    "objectTherapeutic": [
-      71,
-      72
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 29
   },
   {
     "id": 171,
@@ -2438,11 +2161,9 @@
       35
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      71,
-      72
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 29
   },
   {
     "id": 172,
@@ -2453,13 +2174,9 @@
       35
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      37,
-      71,
-      72,
-      49
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 30
   },
   {
     "id": 173,
@@ -2470,13 +2187,9 @@
       35
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      39,
-      71,
-      72,
-      49
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 31
   },
   {
     "id": 174,
@@ -2487,13 +2200,9 @@
       35
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      37,
-      71,
-      72,
-      35
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 32
   },
   {
     "id": 175,
@@ -2503,10 +2212,9 @@
       74
     ],
     "conditionQualifier_id": 1,
-    "objectTherapeutic": [
-      92
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 92,
+    "therapy_group_id": null
   },
   {
     "id": 176,
@@ -2516,10 +2224,9 @@
       75
     ],
     "conditionQualifier_id": 1,
-    "objectTherapeutic": [
-      92
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 92,
+    "therapy_group_id": null
   },
   {
     "id": 177,
@@ -2529,10 +2236,9 @@
       76
     ],
     "conditionQualifier_id": 1,
-    "objectTherapeutic": [
-      92
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 92,
+    "therapy_group_id": null
   },
   {
     "id": 178,
@@ -2542,10 +2248,9 @@
       77
     ],
     "conditionQualifier_id": 1,
-    "objectTherapeutic": [
-      92
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 92,
+    "therapy_group_id": null
   },
   {
     "id": 179,
@@ -2555,10 +2260,9 @@
       78
     ],
     "conditionQualifier_id": 1,
-    "objectTherapeutic": [
-      92
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 92,
+    "therapy_group_id": null
   },
   {
     "id": 180,
@@ -2568,11 +2272,9 @@
       74
     ],
     "conditionQualifier_id": 1,
-    "objectTherapeutic": [
-      91,
-      92
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 33
   },
   {
     "id": 181,
@@ -2582,11 +2284,9 @@
       75
     ],
     "conditionQualifier_id": 1,
-    "objectTherapeutic": [
-      91,
-      92
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 33
   },
   {
     "id": 182,
@@ -2596,11 +2296,9 @@
       76
     ],
     "conditionQualifier_id": 1,
-    "objectTherapeutic": [
-      91,
-      92
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 33
   },
   {
     "id": 183,
@@ -2610,11 +2308,9 @@
       77
     ],
     "conditionQualifier_id": 1,
-    "objectTherapeutic": [
-      91,
-      92
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 33
   },
   {
     "id": 184,
@@ -2624,11 +2320,9 @@
       78
     ],
     "conditionQualifier_id": 1,
-    "objectTherapeutic": [
-      91,
-      92
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 33
   },
   {
     "id": 185,
@@ -2638,10 +2332,9 @@
       74
     ],
     "conditionQualifier_id": 43,
-    "objectTherapeutic": [
-      92
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 92,
+    "therapy_group_id": null
   },
   {
     "id": 186,
@@ -2651,10 +2344,9 @@
       75
     ],
     "conditionQualifier_id": 43,
-    "objectTherapeutic": [
-      92
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 92,
+    "therapy_group_id": null
   },
   {
     "id": 187,
@@ -2664,10 +2356,9 @@
       76
     ],
     "conditionQualifier_id": 43,
-    "objectTherapeutic": [
-      92
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 92,
+    "therapy_group_id": null
   },
   {
     "id": 188,
@@ -2677,10 +2368,9 @@
       77
     ],
     "conditionQualifier_id": 43,
-    "objectTherapeutic": [
-      92
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 92,
+    "therapy_group_id": null
   },
   {
     "id": 189,
@@ -2690,10 +2380,9 @@
       78
     ],
     "conditionQualifier_id": 43,
-    "objectTherapeutic": [
-      92
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 92,
+    "therapy_group_id": null
   },
   {
     "id": 190,
@@ -2703,10 +2392,9 @@
       74
     ],
     "conditionQualifier_id": 11,
-    "objectTherapeutic": [
-      92
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 92,
+    "therapy_group_id": null
   },
   {
     "id": 191,
@@ -2716,10 +2404,9 @@
       75
     ],
     "conditionQualifier_id": 11,
-    "objectTherapeutic": [
-      92
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 92,
+    "therapy_group_id": null
   },
   {
     "id": 192,
@@ -2729,10 +2416,9 @@
       76
     ],
     "conditionQualifier_id": 11,
-    "objectTherapeutic": [
-      92
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 92,
+    "therapy_group_id": null
   },
   {
     "id": 193,
@@ -2742,10 +2428,9 @@
       77
     ],
     "conditionQualifier_id": 11,
-    "objectTherapeutic": [
-      92
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 92,
+    "therapy_group_id": null
   },
   {
     "id": 194,
@@ -2755,10 +2440,9 @@
       78
     ],
     "conditionQualifier_id": 11,
-    "objectTherapeutic": [
-      92
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 92,
+    "therapy_group_id": null
   },
   {
     "id": 195,
@@ -2768,11 +2452,9 @@
       20
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      38,
-      96
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 34
   },
   {
     "id": 196,
@@ -2783,11 +2465,9 @@
       20
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      96,
-      40
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 35
   },
   {
     "id": 197,
@@ -2798,11 +2478,9 @@
       20
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      96,
-      40
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 35
   },
   {
     "id": 198,
@@ -2814,11 +2492,9 @@
       20
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      96,
-      40
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 35
   },
   {
     "id": 199,
@@ -2828,10 +2504,9 @@
       63
     ],
     "conditionQualifier_id": 5,
-    "objectTherapeutic": [
-      100
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 100,
+    "therapy_group_id": null
   },
   {
     "id": 200,
@@ -2841,10 +2516,9 @@
       64
     ],
     "conditionQualifier_id": 5,
-    "objectTherapeutic": [
-      100
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 100,
+    "therapy_group_id": null
   },
   {
     "id": 201,
@@ -2854,10 +2528,9 @@
       65
     ],
     "conditionQualifier_id": 5,
-    "objectTherapeutic": [
-      100
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 100,
+    "therapy_group_id": null
   },
   {
     "id": 202,
@@ -2867,10 +2540,9 @@
       61
     ],
     "conditionQualifier_id": 43,
-    "objectTherapeutic": [
-      79
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 79,
+    "therapy_group_id": null
   },
   {
     "id": 203,
@@ -2880,10 +2552,9 @@
       8
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      56
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 56,
+    "therapy_group_id": null
   },
   {
     "id": 204,
@@ -2893,11 +2564,9 @@
       20
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      38,
-      128
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 36
   },
   {
     "id": 205,
@@ -2907,11 +2576,9 @@
       20
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      129,
-      128
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 37
   },
   {
     "id": 206,
@@ -2921,11 +2588,9 @@
       20
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      50,
-      128
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 38
   },
   {
     "id": 207,
@@ -2935,11 +2600,9 @@
       20
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      128,
-      117
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 39
   },
   {
     "id": 208,
@@ -2949,12 +2612,9 @@
       66
     ],
     "conditionQualifier_id": 1,
-    "objectTherapeutic": [
-      63,
-      68,
-      82
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 40
   },
   {
     "id": 209,
@@ -2964,12 +2624,9 @@
       85
     ],
     "conditionQualifier_id": 1,
-    "objectTherapeutic": [
-      63,
-      68,
-      82
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 40
   },
   {
     "id": 210,
@@ -2979,12 +2636,9 @@
       116
     ],
     "conditionQualifier_id": 1,
-    "objectTherapeutic": [
-      63,
-      68,
-      82
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 40
   },
   {
     "id": 211,
@@ -2994,12 +2648,9 @@
       117
     ],
     "conditionQualifier_id": 1,
-    "objectTherapeutic": [
-      63,
-      68,
-      82
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 40
   },
   {
     "id": 212,
@@ -3009,12 +2660,9 @@
       118
     ],
     "conditionQualifier_id": 1,
-    "objectTherapeutic": [
-      63,
-      68,
-      82
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 40
   },
   {
     "id": 213,
@@ -3024,12 +2672,9 @@
       119
     ],
     "conditionQualifier_id": 1,
-    "objectTherapeutic": [
-      63,
-      68,
-      82
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 40
   },
   {
     "id": 214,
@@ -3039,12 +2684,9 @@
       120
     ],
     "conditionQualifier_id": 1,
-    "objectTherapeutic": [
-      63,
-      68,
-      82
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 40
   },
   {
     "id": 215,
@@ -3054,12 +2696,9 @@
       121
     ],
     "conditionQualifier_id": 1,
-    "objectTherapeutic": [
-      63,
-      68,
-      82
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 40
   },
   {
     "id": 216,
@@ -3069,12 +2708,9 @@
       123
     ],
     "conditionQualifier_id": 1,
-    "objectTherapeutic": [
-      63,
-      68,
-      82
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 40
   },
   {
     "id": 217,
@@ -3084,12 +2720,9 @@
       125
     ],
     "conditionQualifier_id": 1,
-    "objectTherapeutic": [
-      63,
-      68,
-      82
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 40
   },
   {
     "id": 218,
@@ -3099,10 +2732,9 @@
       86
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      130
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 130,
+    "therapy_group_id": null
   },
   {
     "id": 219,
@@ -3112,10 +2744,9 @@
       20
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      70
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 70,
+    "therapy_group_id": null
   },
   {
     "id": 220,
@@ -3125,11 +2756,9 @@
       20
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      38,
-      70
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 41
   },
   {
     "id": 221,
@@ -3139,10 +2768,9 @@
       12
     ],
     "conditionQualifier_id": 13,
-    "objectTherapeutic": [
-      88
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 88,
+    "therapy_group_id": null
   },
   {
     "id": 222,
@@ -3152,10 +2780,9 @@
       12
     ],
     "conditionQualifier_id": 71,
-    "objectTherapeutic": [
-      88
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 88,
+    "therapy_group_id": null
   },
   {
     "id": 223,
@@ -3165,10 +2792,9 @@
       48
     ],
     "conditionQualifier_id": 51,
-    "objectTherapeutic": [
-      6
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 6,
+    "therapy_group_id": null
   },
   {
     "id": 224,
@@ -3178,10 +2804,9 @@
       50
     ],
     "conditionQualifier_id": 51,
-    "objectTherapeutic": [
-      6
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 6,
+    "therapy_group_id": null
   },
   {
     "id": 225,
@@ -3191,10 +2816,9 @@
       48
     ],
     "conditionQualifier_id": 27,
-    "objectTherapeutic": [
-      6
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 6,
+    "therapy_group_id": null
   },
   {
     "id": 226,
@@ -3204,10 +2828,9 @@
       50
     ],
     "conditionQualifier_id": 27,
-    "objectTherapeutic": [
-      6
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 6,
+    "therapy_group_id": null
   },
   {
     "id": 227,
@@ -3217,10 +2840,9 @@
       48
     ],
     "conditionQualifier_id": 54,
-    "objectTherapeutic": [
-      6
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 6,
+    "therapy_group_id": null
   },
   {
     "id": 228,
@@ -3230,10 +2852,9 @@
       50
     ],
     "conditionQualifier_id": 54,
-    "objectTherapeutic": [
-      6
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 6,
+    "therapy_group_id": null
   },
   {
     "id": 229,
@@ -3244,12 +2865,9 @@
       35
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      37,
-      72,
-      35
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 42
   },
   {
     "id": 230,
@@ -3259,11 +2877,9 @@
       33
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      71,
-      72
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 29
   },
   {
     "id": 231,
@@ -3273,10 +2889,9 @@
       47
     ],
     "conditionQualifier_id": 51,
-    "objectTherapeutic": [
-      46
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 46,
+    "therapy_group_id": null
   },
   {
     "id": 232,
@@ -3286,10 +2901,9 @@
       48
     ],
     "conditionQualifier_id": 51,
-    "objectTherapeutic": [
-      46
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 46,
+    "therapy_group_id": null
   },
   {
     "id": 233,
@@ -3299,10 +2913,9 @@
       49
     ],
     "conditionQualifier_id": 51,
-    "objectTherapeutic": [
-      46
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 46,
+    "therapy_group_id": null
   },
   {
     "id": 234,
@@ -3312,10 +2925,9 @@
       50
     ],
     "conditionQualifier_id": 51,
-    "objectTherapeutic": [
-      46
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 46,
+    "therapy_group_id": null
   },
   {
     "id": 235,
@@ -3325,10 +2937,9 @@
       47
     ],
     "conditionQualifier_id": 27,
-    "objectTherapeutic": [
-      46
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 46,
+    "therapy_group_id": null
   },
   {
     "id": 236,
@@ -3338,10 +2949,9 @@
       48
     ],
     "conditionQualifier_id": 27,
-    "objectTherapeutic": [
-      46
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 46,
+    "therapy_group_id": null
   },
   {
     "id": 237,
@@ -3351,10 +2961,9 @@
       49
     ],
     "conditionQualifier_id": 27,
-    "objectTherapeutic": [
-      46
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 46,
+    "therapy_group_id": null
   },
   {
     "id": 238,
@@ -3364,10 +2973,9 @@
       50
     ],
     "conditionQualifier_id": 27,
-    "objectTherapeutic": [
-      46
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 46,
+    "therapy_group_id": null
   },
   {
     "id": 239,
@@ -3377,10 +2985,9 @@
       47
     ],
     "conditionQualifier_id": 54,
-    "objectTherapeutic": [
-      46
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 46,
+    "therapy_group_id": null
   },
   {
     "id": 240,
@@ -3390,10 +2997,9 @@
       48
     ],
     "conditionQualifier_id": 54,
-    "objectTherapeutic": [
-      46
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 46,
+    "therapy_group_id": null
   },
   {
     "id": 241,
@@ -3403,10 +3009,9 @@
       49
     ],
     "conditionQualifier_id": 54,
-    "objectTherapeutic": [
-      46
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 46,
+    "therapy_group_id": null
   },
   {
     "id": 242,
@@ -3416,10 +3021,9 @@
       50
     ],
     "conditionQualifier_id": 54,
-    "objectTherapeutic": [
-      46
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 46,
+    "therapy_group_id": null
   },
   {
     "id": 243,
@@ -3429,11 +3033,9 @@
       47
     ],
     "conditionQualifier_id": 51,
-    "objectTherapeutic": [
-      11,
-      46
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 43
   },
   {
     "id": 244,
@@ -3443,11 +3045,9 @@
       48
     ],
     "conditionQualifier_id": 51,
-    "objectTherapeutic": [
-      11,
-      46
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 43
   },
   {
     "id": 245,
@@ -3457,11 +3057,9 @@
       49
     ],
     "conditionQualifier_id": 51,
-    "objectTherapeutic": [
-      11,
-      46
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 43
   },
   {
     "id": 246,
@@ -3471,11 +3069,9 @@
       50
     ],
     "conditionQualifier_id": 51,
-    "objectTherapeutic": [
-      11,
-      46
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 43
   },
   {
     "id": 247,
@@ -3485,11 +3081,9 @@
       51
     ],
     "conditionQualifier_id": 51,
-    "objectTherapeutic": [
-      11,
-      46
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 43
   },
   {
     "id": 248,
@@ -3499,11 +3093,9 @@
       47
     ],
     "conditionQualifier_id": 27,
-    "objectTherapeutic": [
-      11,
-      46
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 43
   },
   {
     "id": 249,
@@ -3513,11 +3105,9 @@
       48
     ],
     "conditionQualifier_id": 27,
-    "objectTherapeutic": [
-      11,
-      46
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 43
   },
   {
     "id": 250,
@@ -3527,11 +3117,9 @@
       49
     ],
     "conditionQualifier_id": 27,
-    "objectTherapeutic": [
-      11,
-      46
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 43
   },
   {
     "id": 251,
@@ -3541,11 +3129,9 @@
       50
     ],
     "conditionQualifier_id": 27,
-    "objectTherapeutic": [
-      11,
-      46
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 43
   },
   {
     "id": 252,
@@ -3555,11 +3141,9 @@
       51
     ],
     "conditionQualifier_id": 27,
-    "objectTherapeutic": [
-      11,
-      46
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 43
   },
   {
     "id": 253,
@@ -3569,11 +3153,9 @@
       47
     ],
     "conditionQualifier_id": 54,
-    "objectTherapeutic": [
-      11,
-      46
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 43
   },
   {
     "id": 254,
@@ -3583,11 +3165,9 @@
       48
     ],
     "conditionQualifier_id": 54,
-    "objectTherapeutic": [
-      11,
-      46
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 43
   },
   {
     "id": 255,
@@ -3597,11 +3177,9 @@
       49
     ],
     "conditionQualifier_id": 54,
-    "objectTherapeutic": [
-      11,
-      46
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 43
   },
   {
     "id": 256,
@@ -3611,11 +3189,9 @@
       50
     ],
     "conditionQualifier_id": 54,
-    "objectTherapeutic": [
-      11,
-      46
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 43
   },
   {
     "id": 257,
@@ -3625,11 +3201,9 @@
       51
     ],
     "conditionQualifier_id": 54,
-    "objectTherapeutic": [
-      11,
-      46
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 43
   },
   {
     "id": 258,
@@ -3640,10 +3214,9 @@
       2
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      46
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 46,
+    "therapy_group_id": null
   },
   {
     "id": 259,
@@ -3654,10 +3227,9 @@
       2
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      46
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 46,
+    "therapy_group_id": null
   },
   {
     "id": 260,
@@ -3667,10 +3239,9 @@
       48
     ],
     "conditionQualifier_id": 52,
-    "objectTherapeutic": [
-      46
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 46,
+    "therapy_group_id": null
   },
   {
     "id": 261,
@@ -3680,10 +3251,9 @@
       50
     ],
     "conditionQualifier_id": 52,
-    "objectTherapeutic": [
-      46
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 46,
+    "therapy_group_id": null
   },
   {
     "id": 262,
@@ -3693,11 +3263,9 @@
       47
     ],
     "conditionQualifier_id": 55,
-    "objectTherapeutic": [
-      138,
-      87
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 44
   },
   {
     "id": 263,
@@ -3707,10 +3275,9 @@
       47
     ],
     "conditionQualifier_id": 55,
-    "objectTherapeutic": [
-      46
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 46,
+    "therapy_group_id": null
   },
   {
     "id": 264,
@@ -3720,10 +3287,9 @@
       48
     ],
     "conditionQualifier_id": 55,
-    "objectTherapeutic": [
-      46
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 46,
+    "therapy_group_id": null
   },
   {
     "id": 265,
@@ -3733,10 +3299,9 @@
       49
     ],
     "conditionQualifier_id": 55,
-    "objectTherapeutic": [
-      46
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 46,
+    "therapy_group_id": null
   },
   {
     "id": 266,
@@ -3746,10 +3311,9 @@
       50
     ],
     "conditionQualifier_id": 55,
-    "objectTherapeutic": [
-      46
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 46,
+    "therapy_group_id": null
   },
   {
     "id": 267,
@@ -3759,10 +3323,9 @@
       104
     ],
     "conditionQualifier_id": 55,
-    "objectTherapeutic": [
-      46
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 46,
+    "therapy_group_id": null
   },
   {
     "id": 268,
@@ -3772,10 +3335,9 @@
       105
     ],
     "conditionQualifier_id": 55,
-    "objectTherapeutic": [
-      46
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 46,
+    "therapy_group_id": null
   },
   {
     "id": 269,
@@ -3785,10 +3347,9 @@
       106
     ],
     "conditionQualifier_id": 55,
-    "objectTherapeutic": [
-      46
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 46,
+    "therapy_group_id": null
   },
   {
     "id": 270,
@@ -3798,10 +3359,9 @@
       4
     ],
     "conditionQualifier_id": 55,
-    "objectTherapeutic": [
-      46
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 46,
+    "therapy_group_id": null
   },
   {
     "id": 271,
@@ -3811,10 +3371,9 @@
       5
     ],
     "conditionQualifier_id": 55,
-    "objectTherapeutic": [
-      46
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 46,
+    "therapy_group_id": null
   },
   {
     "id": 272,
@@ -3824,10 +3383,9 @@
       6
     ],
     "conditionQualifier_id": 55,
-    "objectTherapeutic": [
-      46
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 46,
+    "therapy_group_id": null
   },
   {
     "id": 273,
@@ -3837,10 +3395,9 @@
       7
     ],
     "conditionQualifier_id": 55,
-    "objectTherapeutic": [
-      46
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 46,
+    "therapy_group_id": null
   },
   {
     "id": 274,
@@ -3850,10 +3407,9 @@
       125
     ],
     "conditionQualifier_id": 55,
-    "objectTherapeutic": [
-      46
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 46,
+    "therapy_group_id": null
   },
   {
     "id": 275,
@@ -3863,10 +3419,9 @@
       126
     ],
     "conditionQualifier_id": 55,
-    "objectTherapeutic": [
-      46
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 46,
+    "therapy_group_id": null
   },
   {
     "id": 276,
@@ -3876,10 +3431,9 @@
       127
     ],
     "conditionQualifier_id": 55,
-    "objectTherapeutic": [
-      46
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 46,
+    "therapy_group_id": null
   },
   {
     "id": 277,
@@ -3889,10 +3443,9 @@
       128
     ],
     "conditionQualifier_id": 55,
-    "objectTherapeutic": [
-      46
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 46,
+    "therapy_group_id": null
   },
   {
     "id": 278,
@@ -3902,10 +3455,9 @@
       129
     ],
     "conditionQualifier_id": 55,
-    "objectTherapeutic": [
-      46
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 46,
+    "therapy_group_id": null
   },
   {
     "id": 279,
@@ -3915,10 +3467,9 @@
       130
     ],
     "conditionQualifier_id": 55,
-    "objectTherapeutic": [
-      46
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 46,
+    "therapy_group_id": null
   },
   {
     "id": 280,
@@ -3928,10 +3479,9 @@
       131
     ],
     "conditionQualifier_id": 55,
-    "objectTherapeutic": [
-      46
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 46,
+    "therapy_group_id": null
   },
   {
     "id": 281,
@@ -3941,10 +3491,9 @@
       132
     ],
     "conditionQualifier_id": 55,
-    "objectTherapeutic": [
-      46
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 46,
+    "therapy_group_id": null
   },
   {
     "id": 282,
@@ -3954,10 +3503,9 @@
       133
     ],
     "conditionQualifier_id": 55,
-    "objectTherapeutic": [
-      46
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 46,
+    "therapy_group_id": null
   },
   {
     "id": 283,
@@ -3967,10 +3515,9 @@
       134
     ],
     "conditionQualifier_id": 55,
-    "objectTherapeutic": [
-      46
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 46,
+    "therapy_group_id": null
   },
   {
     "id": 284,
@@ -3980,10 +3527,9 @@
       135
     ],
     "conditionQualifier_id": 55,
-    "objectTherapeutic": [
-      87
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 87,
+    "therapy_group_id": null
   },
   {
     "id": 285,
@@ -3993,10 +3539,9 @@
       136
     ],
     "conditionQualifier_id": 55,
-    "objectTherapeutic": [
-      46
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 46,
+    "therapy_group_id": null
   },
   {
     "id": 286,
@@ -4006,10 +3551,9 @@
       137
     ],
     "conditionQualifier_id": 55,
-    "objectTherapeutic": [
-      46
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 46,
+    "therapy_group_id": null
   },
   {
     "id": 287,
@@ -4019,10 +3563,9 @@
       138
     ],
     "conditionQualifier_id": 55,
-    "objectTherapeutic": [
-      46
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 46,
+    "therapy_group_id": null
   },
   {
     "id": 288,
@@ -4032,10 +3575,9 @@
       139
     ],
     "conditionQualifier_id": 55,
-    "objectTherapeutic": [
-      46
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 46,
+    "therapy_group_id": null
   },
   {
     "id": 289,
@@ -4045,10 +3587,9 @@
       140
     ],
     "conditionQualifier_id": 55,
-    "objectTherapeutic": [
-      46
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 46,
+    "therapy_group_id": null
   },
   {
     "id": 290,
@@ -4058,10 +3599,9 @@
       141
     ],
     "conditionQualifier_id": 55,
-    "objectTherapeutic": [
-      46
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 46,
+    "therapy_group_id": null
   },
   {
     "id": 291,
@@ -4071,12 +3611,9 @@
       47
     ],
     "conditionQualifier_id": 55,
-    "objectTherapeutic": [
-      7,
-      46,
-      8
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 45
   },
   {
     "id": 292,
@@ -4086,12 +3623,9 @@
       48
     ],
     "conditionQualifier_id": 55,
-    "objectTherapeutic": [
-      7,
-      46,
-      8
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 45
   },
   {
     "id": 293,
@@ -4101,12 +3635,9 @@
       49
     ],
     "conditionQualifier_id": 55,
-    "objectTherapeutic": [
-      7,
-      46,
-      8
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 45
   },
   {
     "id": 294,
@@ -4116,12 +3647,9 @@
       50
     ],
     "conditionQualifier_id": 55,
-    "objectTherapeutic": [
-      7,
-      46,
-      8
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 45
   },
   {
     "id": 295,
@@ -4131,12 +3659,9 @@
       47
     ],
     "conditionQualifier_id": 55,
-    "objectTherapeutic": [
-      7,
-      46,
-      122
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 46
   },
   {
     "id": 296,
@@ -4146,12 +3671,9 @@
       48
     ],
     "conditionQualifier_id": 55,
-    "objectTherapeutic": [
-      7,
-      46,
-      122
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 46
   },
   {
     "id": 297,
@@ -4161,12 +3683,9 @@
       49
     ],
     "conditionQualifier_id": 55,
-    "objectTherapeutic": [
-      7,
-      46,
-      122
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 46
   },
   {
     "id": 298,
@@ -4176,12 +3695,9 @@
       50
     ],
     "conditionQualifier_id": 55,
-    "objectTherapeutic": [
-      7,
-      46,
-      122
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 46
   },
   {
     "id": 299,
@@ -4191,10 +3707,9 @@
       74
     ],
     "conditionQualifier_id": 1,
-    "objectTherapeutic": [
-      131
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 131,
+    "therapy_group_id": null
   },
   {
     "id": 300,
@@ -4204,10 +3719,9 @@
       75
     ],
     "conditionQualifier_id": 1,
-    "objectTherapeutic": [
-      131
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 131,
+    "therapy_group_id": null
   },
   {
     "id": 301,
@@ -4217,10 +3731,9 @@
       76
     ],
     "conditionQualifier_id": 1,
-    "objectTherapeutic": [
-      131
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 131,
+    "therapy_group_id": null
   },
   {
     "id": 302,
@@ -4230,10 +3743,9 @@
       77
     ],
     "conditionQualifier_id": 1,
-    "objectTherapeutic": [
-      131
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 131,
+    "therapy_group_id": null
   },
   {
     "id": 303,
@@ -4243,10 +3755,9 @@
       78
     ],
     "conditionQualifier_id": 1,
-    "objectTherapeutic": [
-      131
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 131,
+    "therapy_group_id": null
   },
   {
     "id": 304,
@@ -4256,10 +3767,9 @@
       10
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      86
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 86,
+    "therapy_group_id": null
   },
   {
     "id": 305,
@@ -4269,10 +3779,9 @@
       9
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      86
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 86,
+    "therapy_group_id": null
   },
   {
     "id": 306,
@@ -4282,12 +3791,9 @@
       9
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      39,
-      86,
-      49
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 47
   },
   {
     "id": 307,
@@ -4297,12 +3803,9 @@
       9
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      37,
-      86,
-      49
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 48
   },
   {
     "id": 308,
@@ -4312,12 +3815,9 @@
       10
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      37,
-      86,
-      49
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 48
   },
   {
     "id": 309,
@@ -4327,12 +3827,9 @@
       10
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      39,
-      86,
-      49
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 47
   },
   {
     "id": 310,
@@ -4342,10 +3839,9 @@
       70
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      86
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 86,
+    "therapy_group_id": null
   },
   {
     "id": 311,
@@ -4356,11 +3852,9 @@
       2
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      40,
-      31
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 49
   },
   {
     "id": 312,
@@ -4371,11 +3865,9 @@
       3
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      40,
-      31
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 49
   },
   {
     "id": 313,
@@ -4387,11 +3879,9 @@
       3
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      40,
-      31
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 49
   },
   {
     "id": 314,
@@ -4402,12 +3892,9 @@
       26
     ],
     "conditionQualifier_id": 15,
-    "objectTherapeutic": [
-      28,
-      97,
-      29
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 50
   },
   {
     "id": 315,
@@ -4418,10 +3905,9 @@
       26
     ],
     "conditionQualifier_id": 15,
-    "objectTherapeutic": [
-      97
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 97,
+    "therapy_group_id": null
   },
   {
     "id": 316,
@@ -4432,12 +3918,9 @@
       35
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      37,
-      48,
-      49
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 51
   },
   {
     "id": 317,
@@ -4448,12 +3931,9 @@
       35
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      39,
-      48,
-      49
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 52
   },
   {
     "id": 318,
@@ -4465,10 +3945,9 @@
       35
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      48
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 48,
+    "therapy_group_id": null
   },
   {
     "id": 319,
@@ -4478,10 +3957,9 @@
       33
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      48
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 48,
+    "therapy_group_id": null
   },
   {
     "id": 320,
@@ -4491,10 +3969,9 @@
       42
     ],
     "conditionQualifier_id": 25,
-    "objectTherapeutic": [
-      48
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 48,
+    "therapy_group_id": null
   },
   {
     "id": 321,
@@ -4504,10 +3981,9 @@
       36
     ],
     "conditionQualifier_id": 5,
-    "objectTherapeutic": [
-      48
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 48,
+    "therapy_group_id": null
   },
   {
     "id": 322,
@@ -4517,10 +3993,9 @@
       38
     ],
     "conditionQualifier_id": 5,
-    "objectTherapeutic": [
-      48
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 48,
+    "therapy_group_id": null
   },
   {
     "id": 323,
@@ -4530,10 +4005,9 @@
       36
     ],
     "conditionQualifier_id": 15,
-    "objectTherapeutic": [
-      48
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 48,
+    "therapy_group_id": null
   },
   {
     "id": 324,
@@ -4543,10 +4017,9 @@
       38
     ],
     "conditionQualifier_id": 15,
-    "objectTherapeutic": [
-      48
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 48,
+    "therapy_group_id": null
   },
   {
     "id": 325,
@@ -4557,13 +4030,9 @@
       42
     ],
     "conditionQualifier_id": 2,
-    "objectTherapeutic": [
-      39,
-      48,
-      25,
-      29
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 53
   },
   {
     "id": 326,
@@ -4574,13 +4043,9 @@
       42
     ],
     "conditionQualifier_id": 2,
-    "objectTherapeutic": [
-      38,
-      28,
-      48,
-      25
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 54
   },
   {
     "id": 327,
@@ -4590,12 +4055,9 @@
       2
     ],
     "conditionQualifier_id": 2,
-    "objectTherapeutic": [
-      39,
-      48,
-      29
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 55
   },
   {
     "id": 328,
@@ -4605,12 +4067,9 @@
       2
     ],
     "conditionQualifier_id": 2,
-    "objectTherapeutic": [
-      38,
-      28,
-      48
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 56
   },
   {
     "id": 329,
@@ -4620,10 +4079,9 @@
       41
     ],
     "conditionQualifier_id": 2,
-    "objectTherapeutic": [
-      48
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 48,
+    "therapy_group_id": null
   },
   {
     "id": 330,
@@ -4633,10 +4091,9 @@
       41
     ],
     "conditionQualifier_id": 74,
-    "objectTherapeutic": [
-      48
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 48,
+    "therapy_group_id": null
   },
   {
     "id": 331,
@@ -4646,12 +4103,9 @@
       42
     ],
     "conditionQualifier_id": 72,
-    "objectTherapeutic": [
-      39,
-      35,
-      48
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 57
   },
   {
     "id": 332,
@@ -4661,12 +4115,9 @@
       42
     ],
     "conditionQualifier_id": 73,
-    "objectTherapeutic": [
-      39,
-      35,
-      48
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 57
   },
   {
     "id": 333,
@@ -4676,13 +4127,9 @@
       42
     ],
     "conditionQualifier_id": 72,
-    "objectTherapeutic": [
-      11,
-      39,
-      35,
-      48
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 58
   },
   {
     "id": 334,
@@ -4692,13 +4139,9 @@
       42
     ],
     "conditionQualifier_id": 73,
-    "objectTherapeutic": [
-      11,
-      39,
-      35,
-      48
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 58
   },
   {
     "id": 335,
@@ -4708,12 +4151,9 @@
       42
     ],
     "conditionQualifier_id": 72,
-    "objectTherapeutic": [
-      37,
-      35,
-      48
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 59
   },
   {
     "id": 336,
@@ -4723,12 +4163,9 @@
       42
     ],
     "conditionQualifier_id": 73,
-    "objectTherapeutic": [
-      37,
-      35,
-      48
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 59
   },
   {
     "id": 337,
@@ -4738,13 +4175,9 @@
       42
     ],
     "conditionQualifier_id": 72,
-    "objectTherapeutic": [
-      11,
-      37,
-      35,
-      48
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 60
   },
   {
     "id": 338,
@@ -4754,13 +4187,9 @@
       42
     ],
     "conditionQualifier_id": 73,
-    "objectTherapeutic": [
-      11,
-      37,
-      35,
-      48
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 60
   },
   {
     "id": 339,
@@ -4770,10 +4199,9 @@
       42
     ],
     "conditionQualifier_id": 72,
-    "objectTherapeutic": [
-      48
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 48,
+    "therapy_group_id": null
   },
   {
     "id": 340,
@@ -4783,10 +4211,9 @@
       42
     ],
     "conditionQualifier_id": 73,
-    "objectTherapeutic": [
-      48
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 48,
+    "therapy_group_id": null
   },
   {
     "id": 341,
@@ -4796,11 +4223,9 @@
       142
     ],
     "conditionQualifier_id": 18,
-    "objectTherapeutic": [
-      132,
-      48
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 61
   },
   {
     "id": 342,
@@ -4810,10 +4235,9 @@
       37
     ],
     "conditionQualifier_id": 18,
-    "objectTherapeutic": [
-      48
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 48,
+    "therapy_group_id": null
   },
   {
     "id": 343,
@@ -4823,10 +4247,9 @@
       38
     ],
     "conditionQualifier_id": 18,
-    "objectTherapeutic": [
-      48
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 48,
+    "therapy_group_id": null
   },
   {
     "id": 344,
@@ -4836,10 +4259,9 @@
       144
     ],
     "conditionQualifier_id": 5,
-    "objectTherapeutic": [
-      48
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 48,
+    "therapy_group_id": null
   },
   {
     "id": 345,
@@ -4851,14 +4273,9 @@
       44
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      37,
-      59,
-      2,
-      35,
-      48
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 62
   },
   {
     "id": 346,
@@ -4871,11 +4288,9 @@
       44
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      35,
-      48
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 63
   },
   {
     "id": 347,
@@ -4888,12 +4303,9 @@
       44
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      37,
-      50,
-      48
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 64
   },
   {
     "id": 348,
@@ -4903,10 +4315,9 @@
       52
     ],
     "conditionQualifier_id": 11,
-    "objectTherapeutic": [
-      133
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 133,
+    "therapy_group_id": null
   },
   {
     "id": 349,
@@ -4916,10 +4327,9 @@
       53
     ],
     "conditionQualifier_id": 11,
-    "objectTherapeutic": [
-      133
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 133,
+    "therapy_group_id": null
   },
   {
     "id": 350,
@@ -4929,10 +4339,9 @@
       69
     ],
     "conditionQualifier_id": 44,
-    "objectTherapeutic": [
-      133
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 133,
+    "therapy_group_id": null
   },
   {
     "id": 351,
@@ -4942,12 +4351,9 @@
       20
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      24,
-      75,
-      25
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 65
   },
   {
     "id": 352,
@@ -4957,14 +4363,9 @@
       20
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      59,
-      2,
-      35,
-      75,
-      25
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 66
   },
   {
     "id": 353,
@@ -4974,15 +4375,9 @@
       20
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      59,
-      24,
-      76,
-      75,
-      25,
-      29
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 67
   },
   {
     "id": 354,
@@ -4992,15 +4387,9 @@
       20
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      59,
-      76,
-      35,
-      75,
-      25,
-      29
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 68
   },
   {
     "id": 355,
@@ -5010,15 +4399,9 @@
       20
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      59,
-      24,
-      2,
-      75,
-      25,
-      29
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 69
   },
   {
     "id": 356,
@@ -5028,15 +4411,9 @@
       20
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      59,
-      2,
-      35,
-      75,
-      25,
-      29
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 70
   },
   {
     "id": 357,
@@ -5046,14 +4423,9 @@
       20
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      59,
-      24,
-      76,
-      75,
-      25
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 71
   },
   {
     "id": 358,
@@ -5063,14 +4435,9 @@
       20
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      59,
-      76,
-      35,
-      75,
-      25
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 72
   },
   {
     "id": 359,
@@ -5080,14 +4447,9 @@
       20
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      59,
-      24,
-      2,
-      75,
-      25
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 73
   },
   {
     "id": 360,
@@ -5097,13 +4459,9 @@
       20
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      37,
-      24,
-      75,
-      25
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 74
   },
   {
     "id": 361,
@@ -5113,14 +4471,9 @@
       12
     ],
     "conditionQualifier_id": 0,
-    "objectTherapeutic": [
-      63,
-      65,
-      43,
-      122,
-      61
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 75
   },
   {
     "id": 362,
@@ -5131,10 +4484,9 @@
       12
     ],
     "conditionQualifier_id": 0,
-    "objectTherapeutic": [
-      43
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 43,
+    "therapy_group_id": null
   },
   {
     "id": 363,
@@ -5144,10 +4496,9 @@
       32
     ],
     "conditionQualifier_id": 13,
-    "objectTherapeutic": [
-      43
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 43,
+    "therapy_group_id": null
   },
   {
     "id": 364,
@@ -5157,10 +4508,9 @@
       18
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      32
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 32,
+    "therapy_group_id": null
   },
   {
     "id": 365,
@@ -5170,10 +4520,9 @@
       18
     ],
     "conditionQualifier_id": 75,
-    "objectTherapeutic": [
-      32
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 32,
+    "therapy_group_id": null
   },
   {
     "id": 366,
@@ -5183,11 +4532,9 @@
       10
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      12,
-      23
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 76
   },
   {
     "id": 367,
@@ -5197,11 +4544,9 @@
       9
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      12,
-      23
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 76
   },
   {
     "id": 368,
@@ -5211,10 +4556,9 @@
       62
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      134
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 134,
+    "therapy_group_id": null
   },
   {
     "id": 369,
@@ -5224,10 +4568,9 @@
       63
     ],
     "conditionQualifier_id": 5,
-    "objectTherapeutic": [
-      134
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 134,
+    "therapy_group_id": null
   },
   {
     "id": 370,
@@ -5237,10 +4580,9 @@
       64
     ],
     "conditionQualifier_id": 5,
-    "objectTherapeutic": [
-      134
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 134,
+    "therapy_group_id": null
   },
   {
     "id": 371,
@@ -5250,10 +4592,9 @@
       65
     ],
     "conditionQualifier_id": 5,
-    "objectTherapeutic": [
-      134
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 134,
+    "therapy_group_id": null
   },
   {
     "id": 372,
@@ -5264,11 +4605,9 @@
       2
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      36,
-      53
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 77
   },
   {
     "id": 373,
@@ -5279,11 +4618,9 @@
       3
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      36,
-      53
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 77
   },
   {
     "id": 374,
@@ -5295,11 +4632,9 @@
       3
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      36,
-      53
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 77
   },
   {
     "id": 375,
@@ -5310,11 +4645,9 @@
       2
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      40,
-      53
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 78
   },
   {
     "id": 376,
@@ -5325,11 +4658,9 @@
       3
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      40,
-      53
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 78
   },
   {
     "id": 377,
@@ -5341,11 +4672,9 @@
       3
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      40,
-      53
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 78
   },
   {
     "id": 378,
@@ -5355,10 +4684,9 @@
       54
     ],
     "conditionQualifier_id": 76,
-    "objectTherapeutic": [
-      60
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 60,
+    "therapy_group_id": null
   },
   {
     "id": 379,
@@ -5368,13 +4696,9 @@
       54
     ],
     "conditionQualifier_id": 76,
-    "objectTherapeutic": [
-      59,
-      60,
-      8,
-      61
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 79
   },
   {
     "id": 380,
@@ -5384,14 +4708,9 @@
       54
     ],
     "conditionQualifier_id": 76,
-    "objectTherapeutic": [
-      59,
-      2,
-      60,
-      8,
-      61
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 80
   },
   {
     "id": 381,
@@ -5401,13 +4720,9 @@
       54
     ],
     "conditionQualifier_id": 76,
-    "objectTherapeutic": [
-      59,
-      135,
-      124,
-      60
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 81
   },
   {
     "id": 382,
@@ -5417,14 +4732,9 @@
       54
     ],
     "conditionQualifier_id": 76,
-    "objectTherapeutic": [
-      59,
-      2,
-      60,
-      122,
-      61
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 82
   },
   {
     "id": 383,
@@ -5434,14 +4744,9 @@
       54
     ],
     "conditionQualifier_id": 77,
-    "objectTherapeutic": [
-      59,
-      2,
-      60,
-      122,
-      61
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 82
   },
   {
     "id": 384,
@@ -5451,14 +4756,9 @@
       54
     ],
     "conditionQualifier_id": 78,
-    "objectTherapeutic": [
-      59,
-      2,
-      60,
-      122,
-      61
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 82
   },
   {
     "id": 385,
@@ -5468,14 +4768,9 @@
       54
     ],
     "conditionQualifier_id": 79,
-    "objectTherapeutic": [
-      59,
-      2,
-      60,
-      122,
-      61
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 82
   },
   {
     "id": 386,
@@ -5485,12 +4780,9 @@
       54
     ],
     "conditionQualifier_id": 84,
-    "objectTherapeutic": [
-      59,
-      135,
-      60
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 83
   },
   {
     "id": 387,
@@ -5500,10 +4792,9 @@
       47
     ],
     "conditionQualifier_id": 51,
-    "objectTherapeutic": [
-      136
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 136,
+    "therapy_group_id": null
   },
   {
     "id": 388,
@@ -5513,10 +4804,9 @@
       48
     ],
     "conditionQualifier_id": 51,
-    "objectTherapeutic": [
-      136
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 136,
+    "therapy_group_id": null
   },
   {
     "id": 389,
@@ -5526,10 +4816,9 @@
       49
     ],
     "conditionQualifier_id": 51,
-    "objectTherapeutic": [
-      136
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 136,
+    "therapy_group_id": null
   },
   {
     "id": 390,
@@ -5539,10 +4828,9 @@
       50
     ],
     "conditionQualifier_id": 51,
-    "objectTherapeutic": [
-      136
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 136,
+    "therapy_group_id": null
   },
   {
     "id": 391,
@@ -5552,10 +4840,9 @@
       47
     ],
     "conditionQualifier_id": 27,
-    "objectTherapeutic": [
-      136
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 136,
+    "therapy_group_id": null
   },
   {
     "id": 392,
@@ -5565,10 +4852,9 @@
       48
     ],
     "conditionQualifier_id": 27,
-    "objectTherapeutic": [
-      136
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 136,
+    "therapy_group_id": null
   },
   {
     "id": 393,
@@ -5578,10 +4864,9 @@
       49
     ],
     "conditionQualifier_id": 27,
-    "objectTherapeutic": [
-      136
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 136,
+    "therapy_group_id": null
   },
   {
     "id": 394,
@@ -5591,10 +4876,9 @@
       50
     ],
     "conditionQualifier_id": 27,
-    "objectTherapeutic": [
-      136
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 136,
+    "therapy_group_id": null
   },
   {
     "id": 395,
@@ -5604,10 +4888,9 @@
       47
     ],
     "conditionQualifier_id": 54,
-    "objectTherapeutic": [
-      136
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 136,
+    "therapy_group_id": null
   },
   {
     "id": 396,
@@ -5617,10 +4900,9 @@
       48
     ],
     "conditionQualifier_id": 54,
-    "objectTherapeutic": [
-      136
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 136,
+    "therapy_group_id": null
   },
   {
     "id": 397,
@@ -5630,10 +4912,9 @@
       49
     ],
     "conditionQualifier_id": 54,
-    "objectTherapeutic": [
-      136
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 136,
+    "therapy_group_id": null
   },
   {
     "id": 398,
@@ -5643,10 +4924,9 @@
       50
     ],
     "conditionQualifier_id": 54,
-    "objectTherapeutic": [
-      136
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 136,
+    "therapy_group_id": null
   },
   {
     "id": 399,
@@ -5656,10 +4936,9 @@
       47
     ],
     "conditionQualifier_id": 55,
-    "objectTherapeutic": [
-      136
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 136,
+    "therapy_group_id": null
   },
   {
     "id": 400,
@@ -5669,10 +4948,9 @@
       48
     ],
     "conditionQualifier_id": 55,
-    "objectTherapeutic": [
-      136
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 136,
+    "therapy_group_id": null
   },
   {
     "id": 401,
@@ -5682,10 +4960,9 @@
       49
     ],
     "conditionQualifier_id": 55,
-    "objectTherapeutic": [
-      136
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 136,
+    "therapy_group_id": null
   },
   {
     "id": 402,
@@ -5695,10 +4972,9 @@
       50
     ],
     "conditionQualifier_id": 55,
-    "objectTherapeutic": [
-      136
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 136,
+    "therapy_group_id": null
   },
   {
     "id": 403,
@@ -5710,10 +4986,9 @@
       44
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      94
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 94,
+    "therapy_group_id": null
   },
   {
     "id": 404,
@@ -5724,10 +4999,9 @@
       2
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      94
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 94,
+    "therapy_group_id": null
   },
   {
     "id": 405,
@@ -5738,10 +5012,9 @@
       3
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      94
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 94,
+    "therapy_group_id": null
   },
   {
     "id": 406,
@@ -5753,10 +5026,9 @@
       3
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      94
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 94,
+    "therapy_group_id": null
   },
   {
     "id": 407,
@@ -5766,10 +5038,9 @@
       18
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      78
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 78,
+    "therapy_group_id": null
   },
   {
     "id": 408,
@@ -5779,10 +5050,9 @@
       152
     ],
     "conditionQualifier_id": 38,
-    "objectTherapeutic": [
-      78
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 78,
+    "therapy_group_id": null
   },
   {
     "id": 409,
@@ -5792,10 +5062,9 @@
       18
     ],
     "conditionQualifier_id": 4,
-    "objectTherapeutic": [
-      78
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 78,
+    "therapy_group_id": null
   },
   {
     "id": 410,
@@ -5805,10 +5074,9 @@
       18
     ],
     "conditionQualifier_id": 5,
-    "objectTherapeutic": [
-      78
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 78,
+    "therapy_group_id": null
   },
   {
     "id": 411,
@@ -5818,10 +5086,9 @@
       45
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      57
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 57,
+    "therapy_group_id": null
   },
   {
     "id": 412,
@@ -5832,10 +5099,9 @@
       2
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      87
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 87,
+    "therapy_group_id": null
   },
   {
     "id": 413,
@@ -5846,10 +5112,9 @@
       2
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      87
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 87,
+    "therapy_group_id": null
   },
   {
     "id": 414,
@@ -5859,10 +5124,9 @@
       67
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      90
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 90,
+    "therapy_group_id": null
   },
   {
     "id": 415,
@@ -5872,10 +5136,9 @@
       68
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      90
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 90,
+    "therapy_group_id": null
   },
   {
     "id": 416,
@@ -5885,10 +5148,9 @@
       16
     ],
     "conditionQualifier_id": 40,
-    "objectTherapeutic": [
-      66
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 66,
+    "therapy_group_id": null
   },
   {
     "id": 417,
@@ -5898,10 +5160,9 @@
       17
     ],
     "conditionQualifier_id": 40,
-    "objectTherapeutic": [
-      66
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 66,
+    "therapy_group_id": null
   },
   {
     "id": 418,
@@ -5911,10 +5172,9 @@
       20
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      25
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 25,
+    "therapy_group_id": null
   },
   {
     "id": 419,
@@ -5924,10 +5184,9 @@
       20
     ],
     "conditionQualifier_id": 22,
-    "objectTherapeutic": [
-      25
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 25,
+    "therapy_group_id": null
   },
   {
     "id": 420,
@@ -5937,10 +5196,9 @@
       20
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      26
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 26,
+    "therapy_group_id": null
   },
   {
     "id": 421,
@@ -5950,10 +5208,9 @@
       22
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      26
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 26,
+    "therapy_group_id": null
   },
   {
     "id": 422,
@@ -5963,10 +5220,9 @@
       23
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      26
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 26,
+    "therapy_group_id": null
   },
   {
     "id": 423,
@@ -5976,10 +5232,9 @@
       20
     ],
     "conditionQualifier_id": 2,
-    "objectTherapeutic": [
-      26
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 26,
+    "therapy_group_id": null
   },
   {
     "id": 424,
@@ -5989,10 +5244,9 @@
       20
     ],
     "conditionQualifier_id": 5,
-    "objectTherapeutic": [
-      26
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 26,
+    "therapy_group_id": null
   },
   {
     "id": 425,
@@ -6002,12 +5256,9 @@
       20
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      38,
-      25,
-      95
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 84
   },
   {
     "id": 426,
@@ -6017,10 +5268,9 @@
       16
     ],
     "conditionQualifier_id": 40,
-    "objectTherapeutic": [
-      22
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 22,
+    "therapy_group_id": null
   },
   {
     "id": 427,
@@ -6030,10 +5280,9 @@
       16
     ],
     "conditionQualifier_id": 46,
-    "objectTherapeutic": [
-      22
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 22,
+    "therapy_group_id": null
   },
   {
     "id": 428,
@@ -6043,10 +5292,9 @@
       17
     ],
     "conditionQualifier_id": 46,
-    "objectTherapeutic": [
-      22
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 22,
+    "therapy_group_id": null
   },
   {
     "id": 429,
@@ -6056,10 +5304,9 @@
       145
     ],
     "conditionQualifier_id": 20,
-    "objectTherapeutic": [
-      137
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 137,
+    "therapy_group_id": null
   },
   {
     "id": 430,
@@ -6069,10 +5316,9 @@
       146
     ],
     "conditionQualifier_id": 20,
-    "objectTherapeutic": [
-      137
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 137,
+    "therapy_group_id": null
   },
   {
     "id": 431,
@@ -6082,10 +5328,9 @@
       147
     ],
     "conditionQualifier_id": 20,
-    "objectTherapeutic": [
-      137
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 137,
+    "therapy_group_id": null
   },
   {
     "id": 432,
@@ -6095,10 +5340,9 @@
       148
     ],
     "conditionQualifier_id": 20,
-    "objectTherapeutic": [
-      137
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 137,
+    "therapy_group_id": null
   },
   {
     "id": 433,
@@ -6108,10 +5352,9 @@
       149
     ],
     "conditionQualifier_id": 20,
-    "objectTherapeutic": [
-      137
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 137,
+    "therapy_group_id": null
   },
   {
     "id": 434,
@@ -6121,10 +5364,9 @@
       150
     ],
     "conditionQualifier_id": 20,
-    "objectTherapeutic": [
-      137
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 137,
+    "therapy_group_id": null
   },
   {
     "id": 435,
@@ -6134,10 +5376,9 @@
       151
     ],
     "conditionQualifier_id": 20,
-    "objectTherapeutic": [
-      137
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 137,
+    "therapy_group_id": null
   },
   {
     "id": 436,
@@ -6147,11 +5388,9 @@
       48
     ],
     "conditionQualifier_id": 55,
-    "objectTherapeutic": [
-      138,
-      87
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 44
   },
   {
     "id": 437,
@@ -6161,11 +5400,9 @@
       49
     ],
     "conditionQualifier_id": 55,
-    "objectTherapeutic": [
-      138,
-      87
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 44
   },
   {
     "id": 438,
@@ -6175,11 +5412,9 @@
       50
     ],
     "conditionQualifier_id": 55,
-    "objectTherapeutic": [
-      138,
-      87
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 44
   },
   {
     "id": 439,
@@ -6189,11 +5424,9 @@
       104
     ],
     "conditionQualifier_id": 55,
-    "objectTherapeutic": [
-      138,
-      87
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 44
   },
   {
     "id": 440,
@@ -6203,11 +5436,9 @@
       105
     ],
     "conditionQualifier_id": 55,
-    "objectTherapeutic": [
-      138,
-      87
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 44
   },
   {
     "id": 441,
@@ -6217,11 +5448,9 @@
       160
     ],
     "conditionQualifier_id": 55,
-    "objectTherapeutic": [
-      138,
-      87
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 44
   },
   {
     "id": 442,
@@ -6231,11 +5460,9 @@
       125
     ],
     "conditionQualifier_id": 55,
-    "objectTherapeutic": [
-      138,
-      87
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 44
   },
   {
     "id": 443,
@@ -6245,11 +5472,9 @@
       161
     ],
     "conditionQualifier_id": 55,
-    "objectTherapeutic": [
-      138,
-      87
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 44
   },
   {
     "id": 444,
@@ -6259,11 +5484,9 @@
       162
     ],
     "conditionQualifier_id": 55,
-    "objectTherapeutic": [
-      138,
-      87
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 44
   },
   {
     "id": 445,
@@ -6273,11 +5496,9 @@
       128
     ],
     "conditionQualifier_id": 55,
-    "objectTherapeutic": [
-      138,
-      87
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 44
   },
   {
     "id": 446,
@@ -6287,11 +5508,9 @@
       129
     ],
     "conditionQualifier_id": 55,
-    "objectTherapeutic": [
-      138,
-      87
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 44
   },
   {
     "id": 447,
@@ -6301,11 +5520,9 @@
       163
     ],
     "conditionQualifier_id": 55,
-    "objectTherapeutic": [
-      138,
-      87
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 44
   },
   {
     "id": 448,
@@ -6315,11 +5532,9 @@
       164
     ],
     "conditionQualifier_id": 55,
-    "objectTherapeutic": [
-      138,
-      87
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 44
   },
   {
     "id": 449,
@@ -6329,11 +5544,9 @@
       132
     ],
     "conditionQualifier_id": 55,
-    "objectTherapeutic": [
-      138,
-      87
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 44
   },
   {
     "id": 450,
@@ -6343,11 +5556,9 @@
       133
     ],
     "conditionQualifier_id": 55,
-    "objectTherapeutic": [
-      138,
-      87
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 44
   },
   {
     "id": 451,
@@ -6357,11 +5568,9 @@
       165
     ],
     "conditionQualifier_id": 55,
-    "objectTherapeutic": [
-      138,
-      87
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 44
   },
   {
     "id": 452,
@@ -6371,11 +5580,9 @@
       166
     ],
     "conditionQualifier_id": 55,
-    "objectTherapeutic": [
-      138,
-      87
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 44
   },
   {
     "id": 453,
@@ -6385,11 +5592,9 @@
       136
     ],
     "conditionQualifier_id": 55,
-    "objectTherapeutic": [
-      138,
-      87
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 44
   },
   {
     "id": 454,
@@ -6399,11 +5604,9 @@
       137
     ],
     "conditionQualifier_id": 55,
-    "objectTherapeutic": [
-      138,
-      87
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 44
   },
   {
     "id": 455,
@@ -6413,11 +5616,9 @@
       167
     ],
     "conditionQualifier_id": 55,
-    "objectTherapeutic": [
-      138,
-      87
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 44
   },
   {
     "id": 456,
@@ -6427,11 +5628,9 @@
       168
     ],
     "conditionQualifier_id": 55,
-    "objectTherapeutic": [
-      138,
-      87
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 44
   },
   {
     "id": 457,
@@ -6441,11 +5640,9 @@
       169
     ],
     "conditionQualifier_id": 55,
-    "objectTherapeutic": [
-      138,
-      87
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 44
   },
   {
     "id": 458,
@@ -6455,10 +5652,9 @@
       158
     ],
     "conditionQualifier_id": 88,
-    "objectTherapeutic": [
-      4
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 4,
+    "therapy_group_id": null
   },
   {
     "id": 459,
@@ -6468,10 +5664,9 @@
       159
     ],
     "conditionQualifier_id": 88,
-    "objectTherapeutic": [
-      4
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 4,
+    "therapy_group_id": null
   },
   {
     "id": 460,
@@ -6481,10 +5676,9 @@
       158
     ],
     "conditionQualifier_id": 4,
-    "objectTherapeutic": [
-      4
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 4,
+    "therapy_group_id": null
   },
   {
     "id": 461,
@@ -6494,10 +5688,9 @@
       159
     ],
     "conditionQualifier_id": 4,
-    "objectTherapeutic": [
-      4
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 4,
+    "therapy_group_id": null
   },
   {
     "id": 462,
@@ -6507,11 +5700,9 @@
       7
     ],
     "conditionQualifier_id": 55,
-    "objectTherapeutic": [
-      138,
-      87
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 44
   },
   {
     "id": 463,
@@ -6521,11 +5712,9 @@
       10
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      139,
-      108
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 85
   },
   {
     "id": 464,
@@ -6535,11 +5724,9 @@
       9
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      139,
-      108
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 85
   },
   {
     "id": 465,
@@ -6549,12 +5736,9 @@
       10
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      108,
-      37,
-      49
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 86
   },
   {
     "id": 466,
@@ -6564,12 +5748,9 @@
       9
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      108,
-      37,
-      49
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 86
   },
   {
     "id": 467,
@@ -6579,10 +5760,9 @@
       153
     ],
     "conditionQualifier_id": 51,
-    "objectTherapeutic": [
-      140
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 140,
+    "therapy_group_id": null
   },
   {
     "id": 468,
@@ -6592,10 +5772,9 @@
       153
     ],
     "conditionQualifier_id": 27,
-    "objectTherapeutic": [
-      140
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 140,
+    "therapy_group_id": null
   },
   {
     "id": 469,
@@ -6605,10 +5784,9 @@
       153
     ],
     "conditionQualifier_id": 54,
-    "objectTherapeutic": [
-      140
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 140,
+    "therapy_group_id": null
   },
   {
     "id": 470,
@@ -6618,10 +5796,9 @@
       155
     ],
     "conditionQualifier_id": 35,
-    "objectTherapeutic": [
-      141
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 141,
+    "therapy_group_id": null
   },
   {
     "id": 471,
@@ -6631,10 +5808,9 @@
       154
     ],
     "conditionQualifier_id": 35,
-    "objectTherapeutic": [
-      141
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 141,
+    "therapy_group_id": null
   },
   {
     "id": 472,
@@ -6644,10 +5820,9 @@
       16
     ],
     "conditionQualifier_id": 35,
-    "objectTherapeutic": [
-      141
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 141,
+    "therapy_group_id": null
   },
   {
     "id": 473,
@@ -6657,10 +5832,9 @@
       17
     ],
     "conditionQualifier_id": 35,
-    "objectTherapeutic": [
-      141
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 141,
+    "therapy_group_id": null
   },
   {
     "id": 474,
@@ -6671,12 +5845,9 @@
       35
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      37,
-      44,
-      35
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 25
   },
   {
     "id": 475,
@@ -6687,12 +5858,9 @@
       35
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      39,
-      44,
-      50
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 87
   },
   {
     "id": 476,
@@ -6703,12 +5871,9 @@
       35
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      39,
-      44,
-      49
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 88
   },
   {
     "id": 477,
@@ -6719,12 +5884,9 @@
       35
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      37,
-      44,
-      49
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 89
   },
   {
     "id": 478,
@@ -6734,11 +5896,9 @@
       45
     ],
     "conditionQualifier_id": 15,
-    "objectTherapeutic": [
-      54,
-      19
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 90
   },
   {
     "id": 479,
@@ -6748,10 +5908,9 @@
       74
     ],
     "conditionQualifier_id": 6,
-    "objectTherapeutic": [
-      142
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 142,
+    "therapy_group_id": null
   },
   {
     "id": 480,
@@ -6761,10 +5920,9 @@
       75
     ],
     "conditionQualifier_id": 6,
-    "objectTherapeutic": [
-      142
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 142,
+    "therapy_group_id": null
   },
   {
     "id": 481,
@@ -6774,10 +5932,9 @@
       76
     ],
     "conditionQualifier_id": 6,
-    "objectTherapeutic": [
-      142
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 142,
+    "therapy_group_id": null
   },
   {
     "id": 482,
@@ -6787,10 +5944,9 @@
       77
     ],
     "conditionQualifier_id": 6,
-    "objectTherapeutic": [
-      142
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 142,
+    "therapy_group_id": null
   },
   {
     "id": 483,
@@ -6800,10 +5956,9 @@
       78
     ],
     "conditionQualifier_id": 6,
-    "objectTherapeutic": [
-      142
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 142,
+    "therapy_group_id": null
   },
   {
     "id": 484,
@@ -6813,10 +5968,9 @@
       111
     ],
     "conditionQualifier_id": 6,
-    "objectTherapeutic": [
-      142
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 142,
+    "therapy_group_id": null
   },
   {
     "id": 485,
@@ -6826,10 +5980,9 @@
       112
     ],
     "conditionQualifier_id": 6,
-    "objectTherapeutic": [
-      142
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 142,
+    "therapy_group_id": null
   },
   {
     "id": 486,
@@ -6839,10 +5992,9 @@
       113
     ],
     "conditionQualifier_id": 6,
-    "objectTherapeutic": [
-      142
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 142,
+    "therapy_group_id": null
   },
   {
     "id": 487,
@@ -6852,10 +6004,9 @@
       114
     ],
     "conditionQualifier_id": 6,
-    "objectTherapeutic": [
-      142
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 142,
+    "therapy_group_id": null
   },
   {
     "id": 488,
@@ -6865,10 +6016,9 @@
       115
     ],
     "conditionQualifier_id": 6,
-    "objectTherapeutic": [
-      142
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 142,
+    "therapy_group_id": null
   },
   {
     "id": 489,
@@ -6878,10 +6028,9 @@
       74
     ],
     "conditionQualifier_id": 48,
-    "objectTherapeutic": [
-      142
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 142,
+    "therapy_group_id": null
   },
   {
     "id": 490,
@@ -6891,10 +6040,9 @@
       75
     ],
     "conditionQualifier_id": 48,
-    "objectTherapeutic": [
-      142
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 142,
+    "therapy_group_id": null
   },
   {
     "id": 491,
@@ -6904,10 +6052,9 @@
       76
     ],
     "conditionQualifier_id": 48,
-    "objectTherapeutic": [
-      142
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 142,
+    "therapy_group_id": null
   },
   {
     "id": 492,
@@ -6917,10 +6064,9 @@
       77
     ],
     "conditionQualifier_id": 48,
-    "objectTherapeutic": [
-      142
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 142,
+    "therapy_group_id": null
   },
   {
     "id": 493,
@@ -6930,10 +6076,9 @@
       78
     ],
     "conditionQualifier_id": 48,
-    "objectTherapeutic": [
-      142
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 142,
+    "therapy_group_id": null
   },
   {
     "id": 494,
@@ -6943,10 +6088,9 @@
       111
     ],
     "conditionQualifier_id": 48,
-    "objectTherapeutic": [
-      142
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 142,
+    "therapy_group_id": null
   },
   {
     "id": 495,
@@ -6956,10 +6100,9 @@
       112
     ],
     "conditionQualifier_id": 48,
-    "objectTherapeutic": [
-      142
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 142,
+    "therapy_group_id": null
   },
   {
     "id": 496,
@@ -6969,10 +6112,9 @@
       113
     ],
     "conditionQualifier_id": 48,
-    "objectTherapeutic": [
-      142
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 142,
+    "therapy_group_id": null
   },
   {
     "id": 497,
@@ -6982,10 +6124,9 @@
       114
     ],
     "conditionQualifier_id": 48,
-    "objectTherapeutic": [
-      142
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 142,
+    "therapy_group_id": null
   },
   {
     "id": 498,
@@ -6995,10 +6136,9 @@
       115
     ],
     "conditionQualifier_id": 48,
-    "objectTherapeutic": [
-      142
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 142,
+    "therapy_group_id": null
   },
   {
     "id": 499,
@@ -7009,12 +6149,9 @@
       2
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      36,
-      143,
-      53
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 91
   },
   {
     "id": 500,
@@ -7025,12 +6162,9 @@
       3
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      36,
-      143,
-      53
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 91
   },
   {
     "id": 501,
@@ -7042,12 +6176,9 @@
       3
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      36,
-      143,
-      53
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 91
   },
   {
     "id": 502,
@@ -7058,12 +6189,9 @@
       2
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      143,
-      40,
-      53
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 92
   },
   {
     "id": 503,
@@ -7074,12 +6202,9 @@
       3
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      143,
-      40,
-      53
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 92
   },
   {
     "id": 504,
@@ -7091,12 +6216,9 @@
       3
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      143,
-      40,
-      53
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 92
   },
   {
     "id": 505,
@@ -7107,12 +6229,9 @@
       35
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      39,
-      72,
-      49
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 93
   },
   {
     "id": 506,
@@ -7123,12 +6242,9 @@
       35
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      39,
-      50,
-      72
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 94
   },
   {
     "id": 507,
@@ -7138,11 +6254,9 @@
       36
     ],
     "conditionQualifier_id": 15,
-    "objectTherapeutic": [
-      71,
-      72
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 29
   },
   {
     "id": 508,
@@ -7152,10 +6266,9 @@
       38
     ],
     "conditionQualifier_id": 15,
-    "objectTherapeutic": [
-      72
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 72,
+    "therapy_group_id": null
   },
   {
     "id": 509,
@@ -7165,10 +6278,9 @@
       36
     ],
     "conditionQualifier_id": 15,
-    "objectTherapeutic": [
-      72
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 72,
+    "therapy_group_id": null
   },
   {
     "id": 510,
@@ -7180,12 +6292,9 @@
       59
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      30,
-      144,
-      31
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 95
   },
   {
     "id": 511,
@@ -7197,12 +6306,9 @@
       59
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      30,
-      144,
-      31
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 95
   },
   {
     "id": 512,
@@ -7215,12 +6321,9 @@
       59
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      30,
-      144,
-      31
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 95
   },
   {
     "id": 513,
@@ -7231,12 +6334,9 @@
       103
     ],
     "conditionQualifier_id": 2,
-    "objectTherapeutic": [
-      29,
-      28,
-      111
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 96
   },
   {
     "id": 514,
@@ -7247,12 +6347,9 @@
       103
     ],
     "conditionQualifier_id": 2,
-    "objectTherapeutic": [
-      38,
-      28,
-      111
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 97
   },
   {
     "id": 515,
@@ -7262,10 +6359,9 @@
       20
     ],
     "conditionQualifier_id": 85,
-    "objectTherapeutic": [
-      145
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 145,
+    "therapy_group_id": null
   },
   {
     "id": 516,
@@ -7275,10 +6371,9 @@
       20
     ],
     "conditionQualifier_id": 86,
-    "objectTherapeutic": [
-      145
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 145,
+    "therapy_group_id": null
   },
   {
     "id": 517,
@@ -7288,10 +6383,9 @@
       20
     ],
     "conditionQualifier_id": 11,
-    "objectTherapeutic": [
-      145
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 145,
+    "therapy_group_id": null
   },
   {
     "id": 518,
@@ -7301,10 +6395,9 @@
       156
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      146
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 146,
+    "therapy_group_id": null
   },
   {
     "id": 519,
@@ -7314,10 +6407,9 @@
       156
     ],
     "conditionQualifier_id": 52,
-    "objectTherapeutic": [
-      146
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 146,
+    "therapy_group_id": null
   },
   {
     "id": 520,
@@ -7327,10 +6419,9 @@
       8
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      147
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 147,
+    "therapy_group_id": null
   },
   {
     "id": 521,
@@ -7340,13 +6431,9 @@
       16
     ],
     "conditionQualifier_id": 15,
-    "objectTherapeutic": [
-      29,
-      19,
-      18,
-      28
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 98
   },
   {
     "id": 522,
@@ -7356,10 +6443,9 @@
       12
     ],
     "conditionQualifier_id": 71,
-    "objectTherapeutic": [
-      83
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 83,
+    "therapy_group_id": null
   },
   {
     "id": 523,
@@ -7370,13 +6456,9 @@
       35
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      37,
-      44,
-      45,
-      49
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 99
   },
   {
     "id": 524,
@@ -7387,13 +6469,9 @@
       35
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      39,
-      44,
-      45,
-      49
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 100
   },
   {
     "id": 525,
@@ -7404,13 +6482,9 @@
       35
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      37,
-      44,
-      50,
-      45
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 101
   },
   {
     "id": 526,
@@ -7421,13 +6495,9 @@
       35
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      39,
-      44,
-      50,
-      45
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 102
   },
   {
     "id": 527,
@@ -7438,13 +6508,9 @@
       35
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      37,
-      44,
-      51,
-      45
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 103
   },
   {
     "id": 528,
@@ -7454,10 +6520,9 @@
       157
     ],
     "conditionQualifier_id": 0,
-    "objectTherapeutic": [
-      148
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 148,
+    "therapy_group_id": null
   },
   {
     "id": 529,
@@ -7467,10 +6532,9 @@
       157
     ],
     "conditionQualifier_id": 1,
-    "objectTherapeutic": [
-      148
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 148,
+    "therapy_group_id": null
   },
   {
     "id": 530,
@@ -7480,10 +6544,9 @@
       157
     ],
     "conditionQualifier_id": 78,
-    "objectTherapeutic": [
-      148
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 148,
+    "therapy_group_id": null
   },
   {
     "id": 531,
@@ -7493,10 +6556,9 @@
       157
     ],
     "conditionQualifier_id": 87,
-    "objectTherapeutic": [
-      148
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 148,
+    "therapy_group_id": null
   },
   {
     "id": 532,
@@ -7506,13 +6568,9 @@
       0
     ],
     "conditionQualifier_id": 80,
-    "objectTherapeutic": [
-      0,
-      1,
-      2,
-      3
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 104
   },
   {
     "id": 533,
@@ -7522,10 +6580,9 @@
       0
     ],
     "conditionQualifier_id": 80,
-    "objectTherapeutic": [
-      0
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 0,
+    "therapy_group_id": null
   },
   {
     "id": 534,
@@ -7535,10 +6592,9 @@
       0
     ],
     "conditionQualifier_id": 30,
-    "objectTherapeutic": [
-      0
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 0,
+    "therapy_group_id": null
   },
   {
     "id": 535,
@@ -7549,11 +6605,9 @@
       2
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      4,
-      5
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 26
   },
   {
     "id": 536,
@@ -7565,11 +6619,9 @@
       2
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      4,
-      5
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 26
   },
   {
     "id": 537,
@@ -7579,12 +6631,9 @@
       47
     ],
     "conditionQualifier_id": 55,
-    "objectTherapeutic": [
-      6,
-      7,
-      8
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 105
   },
   {
     "id": 538,
@@ -7594,12 +6643,9 @@
       49
     ],
     "conditionQualifier_id": 55,
-    "objectTherapeutic": [
-      6,
-      7,
-      8
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 105
   },
   {
     "id": 539,
@@ -7609,12 +6655,9 @@
       48
     ],
     "conditionQualifier_id": 55,
-    "objectTherapeutic": [
-      6,
-      7,
-      8
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 105
   },
   {
     "id": 540,
@@ -7624,12 +6667,9 @@
       50
     ],
     "conditionQualifier_id": 55,
-    "objectTherapeutic": [
-      6,
-      7,
-      8
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 105
   },
   {
     "id": 541,
@@ -7639,11 +6679,9 @@
       9
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      11,
-      12
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 106
   },
   {
     "id": 542,
@@ -7653,11 +6691,9 @@
       10
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      11,
-      12
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 106
   },
   {
     "id": 543,
@@ -7668,10 +6704,9 @@
       13
     ],
     "conditionQualifier_id": 0,
-    "objectTherapeutic": [
-      14
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 14,
+    "therapy_group_id": null
   },
   {
     "id": 544,
@@ -7682,10 +6717,9 @@
       14
     ],
     "conditionQualifier_id": 0,
-    "objectTherapeutic": [
-      15
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 15,
+    "therapy_group_id": null
   },
   {
     "id": 545,
@@ -7695,10 +6729,9 @@
       15
     ],
     "conditionQualifier_id": 13,
-    "objectTherapeutic": [
-      16
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 16,
+    "therapy_group_id": null
   },
   {
     "id": 546,
@@ -7708,11 +6741,9 @@
       16
     ],
     "conditionQualifier_id": 15,
-    "objectTherapeutic": [
-      19,
-      18
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 107
   },
   {
     "id": 547,
@@ -7722,10 +6753,9 @@
       18
     ],
     "conditionQualifier_id": 38,
-    "objectTherapeutic": [
-      20
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 20,
+    "therapy_group_id": null
   },
   {
     "id": 548,
@@ -7735,11 +6765,9 @@
       19
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      12,
-      23
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 76
   },
   {
     "id": 549,
@@ -7749,11 +6777,9 @@
       20
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      24,
-      25
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 108
   },
   {
     "id": 550,
@@ -7763,11 +6789,9 @@
       21
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      24,
-      25
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 108
   },
   {
     "id": 551,
@@ -7777,10 +6801,9 @@
       21
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      26
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 26,
+    "therapy_group_id": null
   },
   {
     "id": 552,
@@ -7790,10 +6813,9 @@
       21
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      26
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 26,
+    "therapy_group_id": null
   },
   {
     "id": 553,
@@ -7803,10 +6825,9 @@
       21
     ],
     "conditionQualifier_id": 2,
-    "objectTherapeutic": [
-      26
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 26,
+    "therapy_group_id": null
   },
   {
     "id": 554,
@@ -7819,10 +6840,9 @@
       27
     ],
     "conditionQualifier_id": 15,
-    "objectTherapeutic": [
-      19
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 19,
+    "therapy_group_id": null
   },
   {
     "id": 555,
@@ -7835,11 +6855,9 @@
       27
     ],
     "conditionQualifier_id": 15,
-    "objectTherapeutic": [
-      19,
-      27
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 15
   },
   {
     "id": 556,
@@ -7852,12 +6870,9 @@
       27
     ],
     "conditionQualifier_id": 15,
-    "objectTherapeutic": [
-      19,
-      28,
-      29
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 109
   },
   {
     "id": 557,
@@ -7868,11 +6883,9 @@
       2
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      30,
-      31
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 28
   },
   {
     "id": 558,
@@ -7884,11 +6897,9 @@
       2
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      30,
-      31
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 28
   },
   {
     "id": 559,
@@ -7898,10 +6909,9 @@
       19
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      33
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 33,
+    "therapy_group_id": null
   },
   {
     "id": 560,
@@ -7911,10 +6921,9 @@
       19
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      34
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 34,
+    "therapy_group_id": null
   },
   {
     "id": 561,
@@ -7924,11 +6933,9 @@
       20
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      35,
-      25
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 110
   },
   {
     "id": 562,
@@ -7938,11 +6945,9 @@
       20
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      36,
-      25
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 111
   },
   {
     "id": 563,
@@ -7952,12 +6957,9 @@
       20
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      37,
-      24,
-      25
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 112
   },
   {
     "id": 564,
@@ -7967,12 +6969,9 @@
       20
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      2,
-      25,
-      35
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 113
   },
   {
     "id": 565,
@@ -7982,10 +6981,9 @@
       21
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      25
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 25,
+    "therapy_group_id": null
   },
   {
     "id": 566,
@@ -7995,11 +6993,9 @@
       21
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      35,
-      25
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 110
   },
   {
     "id": 567,
@@ -8009,11 +7005,9 @@
       21
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      36,
-      25
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 111
   },
   {
     "id": 568,
@@ -8023,12 +7017,9 @@
       21
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      37,
-      24,
-      25
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 112
   },
   {
     "id": 569,
@@ -8038,12 +7029,9 @@
       21
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      2,
-      35,
-      25
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 114
   },
   {
     "id": 570,
@@ -8053,12 +7041,9 @@
       20
     ],
     "conditionQualifier_id": 81,
-    "objectTherapeutic": [
-      38,
-      39,
-      25
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 115
   },
   {
     "id": 571,
@@ -8068,12 +7053,9 @@
       20
     ],
     "conditionQualifier_id": 81,
-    "objectTherapeutic": [
-      39,
-      25,
-      29
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 116
   },
   {
     "id": 572,
@@ -8083,12 +7065,9 @@
       21
     ],
     "conditionQualifier_id": 81,
-    "objectTherapeutic": [
-      38,
-      39,
-      25
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 115
   },
   {
     "id": 573,
@@ -8098,12 +7077,9 @@
       21
     ],
     "conditionQualifier_id": 81,
-    "objectTherapeutic": [
-      39,
-      25,
-      29
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 116
   },
   {
     "id": 574,
@@ -8114,11 +7090,9 @@
       1
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      40,
-      31
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 49
   },
   {
     "id": 575,
@@ -8130,11 +7104,9 @@
       3
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      40,
-      31
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 49
   },
   {
     "id": 576,
@@ -8145,11 +7117,9 @@
       1
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      30,
-      31
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 28
   },
   {
     "id": 577,
@@ -8161,11 +7131,9 @@
       3
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      30,
-      31
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 28
   },
   {
     "id": 578,
@@ -8175,10 +7143,9 @@
       15
     ],
     "conditionQualifier_id": 13,
-    "objectTherapeutic": [
-      41
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 41,
+    "therapy_group_id": null
   },
   {
     "id": 579,
@@ -8188,10 +7155,9 @@
       15
     ],
     "conditionQualifier_id": 0,
-    "objectTherapeutic": [
-      41
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 41,
+    "therapy_group_id": null
   },
   {
     "id": 580,
@@ -8201,10 +7167,9 @@
       28
     ],
     "conditionQualifier_id": 45,
-    "objectTherapeutic": [
-      41
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 41,
+    "therapy_group_id": null
   },
   {
     "id": 581,
@@ -8214,10 +7179,9 @@
       29
     ],
     "conditionQualifier_id": 45,
-    "objectTherapeutic": [
-      41
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 41,
+    "therapy_group_id": null
   },
   {
     "id": 582,
@@ -8227,10 +7191,9 @@
       15
     ],
     "conditionQualifier_id": 0,
-    "objectTherapeutic": [
-      43
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 43,
+    "therapy_group_id": null
   },
   {
     "id": 583,
@@ -8241,10 +7204,9 @@
       32
     ],
     "conditionQualifier_id": 0,
-    "objectTherapeutic": [
-      43
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 43,
+    "therapy_group_id": null
   },
   {
     "id": 584,
@@ -8254,10 +7216,9 @@
       33
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      44
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 44,
+    "therapy_group_id": null
   },
   {
     "id": 585,
@@ -8268,12 +7229,9 @@
       35
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      37,
-      44,
-      45
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 117
   },
   {
     "id": 586,
@@ -8283,13 +7241,9 @@
       37
     ],
     "conditionQualifier_id": 18,
-    "objectTherapeutic": [
-      37,
-      44,
-      46,
-      35
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 118
   },
   {
     "id": 587,
@@ -8299,10 +7253,9 @@
       38
     ],
     "conditionQualifier_id": 18,
-    "objectTherapeutic": [
-      47
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 47,
+    "therapy_group_id": null
   },
   {
     "id": 588,
@@ -8314,10 +7267,9 @@
       34
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      48
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 48,
+    "therapy_group_id": null
   },
   {
     "id": 589,
@@ -8329,10 +7281,9 @@
       34
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      48
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 48,
+    "therapy_group_id": null
   },
   {
     "id": 590,
@@ -8343,12 +7294,9 @@
       34
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      37,
-      48,
-      49
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 51
   },
   {
     "id": 591,
@@ -8359,12 +7307,9 @@
       34
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      39,
-      48,
-      49
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 52
   },
   {
     "id": 592,
@@ -8375,12 +7320,9 @@
       34
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      39,
-      50,
-      48
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 119
   },
   {
     "id": 593,
@@ -8391,12 +7333,9 @@
       34
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      37,
-      50,
-      48
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 64
   },
   {
     "id": 594,
@@ -8407,12 +7346,9 @@
       34
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      37,
-      35,
-      48
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 59
   },
   {
     "id": 595,
@@ -8422,10 +7358,9 @@
       41
     ],
     "conditionQualifier_id": 8,
-    "objectTherapeutic": [
-      48
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 48,
+    "therapy_group_id": null
   },
   {
     "id": 596,
@@ -8435,12 +7370,9 @@
       42
     ],
     "conditionQualifier_id": 25,
-    "objectTherapeutic": [
-      37,
-      48,
-      29
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 120
   },
   {
     "id": 597,
@@ -8450,12 +7382,9 @@
       42
     ],
     "conditionQualifier_id": 25,
-    "objectTherapeutic": [
-      39,
-      48,
-      29
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 55
   },
   {
     "id": 598,
@@ -8465,10 +7394,9 @@
       39
     ],
     "conditionQualifier_id": 25,
-    "objectTherapeutic": [
-      48
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 48,
+    "therapy_group_id": null
   },
   {
     "id": 599,
@@ -8478,10 +7406,9 @@
       36
     ],
     "conditionQualifier_id": 18,
-    "objectTherapeutic": [
-      48
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 48,
+    "therapy_group_id": null
   },
   {
     "id": 600,
@@ -8491,10 +7418,9 @@
       38
     ],
     "conditionQualifier_id": 81,
-    "objectTherapeutic": [
-      48
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 48,
+    "therapy_group_id": null
   },
   {
     "id": 601,
@@ -8504,10 +7430,9 @@
       36
     ],
     "conditionQualifier_id": 81,
-    "objectTherapeutic": [
-      48
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 48,
+    "therapy_group_id": null
   },
   {
     "id": 602,
@@ -8517,10 +7442,9 @@
       38
     ],
     "conditionQualifier_id": 22,
-    "objectTherapeutic": [
-      48
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 48,
+    "therapy_group_id": null
   },
   {
     "id": 603,
@@ -8530,10 +7454,9 @@
       36
     ],
     "conditionQualifier_id": 22,
-    "objectTherapeutic": [
-      48
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 48,
+    "therapy_group_id": null
   },
   {
     "id": 604,
@@ -8543,10 +7466,9 @@
       38
     ],
     "conditionQualifier_id": 11,
-    "objectTherapeutic": [
-      48
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 48,
+    "therapy_group_id": null
   },
   {
     "id": 605,
@@ -8556,10 +7478,9 @@
       36
     ],
     "conditionQualifier_id": 11,
-    "objectTherapeutic": [
-      48
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 48,
+    "therapy_group_id": null
   },
   {
     "id": 606,
@@ -8569,12 +7490,9 @@
       41
     ],
     "conditionQualifier_id": 74,
-    "objectTherapeutic": [
-      39,
-      48,
-      29
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 55
   },
   {
     "id": 607,
@@ -8584,12 +7502,9 @@
       41
     ],
     "conditionQualifier_id": 74,
-    "objectTherapeutic": [
-      37,
-      48,
-      29
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 120
   },
   {
     "id": 608,
@@ -8601,10 +7516,9 @@
       44
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      48
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 48,
+    "therapy_group_id": null
   },
   {
     "id": 609,
@@ -8617,11 +7531,9 @@
       44
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      51,
-      48
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 121
   },
   {
     "id": 610,
@@ -8632,13 +7544,9 @@
       42
     ],
     "conditionQualifier_id": 2,
-    "objectTherapeutic": [
-      37,
-      48,
-      25,
-      29
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 122
   },
   {
     "id": 611,
@@ -8649,12 +7557,9 @@
       42
     ],
     "conditionQualifier_id": 2,
-    "objectTherapeutic": [
-      39,
-      48,
-      29
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 55
   },
   {
     "id": 612,
@@ -8665,12 +7570,9 @@
       42
     ],
     "conditionQualifier_id": 2,
-    "objectTherapeutic": [
-      37,
-      48,
-      29
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 120
   },
   {
     "id": 613,
@@ -8680,10 +7582,9 @@
       21
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      52
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 52,
+    "therapy_group_id": null
   },
   {
     "id": 614,
@@ -8694,11 +7595,9 @@
       2
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      40,
-      53
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 78
   },
   {
     "id": 615,
@@ -8710,11 +7609,9 @@
       2
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      40,
-      53
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 78
   },
   {
     "id": 616,
@@ -8725,11 +7622,9 @@
       2
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      30,
-      53
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 27
   },
   {
     "id": 617,
@@ -8741,11 +7636,9 @@
       2
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      30,
-      53
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 27
   },
   {
     "id": 618,
@@ -8758,10 +7651,9 @@
       46
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      55
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 55,
+    "therapy_group_id": null
   },
   {
     "id": 619,
@@ -8774,12 +7666,9 @@
       46
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      37,
-      55,
-      49
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 13
   },
   {
     "id": 620,
@@ -8789,11 +7678,9 @@
       37
     ],
     "conditionQualifier_id": 18,
-    "objectTherapeutic": [
-      44,
-      46
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 123
   },
   {
     "id": 621,
@@ -8803,10 +7690,9 @@
       53
     ],
     "conditionQualifier_id": 29,
-    "objectTherapeutic": [
-      58
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 58,
+    "therapy_group_id": null
   },
   {
     "id": 622,
@@ -8816,14 +7702,9 @@
       54
     ],
     "conditionQualifier_id": 77,
-    "objectTherapeutic": [
-      59,
-      60,
-      2,
-      8,
-      61
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 124
   },
   {
     "id": 623,
@@ -8833,14 +7714,9 @@
       54
     ],
     "conditionQualifier_id": 76,
-    "objectTherapeutic": [
-      59,
-      60,
-      2,
-      8,
-      61
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 124
   },
   {
     "id": 624,
@@ -8850,17 +7726,9 @@
       54
     ],
     "conditionQualifier_id": 77,
-    "objectTherapeutic": [
-      59,
-      62,
-      63,
-      2,
-      64,
-      65,
-      60,
-      61
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 125
   },
   {
     "id": 625,
@@ -8870,17 +7738,9 @@
       54
     ],
     "conditionQualifier_id": 76,
-    "objectTherapeutic": [
-      59,
-      62,
-      63,
-      2,
-      64,
-      65,
-      60,
-      61
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 125
   },
   {
     "id": 626,
@@ -8890,17 +7750,9 @@
       54
     ],
     "conditionQualifier_id": 78,
-    "objectTherapeutic": [
-      59,
-      62,
-      63,
-      2,
-      64,
-      65,
-      60,
-      61
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 125
   },
   {
     "id": 627,
@@ -8910,11 +7762,9 @@
       17
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      67,
-      66
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 18
   },
   {
     "id": 628,
@@ -8924,12 +7774,9 @@
       55
     ],
     "conditionQualifier_id": 1,
-    "objectTherapeutic": [
-      63,
-      68,
-      69
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 126
   },
   {
     "id": 629,
@@ -8941,10 +7788,9 @@
       3
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      112
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 112,
+    "therapy_group_id": null
   },
   {
     "id": 630,
@@ -8955,10 +7801,9 @@
       1
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      112
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 112,
+    "therapy_group_id": null
   },
   {
     "id": 631,
@@ -8969,10 +7814,9 @@
       3
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      112
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 112,
+    "therapy_group_id": null
   },
   {
     "id": 632,
@@ -8984,10 +7828,9 @@
       3
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      112
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 112,
+    "therapy_group_id": null
   },
   {
     "id": 633,
@@ -8998,10 +7841,9 @@
       1
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      112
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 112,
+    "therapy_group_id": null
   },
   {
     "id": 634,
@@ -9012,10 +7854,9 @@
       3
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      112
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 112,
+    "therapy_group_id": null
   },
   {
     "id": 635,
@@ -9026,13 +7867,9 @@
       34
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      37,
-      71,
-      72,
-      49
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 30
   },
   {
     "id": 636,
@@ -9043,13 +7880,9 @@
       34
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      39,
-      71,
-      72,
-      49
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 31
   },
   {
     "id": 637,
@@ -9060,13 +7893,9 @@
       34
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      37,
-      71,
-      72,
-      35
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 32
   },
   {
     "id": 638,
@@ -9076,12 +7905,9 @@
       33
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      37,
-      72,
-      35
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 42
   },
   {
     "id": 639,
@@ -9091,12 +7917,9 @@
       33
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      37,
-      72,
-      49
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 127
   },
   {
     "id": 640,
@@ -9106,12 +7929,9 @@
       33
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      39,
-      50,
-      72
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 94
   },
   {
     "id": 641,
@@ -9121,10 +7941,9 @@
       33
     ],
     "conditionQualifier_id": 8,
-    "objectTherapeutic": [
-      72
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 72,
+    "therapy_group_id": null
   },
   {
     "id": 642,
@@ -9134,11 +7953,9 @@
       33
     ],
     "conditionQualifier_id": 82,
-    "objectTherapeutic": [
-      71,
-      72
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 29
   },
   {
     "id": 643,
@@ -9148,12 +7965,9 @@
       33
     ],
     "conditionQualifier_id": 82,
-    "objectTherapeutic": [
-      39,
-      72,
-      29
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 128
   },
   {
     "id": 644,
@@ -9164,12 +7978,9 @@
       56
     ],
     "conditionQualifier_id": 74,
-    "objectTherapeutic": [
-      72,
-      28,
-      29
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 129
   },
   {
     "id": 645,
@@ -9180,11 +7991,9 @@
       56
     ],
     "conditionQualifier_id": 74,
-    "objectTherapeutic": [
-      72,
-      28
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 130
   },
   {
     "id": 646,
@@ -9195,12 +8004,9 @@
       56
     ],
     "conditionQualifier_id": 81,
-    "objectTherapeutic": [
-      72,
-      28,
-      29
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 129
   },
   {
     "id": 647,
@@ -9211,11 +8017,9 @@
       56
     ],
     "conditionQualifier_id": 81,
-    "objectTherapeutic": [
-      72,
-      28
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 130
   },
   {
     "id": 648,
@@ -9226,12 +8030,9 @@
       56
     ],
     "conditionQualifier_id": 2,
-    "objectTherapeutic": [
-      72,
-      28,
-      29
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 129
   },
   {
     "id": 649,
@@ -9242,11 +8043,9 @@
       56
     ],
     "conditionQualifier_id": 2,
-    "objectTherapeutic": [
-      72,
-      28
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 130
   },
   {
     "id": 650,
@@ -9256,11 +8055,9 @@
       57
     ],
     "conditionQualifier_id": 40,
-    "objectTherapeutic": [
-      72,
-      73
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 131
   },
   {
     "id": 651,
@@ -9270,10 +8067,9 @@
       52
     ],
     "conditionQualifier_id": 29,
-    "objectTherapeutic": [
-      74
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 74,
+    "therapy_group_id": null
   },
   {
     "id": 652,
@@ -9283,10 +8079,9 @@
       53
     ],
     "conditionQualifier_id": 29,
-    "objectTherapeutic": [
-      74
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 74,
+    "therapy_group_id": null
   },
   {
     "id": 653,
@@ -9298,11 +8093,9 @@
       87
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      77,
-      30
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 5
   },
   {
     "id": 654,
@@ -9314,11 +8107,9 @@
       87
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      77,
-      30
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 5
   },
   {
     "id": 655,
@@ -9331,11 +8122,9 @@
       87
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      77,
-      30
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 5
   },
   {
     "id": 656,
@@ -9345,10 +8134,9 @@
       18
     ],
     "conditionQualifier_id": 75,
-    "objectTherapeutic": [
-      78
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 78,
+    "therapy_group_id": null
   },
   {
     "id": 657,
@@ -9358,10 +8146,9 @@
       60
     ],
     "conditionQualifier_id": 38,
-    "objectTherapeutic": [
-      78
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 78,
+    "therapy_group_id": null
   },
   {
     "id": 658,
@@ -9371,10 +8158,9 @@
       61
     ],
     "conditionQualifier_id": 45,
-    "objectTherapeutic": [
-      79
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 79,
+    "therapy_group_id": null
   },
   {
     "id": 659,
@@ -9384,10 +8170,9 @@
       15
     ],
     "conditionQualifier_id": 13,
-    "objectTherapeutic": [
-      83
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 83,
+    "therapy_group_id": null
   },
   {
     "id": 660,
@@ -9397,11 +8182,9 @@
       16
     ],
     "conditionQualifier_id": 83,
-    "objectTherapeutic": [
-      67,
-      66
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 18
   },
   {
     "id": 661,
@@ -9411,10 +8194,9 @@
       15
     ],
     "conditionQualifier_id": 13,
-    "objectTherapeutic": [
-      84
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 84,
+    "therapy_group_id": null
   },
   {
     "id": 662,
@@ -9424,10 +8206,9 @@
       15
     ],
     "conditionQualifier_id": 0,
-    "objectTherapeutic": [
-      84
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 84,
+    "therapy_group_id": null
   },
   {
     "id": 663,
@@ -9437,10 +8218,9 @@
       17
     ],
     "conditionQualifier_id": 40,
-    "objectTherapeutic": [
-      67
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 67,
+    "therapy_group_id": null
   },
   {
     "id": 664,
@@ -9450,10 +8230,9 @@
       19
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      86
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 86,
+    "therapy_group_id": null
   },
   {
     "id": 665,
@@ -9463,11 +8242,9 @@
       10
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      39,
-      86
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 132
   },
   {
     "id": 666,
@@ -9477,11 +8254,9 @@
       10
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      37,
-      86
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 133
   },
   {
     "id": 667,
@@ -9491,11 +8266,9 @@
       9
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      39,
-      86
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 132
   },
   {
     "id": 668,
@@ -9505,11 +8278,9 @@
       9
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      37,
-      86
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 133
   },
   {
     "id": 669,
@@ -9519,10 +8290,9 @@
       19
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      12
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 12,
+    "therapy_group_id": null
   },
   {
     "id": 670,
@@ -9532,10 +8302,9 @@
       15
     ],
     "conditionQualifier_id": 13,
-    "objectTherapeutic": [
-      88
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 88,
+    "therapy_group_id": null
   },
   {
     "id": 671,
@@ -9545,10 +8314,9 @@
       71
     ],
     "conditionQualifier_id": 8,
-    "objectTherapeutic": [
-      89
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 89,
+    "therapy_group_id": null
   },
   {
     "id": 672,
@@ -9560,10 +8328,9 @@
       35
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      89
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 89,
+    "therapy_group_id": null
   },
   {
     "id": 673,
@@ -9573,13 +8340,9 @@
       72
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      89,
-      11,
-      37,
-      35
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 134
   },
   {
     "id": 674,
@@ -9589,13 +8352,9 @@
       8
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      89,
-      11,
-      37,
-      35
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 134
   },
   {
     "id": 675,
@@ -9605,12 +8364,9 @@
       35
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      89,
-      37,
-      51
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 135
   },
   {
     "id": 676,
@@ -9620,12 +8376,9 @@
       34
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      89,
-      37,
-      51
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 135
   },
   {
     "id": 677,
@@ -9636,12 +8389,9 @@
       35
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      89,
-      37,
-      51
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 135
   },
   {
     "id": 678,
@@ -9653,10 +8403,9 @@
       35
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      89
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 89,
+    "therapy_group_id": null
   },
   {
     "id": 679,
@@ -9669,11 +8418,9 @@
       44
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      89,
-      51
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 136
   },
   {
     "id": 680,
@@ -9684,13 +8431,9 @@
       35
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      37,
-      44,
-      49,
-      45
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 137
   },
   {
     "id": 681,
@@ -9701,13 +8444,9 @@
       35
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      39,
-      44,
-      49,
-      45
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 138
   },
   {
     "id": 682,
@@ -9719,10 +8458,9 @@
       44
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      94
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 94,
+    "therapy_group_id": null
   },
   {
     "id": 683,
@@ -9733,10 +8471,9 @@
       1
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      94
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 94,
+    "therapy_group_id": null
   },
   {
     "id": 684,
@@ -9748,10 +8485,9 @@
       3
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      94
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 94,
+    "therapy_group_id": null
   },
   {
     "id": 685,
@@ -9763,11 +8499,9 @@
       44
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      96,
-      25
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 139
   },
   {
     "id": 686,
@@ -9779,11 +8513,9 @@
       3
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      96,
-      40
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 35
   },
   {
     "id": 687,
@@ -9793,11 +8525,9 @@
       21
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      38,
-      96
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 34
   },
   {
     "id": 688,
@@ -9809,11 +8539,9 @@
       44
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      96,
-      25
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 139
   },
   {
     "id": 689,
@@ -9825,11 +8553,9 @@
       3
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      96,
-      40
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 35
   },
   {
     "id": 690,
@@ -9840,12 +8566,9 @@
       27
     ],
     "conditionQualifier_id": 15,
-    "objectTherapeutic": [
-      97,
-      28,
-      29
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 140
   },
   {
     "id": 691,
@@ -9856,12 +8579,9 @@
       27
     ],
     "conditionQualifier_id": 15,
-    "objectTherapeutic": [
-      97,
-      27,
-      29
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 141
   },
   {
     "id": 692,
@@ -9872,10 +8592,9 @@
       27
     ],
     "conditionQualifier_id": 15,
-    "objectTherapeutic": [
-      97
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 97,
+    "therapy_group_id": null
   },
   {
     "id": 693,
@@ -9885,10 +8604,9 @@
       80
     ],
     "conditionQualifier_id": 84,
-    "objectTherapeutic": [
-      98
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 98,
+    "therapy_group_id": null
   },
   {
     "id": 694,
@@ -9898,10 +8616,9 @@
       81
     ],
     "conditionQualifier_id": 84,
-    "objectTherapeutic": [
-      98
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 98,
+    "therapy_group_id": null
   },
   {
     "id": 695,
@@ -9911,10 +8628,9 @@
       84
     ],
     "conditionQualifier_id": 84,
-    "objectTherapeutic": [
-      98
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 98,
+    "therapy_group_id": null
   },
   {
     "id": 696,
@@ -9924,10 +8640,9 @@
       83
     ],
     "conditionQualifier_id": 84,
-    "objectTherapeutic": [
-      98
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 98,
+    "therapy_group_id": null
   },
   {
     "id": 697,
@@ -9938,10 +8653,9 @@
       1
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      99
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 99,
+    "therapy_group_id": null
   },
   {
     "id": 698,
@@ -9953,10 +8667,9 @@
       3
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      99
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 99,
+    "therapy_group_id": null
   },
   {
     "id": 699,
@@ -9967,11 +8680,9 @@
       1
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      99,
-      36
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 142
   },
   {
     "id": 700,
@@ -9982,11 +8693,9 @@
       3
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      99,
-      36
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 142
   },
   {
     "id": 701,
@@ -9998,11 +8707,9 @@
       3
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      99,
-      36
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 142
   },
   {
     "id": 702,
@@ -10013,11 +8720,9 @@
       1
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      99,
-      40
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 143
   },
   {
     "id": 703,
@@ -10028,11 +8733,9 @@
       3
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      99,
-      40
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 143
   },
   {
     "id": 704,
@@ -10044,11 +8747,9 @@
       3
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      99,
-      40
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 143
   },
   {
     "id": 705,
@@ -10059,11 +8760,9 @@
       1
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      99,
-      30
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 144
   },
   {
     "id": 706,
@@ -10074,11 +8773,9 @@
       3
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      99,
-      30
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 144
   },
   {
     "id": 707,
@@ -10090,11 +8787,9 @@
       3
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      99,
-      30
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 144
   },
   {
     "id": 708,
@@ -10104,10 +8799,9 @@
       19
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      101
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 101,
+    "therapy_group_id": null
   },
   {
     "id": 709,
@@ -10117,10 +8811,9 @@
       66
     ],
     "conditionQualifier_id": 1,
-    "objectTherapeutic": [
-      104
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 104,
+    "therapy_group_id": null
   },
   {
     "id": 710,
@@ -10130,10 +8823,9 @@
       85
     ],
     "conditionQualifier_id": 1,
-    "objectTherapeutic": [
-      104
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 104,
+    "therapy_group_id": null
   },
   {
     "id": 711,
@@ -10143,10 +8835,9 @@
       17
     ],
     "conditionQualifier_id": 40,
-    "objectTherapeutic": [
-      22
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 22,
+    "therapy_group_id": null
   },
   {
     "id": 712,
@@ -10156,11 +8847,9 @@
       81
     ],
     "conditionQualifier_id": 84,
-    "objectTherapeutic": [
-      105,
-      60
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 145
   },
   {
     "id": 713,
@@ -10170,11 +8859,9 @@
       80
     ],
     "conditionQualifier_id": 84,
-    "objectTherapeutic": [
-      105,
-      60
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 145
   },
   {
     "id": 714,
@@ -10184,11 +8871,9 @@
       84
     ],
     "conditionQualifier_id": 84,
-    "objectTherapeutic": [
-      105,
-      60
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 145
   },
   {
     "id": 715,
@@ -10200,12 +8885,9 @@
       35
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      37,
-      49,
-      107
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 146
   },
   {
     "id": 716,
@@ -10217,12 +8899,9 @@
       35
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      39,
-      49,
-      107
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 147
   },
   {
     "id": 717,
@@ -10234,11 +8913,9 @@
       87
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      109,
-      30
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 12
   },
   {
     "id": 718,
@@ -10250,11 +8927,9 @@
       88
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      109,
-      30
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 12
   },
   {
     "id": 719,
@@ -10264,10 +8939,9 @@
       95
     ],
     "conditionQualifier_id": 8,
-    "objectTherapeutic": [
-      110
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 110,
+    "therapy_group_id": null
   },
   {
     "id": 720,
@@ -10277,10 +8951,9 @@
       96
     ],
     "conditionQualifier_id": 8,
-    "objectTherapeutic": [
-      110
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 110,
+    "therapy_group_id": null
   },
   {
     "id": 721,
@@ -10290,10 +8963,9 @@
       98
     ],
     "conditionQualifier_id": 8,
-    "objectTherapeutic": [
-      110
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 110,
+    "therapy_group_id": null
   },
   {
     "id": 722,
@@ -10304,12 +8976,9 @@
       103
     ],
     "conditionQualifier_id": 2,
-    "objectTherapeutic": [
-      28,
-      111,
-      29
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 148
   },
   {
     "id": 723,
@@ -10319,12 +8988,9 @@
       66
     ],
     "conditionQualifier_id": 1,
-    "objectTherapeutic": [
-      82,
-      68,
-      63
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 149
   },
   {
     "id": 724,
@@ -10334,11 +9000,9 @@
       47
     ],
     "conditionQualifier_id": 51,
-    "objectTherapeutic": [
-      46,
-      11
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 150
   },
   {
     "id": 725,
@@ -10348,11 +9012,9 @@
       49
     ],
     "conditionQualifier_id": 51,
-    "objectTherapeutic": [
-      46,
-      11
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 150
   },
   {
     "id": 726,
@@ -10362,11 +9024,9 @@
       48
     ],
     "conditionQualifier_id": 51,
-    "objectTherapeutic": [
-      46,
-      11
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 150
   },
   {
     "id": 727,
@@ -10376,11 +9036,9 @@
       50
     ],
     "conditionQualifier_id": 51,
-    "objectTherapeutic": [
-      46,
-      11
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 150
   },
   {
     "id": 728,
@@ -10390,11 +9048,9 @@
       47
     ],
     "conditionQualifier_id": 27,
-    "objectTherapeutic": [
-      46,
-      11
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 150
   },
   {
     "id": 729,
@@ -10404,11 +9060,9 @@
       49
     ],
     "conditionQualifier_id": 27,
-    "objectTherapeutic": [
-      46,
-      11
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 150
   },
   {
     "id": 730,
@@ -10418,11 +9072,9 @@
       48
     ],
     "conditionQualifier_id": 27,
-    "objectTherapeutic": [
-      46,
-      11
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 150
   },
   {
     "id": 731,
@@ -10432,11 +9084,9 @@
       50
     ],
     "conditionQualifier_id": 27,
-    "objectTherapeutic": [
-      46,
-      11
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 150
   },
   {
     "id": 732,
@@ -10446,11 +9096,9 @@
       47
     ],
     "conditionQualifier_id": 54,
-    "objectTherapeutic": [
-      46,
-      11
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 150
   },
   {
     "id": 733,
@@ -10460,11 +9108,9 @@
       50
     ],
     "conditionQualifier_id": 54,
-    "objectTherapeutic": [
-      46,
-      11
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 150
   },
   {
     "id": 734,
@@ -10474,11 +9120,9 @@
       48
     ],
     "conditionQualifier_id": 54,
-    "objectTherapeutic": [
-      46,
-      11
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 150
   },
   {
     "id": 735,
@@ -10488,11 +9132,9 @@
       51
     ],
     "conditionQualifier_id": 51,
-    "objectTherapeutic": [
-      46,
-      11
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 150
   },
   {
     "id": 736,
@@ -10502,11 +9144,9 @@
       51
     ],
     "conditionQualifier_id": 27,
-    "objectTherapeutic": [
-      46,
-      11
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 150
   },
   {
     "id": 737,
@@ -10516,11 +9156,9 @@
       51
     ],
     "conditionQualifier_id": 54,
-    "objectTherapeutic": [
-      46,
-      11
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 150
   },
   {
     "id": 738,
@@ -10531,10 +9169,9 @@
       15
     ],
     "conditionQualifier_id": 0,
-    "objectTherapeutic": [
-      43
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 43,
+    "therapy_group_id": null
   },
   {
     "id": 739,
@@ -10544,11 +9181,9 @@
       16
     ],
     "conditionQualifier_id": 40,
-    "objectTherapeutic": [
-      66,
-      67
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 151
   },
   {
     "id": 740,
@@ -10558,11 +9193,9 @@
       17
     ],
     "conditionQualifier_id": 40,
-    "objectTherapeutic": [
-      66,
-      67
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 151
   },
   {
     "id": 741,
@@ -10572,10 +9205,9 @@
       80
     ],
     "conditionQualifier_id": 84,
-    "objectTherapeutic": [
-      113
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 113,
+    "therapy_group_id": null
   },
   {
     "id": 742,
@@ -10585,10 +9217,9 @@
       81
     ],
     "conditionQualifier_id": 84,
-    "objectTherapeutic": [
-      113
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 113,
+    "therapy_group_id": null
   },
   {
     "id": 743,
@@ -10598,10 +9229,9 @@
       84
     ],
     "conditionQualifier_id": 84,
-    "objectTherapeutic": [
-      113
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 113,
+    "therapy_group_id": null
   },
   {
     "id": 744,
@@ -10611,10 +9241,9 @@
       80
     ],
     "conditionQualifier_id": 84,
-    "objectTherapeutic": [
-      114
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 114,
+    "therapy_group_id": null
   },
   {
     "id": 745,
@@ -10624,10 +9253,9 @@
       81
     ],
     "conditionQualifier_id": 84,
-    "objectTherapeutic": [
-      114
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 114,
+    "therapy_group_id": null
   },
   {
     "id": 746,
@@ -10637,10 +9265,9 @@
       84
     ],
     "conditionQualifier_id": 84,
-    "objectTherapeutic": [
-      114
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 114,
+    "therapy_group_id": null
   },
   {
     "id": 747,
@@ -10650,10 +9277,9 @@
       80
     ],
     "conditionQualifier_id": 84,
-    "objectTherapeutic": [
-      115
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 115,
+    "therapy_group_id": null
   },
   {
     "id": 748,
@@ -10663,10 +9289,9 @@
       81
     ],
     "conditionQualifier_id": 84,
-    "objectTherapeutic": [
-      115
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 115,
+    "therapy_group_id": null
   },
   {
     "id": 749,
@@ -10676,10 +9301,9 @@
       84
     ],
     "conditionQualifier_id": 84,
-    "objectTherapeutic": [
-      115
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 115,
+    "therapy_group_id": null
   },
   {
     "id": 750,
@@ -10689,11 +9313,9 @@
       38
     ],
     "conditionQualifier_id": 15,
-    "objectTherapeutic": [
-      72,
-      71
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 152
   },
   {
     "id": 751,
@@ -10703,11 +9325,9 @@
       36
     ],
     "conditionQualifier_id": 15,
-    "objectTherapeutic": [
-      72,
-      71
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 152
   },
   {
     "id": 752,
@@ -10718,11 +9338,9 @@
       1
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      40,
-      53
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 78
   },
   {
     "id": 753,
@@ -10734,11 +9352,9 @@
       3
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      40,
-      53
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 78
   },
   {
     "id": 754,
@@ -10749,11 +9365,9 @@
       1
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      30,
-      53
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 27
   },
   {
     "id": 755,
@@ -10765,11 +9379,9 @@
       3
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      30,
-      53
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 27
   },
   {
     "id": 756,
@@ -10780,10 +9392,9 @@
       15
     ],
     "conditionQualifier_id": 0,
-    "objectTherapeutic": [
-      14
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 14,
+    "therapy_group_id": null
   },
   {
     "id": 757,
@@ -10793,13 +9404,9 @@
       0
     ],
     "conditionQualifier_id": 80,
-    "objectTherapeutic": [
-      0,
-      39,
-      63,
-      64
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 153
   },
   {
     "id": 758,
@@ -10809,12 +9416,9 @@
       55
     ],
     "conditionQualifier_id": 0,
-    "objectTherapeutic": [
-      63,
-      68,
-      69
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 126
   },
   {
     "id": 759,
@@ -10824,13 +9428,9 @@
       20
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      37,
-      35,
-      75,
-      25
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 154
   },
   {
     "id": 760,
@@ -10841,13 +9441,9 @@
       2
     ],
     "conditionQualifier_id": 80,
-    "objectTherapeutic": [
-      0,
-      37,
-      64,
-      116
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 155
   },
   {
     "id": 761,
@@ -10858,12 +9454,9 @@
       2
     ],
     "conditionQualifier_id": 2,
-    "objectTherapeutic": [
-      39,
-      48,
-      29
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 55
   },
   {
     "id": 762,
@@ -10874,12 +9467,9 @@
       2
     ],
     "conditionQualifier_id": 2,
-    "objectTherapeutic": [
-      28,
-      48,
-      29
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 156
   },
   {
     "id": 763,
@@ -10889,10 +9479,9 @@
       15
     ],
     "conditionQualifier_id": 0,
-    "objectTherapeutic": [
-      15
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 15,
+    "therapy_group_id": null
   },
   {
     "id": 764,
@@ -10902,12 +9491,9 @@
       20
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      35,
-      75,
-      25
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 157
   },
   {
     "id": 765,
@@ -10917,12 +9503,9 @@
       20
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      117,
-      75,
-      25
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 158
   },
   {
     "id": 766,
@@ -10932,11 +9515,9 @@
       20
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      75,
-      25
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 159
   },
   {
     "id": 767,
@@ -10946,12 +9527,9 @@
       33
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      37,
-      50,
-      72
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 160
   },
   {
     "id": 768,
@@ -10961,12 +9539,9 @@
       33
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      39,
-      72,
-      49
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 93
   },
   {
     "id": 769,
@@ -10976,11 +9551,9 @@
       2
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      11,
-      35
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 161
   },
   {
     "id": 770,
@@ -10990,11 +9563,9 @@
       19
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      11,
-      12
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 106
   },
   {
     "id": 771,
@@ -11006,10 +9577,9 @@
       44
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      38
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 38,
+    "therapy_group_id": null
   },
   {
     "id": 772,
@@ -11019,10 +9589,9 @@
       1
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      119
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 119,
+    "therapy_group_id": null
   },
   {
     "id": 773,
@@ -11034,10 +9603,9 @@
       3
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      36
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 36,
+    "therapy_group_id": null
   },
   {
     "id": 774,
@@ -11048,10 +9616,9 @@
       1
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      36
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 36,
+    "therapy_group_id": null
   },
   {
     "id": 775,
@@ -11062,10 +9629,9 @@
       3
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      36
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 36,
+    "therapy_group_id": null
   },
   {
     "id": 776,
@@ -11077,11 +9643,9 @@
       3
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      36,
-      25
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 111
   },
   {
     "id": 777,
@@ -11092,11 +9656,9 @@
       1
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      36,
-      25
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 111
   },
   {
     "id": 778,
@@ -11107,11 +9669,9 @@
       3
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      36,
-      25
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 111
   },
   {
     "id": 779,
@@ -11121,12 +9681,9 @@
       20
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      2,
-      35,
-      25
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 114
   },
   {
     "id": 780,
@@ -11138,11 +9695,9 @@
       3
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      4,
-      5
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 26
   },
   {
     "id": 781,
@@ -11153,11 +9708,9 @@
       1
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      4,
-      5
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 26
   },
   {
     "id": 782,
@@ -11169,13 +9722,9 @@
       44
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      37,
-      59,
-      2,
-      35
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 162
   },
   {
     "id": 783,
@@ -11185,10 +9734,9 @@
       43
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      30
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 30,
+    "therapy_group_id": null
   },
   {
     "id": 784,
@@ -11199,10 +9747,9 @@
       3
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      40
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 40,
+    "therapy_group_id": null
   },
   {
     "id": 785,
@@ -11212,10 +9759,9 @@
       1
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      40
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 40,
+    "therapy_group_id": null
   },
   {
     "id": 786,
@@ -11225,10 +9771,9 @@
       3
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      40
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 40,
+    "therapy_group_id": null
   },
   {
     "id": 787,
@@ -11239,10 +9784,9 @@
       3
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      5
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 5,
+    "therapy_group_id": null
   },
   {
     "id": 788,
@@ -11252,10 +9796,9 @@
       1
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      5
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 5,
+    "therapy_group_id": null
   },
   {
     "id": 789,
@@ -11265,10 +9808,9 @@
       3
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      5
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 5,
+    "therapy_group_id": null
   },
   {
     "id": 790,
@@ -11280,11 +9822,9 @@
       44
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      37,
-      50
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 163
   },
   {
     "id": 791,
@@ -11294,13 +9834,9 @@
       20
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      59,
-      2,
-      35,
-      25
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 164
   },
   {
     "id": 792,
@@ -11312,11 +9848,9 @@
       3
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      99,
-      5
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 165
   },
   {
     "id": 793,
@@ -11327,11 +9861,9 @@
       2
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      99,
-      5
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 165
   },
   {
     "id": 794,
@@ -11342,11 +9874,9 @@
       3
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      99,
-      5
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 165
   },
   {
     "id": 795,
@@ -11358,13 +9888,9 @@
       44
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      37,
-      59,
-      2,
-      35
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 162
   },
   {
     "id": 796,
@@ -11376,10 +9902,9 @@
       27
     ],
     "conditionQualifier_id": 15,
-    "objectTherapeutic": [
-      19
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 19,
+    "therapy_group_id": null
   },
   {
     "id": 797,
@@ -11390,12 +9915,9 @@
       27
     ],
     "conditionQualifier_id": 15,
-    "objectTherapeutic": [
-      19,
-      27,
-      29
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 14
   },
   {
     "id": 798,
@@ -11406,11 +9928,9 @@
       27
     ],
     "conditionQualifier_id": 15,
-    "objectTherapeutic": [
-      19,
-      27
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 15
   },
   {
     "id": 799,
@@ -11421,12 +9941,9 @@
       27
     ],
     "conditionQualifier_id": 15,
-    "objectTherapeutic": [
-      28,
-      97,
-      29
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 50
   },
   {
     "id": 800,
@@ -11436,12 +9953,9 @@
       33
     ],
     "conditionQualifier_id": 82,
-    "objectTherapeutic": [
-      72,
-      28,
-      29
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 129
   },
   {
     "id": 801,
@@ -11451,11 +9965,9 @@
       80
     ],
     "conditionQualifier_id": 84,
-    "objectTherapeutic": [
-      105,
-      120
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 166
   },
   {
     "id": 802,
@@ -11465,11 +9977,9 @@
       81
     ],
     "conditionQualifier_id": 84,
-    "objectTherapeutic": [
-      105,
-      120
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 166
   },
   {
     "id": 803,
@@ -11479,11 +9989,9 @@
       84
     ],
     "conditionQualifier_id": 84,
-    "objectTherapeutic": [
-      105,
-      120
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 166
   },
   {
     "id": 804,
@@ -11493,10 +10001,9 @@
       66
     ],
     "conditionQualifier_id": 1,
-    "objectTherapeutic": [
-      82
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 82,
+    "therapy_group_id": null
   },
   {
     "id": 805,
@@ -11506,12 +10013,9 @@
       33
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      37,
-      35,
-      72
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 167
   },
   {
     "id": 806,
@@ -11521,12 +10025,9 @@
       33
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      39,
-      49,
-      72
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 168
   },
   {
     "id": 807,
@@ -11536,12 +10037,9 @@
       33
     ],
     "conditionQualifier_id": 47,
-    "objectTherapeutic": [
-      37,
-      49,
-      72
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 169
   },
   {
     "id": 808,
@@ -11551,11 +10049,9 @@
       54
     ],
     "conditionQualifier_id": 76,
-    "objectTherapeutic": [
-      121,
-      60
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 170
   },
   {
     "id": 809,
@@ -11565,12 +10061,9 @@
       54
     ],
     "conditionQualifier_id": 76,
-    "objectTherapeutic": [
-      39,
-      63,
-      60
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 171
   },
   {
     "id": 810,
@@ -11580,15 +10073,9 @@
       54
     ],
     "conditionQualifier_id": 77,
-    "objectTherapeutic": [
-      59,
-      2,
-      64,
-      8,
-      60,
-      61
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 172
   },
   {
     "id": 811,
@@ -11598,15 +10085,9 @@
       54
     ],
     "conditionQualifier_id": 76,
-    "objectTherapeutic": [
-      59,
-      2,
-      64,
-      8,
-      60,
-      61
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 172
   },
   {
     "id": 812,
@@ -11616,13 +10097,9 @@
       54
     ],
     "conditionQualifier_id": 76,
-    "objectTherapeutic": [
-      37,
-      64,
-      116,
-      60
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 173
   },
   {
     "id": 813,
@@ -11632,14 +10109,9 @@
       54
     ],
     "conditionQualifier_id": 76,
-    "objectTherapeutic": [
-      59,
-      2,
-      8,
-      60,
-      117
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 174
   },
   {
     "id": 814,
@@ -11649,12 +10121,9 @@
       54
     ],
     "conditionQualifier_id": 77,
-    "objectTherapeutic": [
-      50,
-      28,
-      60
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 175
   },
   {
     "id": 815,
@@ -11664,12 +10133,9 @@
       54
     ],
     "conditionQualifier_id": 76,
-    "objectTherapeutic": [
-      50,
-      28,
-      60
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 175
   },
   {
     "id": 816,
@@ -11679,14 +10145,9 @@
       54
     ],
     "conditionQualifier_id": 76,
-    "objectTherapeutic": [
-      59,
-      64,
-      8,
-      60,
-      61
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 176
   },
   {
     "id": 817,
@@ -11696,11 +10157,9 @@
       0
     ],
     "conditionQualifier_id": 80,
-    "objectTherapeutic": [
-      121,
-      0
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 177
   },
   {
     "id": 818,
@@ -11710,13 +10169,9 @@
       54
     ],
     "conditionQualifier_id": 20,
-    "objectTherapeutic": [
-      59,
-      8,
-      60,
-      61
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 178
   },
   {
     "id": 819,
@@ -11726,14 +10181,9 @@
       54
     ],
     "conditionQualifier_id": 20,
-    "objectTherapeutic": [
-      59,
-      2,
-      8,
-      60,
-      61
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 179
   },
   {
     "id": 820,
@@ -11743,13 +10193,9 @@
       54
     ],
     "conditionQualifier_id": 20,
-    "objectTherapeutic": [
-      123,
-      124,
-      8,
-      60
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 180
   },
   {
     "id": 821,
@@ -11759,15 +10205,9 @@
       54
     ],
     "conditionQualifier_id": 20,
-    "objectTherapeutic": [
-      59,
-      2,
-      64,
-      125,
-      8,
-      60
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 181
   },
   {
     "id": 822,
@@ -11777,10 +10217,9 @@
       54
     ],
     "conditionQualifier_id": 20,
-    "objectTherapeutic": [
-      60
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 60,
+    "therapy_group_id": null
   },
   {
     "id": 823,
@@ -11790,13 +10229,9 @@
       54
     ],
     "conditionQualifier_id": 76,
-    "objectTherapeutic": [
-      59,
-      8,
-      60,
-      61
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 178
   },
   {
     "id": 824,
@@ -11806,10 +10241,9 @@
       1
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      36
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 36,
+    "therapy_group_id": null
   },
   {
     "id": 825,
@@ -11819,10 +10253,9 @@
       3
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      36
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 36,
+    "therapy_group_id": null
   },
   {
     "id": 826,
@@ -11833,10 +10266,9 @@
       3
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      36
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 36,
+    "therapy_group_id": null
   },
   {
     "id": 827,
@@ -11847,10 +10279,9 @@
       2
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      40
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 40,
+    "therapy_group_id": null
   },
   {
     "id": 828,
@@ -11861,10 +10292,9 @@
       3
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      40
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 40,
+    "therapy_group_id": null
   },
   {
     "id": 829,
@@ -11876,10 +10306,9 @@
       3
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      40
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": 40,
+    "therapy_group_id": null
   },
   {
     "id": 830,
@@ -11891,11 +10320,9 @@
       3
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      99,
-      40
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 143
   },
   {
     "id": 831,
@@ -11906,11 +10333,9 @@
       2
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      99,
-      40
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 143
   },
   {
     "id": 832,
@@ -11921,11 +10346,9 @@
       3
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      99,
-      40
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 143
   },
   {
     "id": 833,
@@ -11937,11 +10360,9 @@
       3
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      99,
-      36
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 142
   },
   {
     "id": 834,
@@ -11952,11 +10373,9 @@
       2
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      99,
-      36
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 142
   },
   {
     "id": 835,
@@ -11967,10 +10386,8 @@
       3
     ],
     "conditionQualifier_id": 9,
-    "objectTherapeutic": [
-      99,
-      36
-    ],
-    "subjectVariant": {}
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 142
   }
 ]

--- a/referenced/propositions.json
+++ b/referenced/propositions.json
@@ -1,12811 +1,11976 @@
 [
-    {
-        "id": 0,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            1,
-            2
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            99,
-            119
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 1,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            2,
-            3
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            99,
-            119
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 2,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            1,
-            2,
-            3
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            99,
-            119
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 3,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            1,
-            2
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            36,
-            99
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 4,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            2,
-            3
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            36,
-            99
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 5,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            1,
-            2,
-            3
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            36,
-            99
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 6,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            1,
-            2
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            40,
-            99
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 7,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            2,
-            3
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            40,
-            99
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 8,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            1,
-            2,
-            3
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            40,
-            99
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 9,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            1,
-            2
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            30,
-            99
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 10,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            2,
-            3
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            30,
-            99
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 11,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            1,
-            2,
-            3
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            30,
-            99
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 12,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            1,
-            2
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            99
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 13,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            2,
-            3
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            99
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 14,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            1,
-            2,
-            3
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            99
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 15,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            4
-        ],
-        "conditionQualifier_id": 55,
-        "therapies": [
-            7,
-            6,
-            122
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 16,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            5
-        ],
-        "conditionQualifier_id": 55,
-        "therapies": [
-            7,
-            6,
-            122
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 17,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            6
-        ],
-        "conditionQualifier_id": 55,
-        "therapies": [
-            7,
-            6,
-            122
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 18,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            7
-        ],
-        "conditionQualifier_id": 55,
-        "therapies": [
-            7,
-            6,
-            122
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 19,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            45
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            54
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 20,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            20
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            52
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 21,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            72
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            34
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 22,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            8
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            9
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 23,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            1,
-            2,
-            59
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            77,
-            30
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 24,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            2,
-            3,
-            59
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            77,
-            30
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 25,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            1,
-            2,
-            3,
-            59
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            77,
-            30
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 26,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            86
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            37,
-            49,
-            108
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 27,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            86
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            108
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 28,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            79
-        ],
-        "conditionQualifier_id": 10,
-        "therapies": [
-            93
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 29,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            12
-        ],
-        "conditionQualifier_id": 13,
-        "therapies": [
-            83
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 30,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            12,
-            32
-        ],
-        "conditionQualifier_id": 13,
-        "therapies": [
-            83
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 31,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            33
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            89
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 32,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            39
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            89
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 33,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            73
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            89
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 34,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            34,
-            35
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            89,
-            11,
-            35,
-            37
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 35,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            34,
-            35
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            89,
-            35,
-            37
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 36,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            72
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            89
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 37,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            8
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            89
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 38,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            16
-        ],
-        "conditionQualifier_id": 40,
-        "therapies": [
-            89,
-            21,
-            22
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 39,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            17
-        ],
-        "conditionQualifier_id": 40,
-        "therapies": [
-            89,
-            21,
-            22
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 40,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            11
-        ],
-        "conditionQualifier_id": 22,
-        "therapies": [
-            13
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 41,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            16
-        ],
-        "conditionQualifier_id": 40,
-        "therapies": [
-            17,
-            18
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 42,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            17
-        ],
-        "conditionQualifier_id": 40,
-        "therapies": [
-            17,
-            18
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 43,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            16
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            17,
-            18
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 45,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            14
-        ],
-        "conditionQualifier_id": 0,
-        "therapies": [
-            15
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 46,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            14,
-            15
-        ],
-        "conditionQualifier_id": 0,
-        "therapies": [
-            15
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 47,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            12
-        ],
-        "conditionQualifier_id": 13,
-        "therapies": [
-            16
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 48,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            0
-        ],
-        "conditionQualifier_id": 3,
-        "therapies": [
-            0,
-            59,
-            2,
-            122
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 49,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            0
-        ],
-        "conditionQualifier_id": 3,
-        "therapies": [
-            0
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 50,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            8
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            10
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 51,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            20
-        ],
-        "conditionQualifier_id": 2,
-        "therapies": [
-            38
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 52,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            1,
-            2,
-            59
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            109,
-            30
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 53,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            2,
-            3,
-            59
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            109,
-            30
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 54,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            1,
-            2,
-            3,
-            59
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            109,
-            30
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 55,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            1,
-            2,
-            90
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            109,
-            30
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 56,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            2,
-            3,
-            90
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            109,
-            30
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 57,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            1,
-            2,
-            3,
-            90
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            109,
-            30
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 58,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            1,
-            2,
-            89
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            109,
-            30
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 59,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            2,
-            3,
-            89
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            109,
-            30
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 60,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            1,
-            2,
-            3,
-            89
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            109,
-            30
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 61,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            1,
-            2,
-            91
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            109,
-            30
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 62,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            2,
-            3,
-            91
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            109,
-            30
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 63,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            1,
-            2,
-            3,
-            91
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            109,
-            30
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 64,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            1,
-            2,
-            92
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            109,
-            30
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 65,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            2,
-            3,
-            92
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            109,
-            30
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 66,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            1,
-            2,
-            3,
-            92
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            109,
-            30
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 67,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            1,
-            2,
-            93
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            109,
-            30
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 68,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            2,
-            3,
-            93
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            109,
-            30
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 69,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            1,
-            2,
-            3,
-            93
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            109,
-            30
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 70,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            1,
-            2,
-            94
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            109,
-            30
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 71,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            2,
-            3,
-            94
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            109,
-            30
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 72,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            1,
-            2,
-            3,
-            94
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            109,
-            30
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 73,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            67
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            85
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 74,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            68
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            85
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 75,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            34,
-            35,
-            46
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            37,
-            55,
-            49
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 76,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            34,
-            35,
-            36,
-            39
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            55
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 77,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            8
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            106
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 78,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            24,
-            25
-        ],
-        "conditionQualifier_id": 15,
-        "therapies": [
-            19,
-            27,
-            29
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 79,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            24,
-            25
-        ],
-        "conditionQualifier_id": 15,
-        "therapies": [
-            19,
-            27
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 80,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            24,
-            25
-        ],
-        "conditionQualifier_id": 15,
-        "therapies": [
-            19
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 81,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            16
-        ],
-        "conditionQualifier_id": 15,
-        "therapies": [
-            18,
-            19
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 82,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            16
-        ],
-        "conditionQualifier_id": 40,
-        "therapies": [
-            21,
-            22
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 83,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            17
-        ],
-        "conditionQualifier_id": 40,
-        "therapies": [
-            21,
-            22
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 84,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            8
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            102
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 85,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            62
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            102
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 86,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            8
-        ],
-        "conditionQualifier_id": 3,
-        "therapies": [
-            102
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 87,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            8
-        ],
-        "conditionQualifier_id": 28,
-        "therapies": [
-            102
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 88,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            16
-        ],
-        "conditionQualifier_id": 40,
-        "therapies": [
-            67
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 89,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            16
-        ],
-        "conditionQualifier_id": 40,
-        "therapies": [
-            67,
-            66
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 90,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            17
-        ],
-        "conditionQualifier_id": 40,
-        "therapies": [
-            67,
-            66
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 91,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            16
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            67,
-            66
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 92,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            16
-        ],
-        "conditionQualifier_id": 4,
-        "therapies": [
-            67,
-            66
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 93,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            16
-        ],
-        "conditionQualifier_id": 5,
-        "therapies": [
-            67,
-            66
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 94,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            16
-        ],
-        "conditionQualifier_id": 35,
-        "therapies": [
-            67,
-            66
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 95,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            10
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            101
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 96,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            9
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            101
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 97,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            12
-        ],
-        "conditionQualifier_id": 13,
-        "therapies": [
-            84
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 98,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            12
-        ],
-        "conditionQualifier_id": 71,
-        "therapies": [
-            84
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 99,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            12
-        ],
-        "conditionQualifier_id": 0,
-        "therapies": [
-            84
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 100,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            36
-        ],
-        "conditionQualifier_id": 18,
-        "therapies": [
-            37,
-            47,
-            35
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 101,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            38
-        ],
-        "conditionQualifier_id": 18,
-        "therapies": [
-            37,
-            47,
-            35
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 102,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            36
-        ],
-        "conditionQualifier_id": 18,
-        "therapies": [
-            47
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 103,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            36
-        ],
-        "conditionQualifier_id": 5,
-        "therapies": [
-            47
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 104,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            34,
-            35
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            44,
-            45,
-            49,
-            37
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 105,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            34,
-            35
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            44,
-            45,
-            49,
-            39
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 106,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            34,
-            35
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            44,
-            45,
-            50,
-            37
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 107,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            34,
-            35
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            44,
-            45,
-            50,
-            39
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 108,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            34,
-            35
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            44,
-            45,
-            51,
-            37
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 109,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            36
-        ],
-        "conditionQualifier_id": 18,
-        "therapies": [
-            37,
-            44,
-            35
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 110,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            1,
-            2,
-            58
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            74
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 111,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            107
-        ],
-        "conditionQualifier_id": 1,
-        "therapies": [
-            126
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 112,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            108
-        ],
-        "conditionQualifier_id": 1,
-        "therapies": [
-            126
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 113,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            109
-        ],
-        "conditionQualifier_id": 1,
-        "therapies": [
-            126
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 114,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            110
-        ],
-        "conditionQualifier_id": 1,
-        "therapies": [
-            126
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 115,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            111
-        ],
-        "conditionQualifier_id": 1,
-        "therapies": [
-            126
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 116,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            112
-        ],
-        "conditionQualifier_id": 1,
-        "therapies": [
-            126
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 117,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            113
-        ],
-        "conditionQualifier_id": 1,
-        "therapies": [
-            126
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 118,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            114
-        ],
-        "conditionQualifier_id": 1,
-        "therapies": [
-            126
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 119,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            115
-        ],
-        "conditionQualifier_id": 1,
-        "therapies": [
-            126
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 120,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            62
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            80
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 121,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            63
-        ],
-        "conditionQualifier_id": 5,
-        "therapies": [
-            80
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 122,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            64
-        ],
-        "conditionQualifier_id": 5,
-        "therapies": [
-            80
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 123,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            65
-        ],
-        "conditionQualifier_id": 5,
-        "therapies": [
-            80
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 124,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            99
-        ],
-        "conditionQualifier_id": 8,
-        "therapies": [
-            110
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 125,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            100
-        ],
-        "conditionQualifier_id": 8,
-        "therapies": [
-            110
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 126,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            101
-        ],
-        "conditionQualifier_id": 8,
-        "therapies": [
-            110
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 127,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            102
-        ],
-        "conditionQualifier_id": 8,
-        "therapies": [
-            110
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 128,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            97
-        ],
-        "conditionQualifier_id": 8,
-        "therapies": [
-            110
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 129,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            10
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            12
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 130,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            9
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            12
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 131,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            1,
-            2
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            4,
-            5
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 132,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            2,
-            3
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            4,
-            5
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 133,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            1,
-            2,
-            3
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            4,
-            5
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 134,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            1,
-            2
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            30
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 135,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            2,
-            3
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            30
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 136,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            1,
-            2,
-            3
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            30
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 137,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            1
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            30
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 138,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            3
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            30
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 139,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            1,
-            3
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            30
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 140,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            1,
-            2
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            30,
-            53
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 141,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            2,
-            3
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            30,
-            53
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 142,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            1,
-            2,
-            3
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            30,
-            53
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 143,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            1,
-            2
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            30,
-            31
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 144,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            2,
-            3
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            30,
-            31
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 145,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            1,
-            2,
-            3
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            30,
-            31
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 146,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            52
-        ],
-        "conditionQualifier_id": 29,
-        "therapies": [
-            58
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 147,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            10
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            33
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 148,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            9
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            33
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 149,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            55
-        ],
-        "conditionQualifier_id": 0,
-        "therapies": [
-            69
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 150,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            66
-        ],
-        "conditionQualifier_id": 0,
-        "therapies": [
-            104
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 151,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            85
-        ],
-        "conditionQualifier_id": 0,
-        "therapies": [
-            104
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 152,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            116
-        ],
-        "conditionQualifier_id": 0,
-        "therapies": [
-            104
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 153,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            117
-        ],
-        "conditionQualifier_id": 0,
-        "therapies": [
-            104
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 154,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            118
-        ],
-        "conditionQualifier_id": 0,
-        "therapies": [
-            104
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 155,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            119
-        ],
-        "conditionQualifier_id": 0,
-        "therapies": [
-            104
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 156,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            120
-        ],
-        "conditionQualifier_id": 0,
-        "therapies": [
-            104
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 157,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            121
-        ],
-        "conditionQualifier_id": 0,
-        "therapies": [
-            104
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 158,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            12
-        ],
-        "conditionQualifier_id": 13,
-        "therapies": [
-            41
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 159,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            12
-        ],
-        "conditionQualifier_id": 71,
-        "therapies": [
-            41
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 160,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            12
-        ],
-        "conditionQualifier_id": 0,
-        "therapies": [
-            41
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 161,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            28
-        ],
-        "conditionQualifier_id": 43,
-        "therapies": [
-            41
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 162,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            29
-        ],
-        "conditionQualifier_id": 43,
-        "therapies": [
-            41
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 163,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            122
-        ],
-        "conditionQualifier_id": 42,
-        "therapies": [
-            41
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 164,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            30
-        ],
-        "conditionQualifier_id": 12,
-        "therapies": [
-            41
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 165,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            31
-        ],
-        "conditionQualifier_id": 22,
-        "therapies": [
-            41
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 166,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            30
-        ],
-        "conditionQualifier_id": 22,
-        "therapies": [
-            41
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 167,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            52
-        ],
-        "conditionQualifier_id": 11,
-        "therapies": [
-            127
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 168,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            13
-        ],
-        "conditionQualifier_id": 0,
-        "therapies": [
-            14
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 169,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            38
-        ],
-        "conditionQualifier_id": 15,
-        "therapies": [
-            71,
-            72
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 170,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            37
-        ],
-        "conditionQualifier_id": 15,
-        "therapies": [
-            71,
-            72
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 171,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            33,
-            34,
-            35
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            71,
-            72
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 172,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            34,
-            35
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            37,
-            71,
-            72,
-            49
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 173,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            34,
-            35
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            39,
-            71,
-            72,
-            49
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 174,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            34,
-            35
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            37,
-            71,
-            72,
-            35
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 175,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            74
-        ],
-        "conditionQualifier_id": 1,
-        "therapies": [
-            92
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 176,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            75
-        ],
-        "conditionQualifier_id": 1,
-        "therapies": [
-            92
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 177,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            76
-        ],
-        "conditionQualifier_id": 1,
-        "therapies": [
-            92
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 178,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            77
-        ],
-        "conditionQualifier_id": 1,
-        "therapies": [
-            92
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 179,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            78
-        ],
-        "conditionQualifier_id": 1,
-        "therapies": [
-            92
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 180,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            74
-        ],
-        "conditionQualifier_id": 1,
-        "therapies": [
-            91,
-            92
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 181,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            75
-        ],
-        "conditionQualifier_id": 1,
-        "therapies": [
-            91,
-            92
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 182,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            76
-        ],
-        "conditionQualifier_id": 1,
-        "therapies": [
-            91,
-            92
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 183,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            77
-        ],
-        "conditionQualifier_id": 1,
-        "therapies": [
-            91,
-            92
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 184,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            78
-        ],
-        "conditionQualifier_id": 1,
-        "therapies": [
-            91,
-            92
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 185,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            74
-        ],
-        "conditionQualifier_id": 43,
-        "therapies": [
-            92
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 186,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            75
-        ],
-        "conditionQualifier_id": 43,
-        "therapies": [
-            92
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 187,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            76
-        ],
-        "conditionQualifier_id": 43,
-        "therapies": [
-            92
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 188,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            77
-        ],
-        "conditionQualifier_id": 43,
-        "therapies": [
-            92
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 189,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            78
-        ],
-        "conditionQualifier_id": 43,
-        "therapies": [
-            92
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 190,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            74
-        ],
-        "conditionQualifier_id": 11,
-        "therapies": [
-            92
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 191,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            75
-        ],
-        "conditionQualifier_id": 11,
-        "therapies": [
-            92
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 192,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            76
-        ],
-        "conditionQualifier_id": 11,
-        "therapies": [
-            92
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 193,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            77
-        ],
-        "conditionQualifier_id": 11,
-        "therapies": [
-            92
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 194,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            78
-        ],
-        "conditionQualifier_id": 11,
-        "therapies": [
-            92
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 195,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            20
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            38,
-            96
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 196,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            1,
-            20
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            96,
-            40
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 197,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            3,
-            20
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            96,
-            40
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 198,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            1,
-            3,
-            20
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            96,
-            40
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 199,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            63
-        ],
-        "conditionQualifier_id": 5,
-        "therapies": [
-            100
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 200,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            64
-        ],
-        "conditionQualifier_id": 5,
-        "therapies": [
-            100
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 201,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            65
-        ],
-        "conditionQualifier_id": 5,
-        "therapies": [
-            100
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 202,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            61
-        ],
-        "conditionQualifier_id": 43,
-        "therapies": [
-            79
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 203,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            8
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            56
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 204,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            20
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            38,
-            128
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 205,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            20
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            129,
-            128
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 206,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            20
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            50,
-            128
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 207,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            20
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            128,
-            117
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 208,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            66
-        ],
-        "conditionQualifier_id": 1,
-        "therapies": [
-            63,
-            68,
-            82
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 209,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            85
-        ],
-        "conditionQualifier_id": 1,
-        "therapies": [
-            63,
-            68,
-            82
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 210,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            116
-        ],
-        "conditionQualifier_id": 1,
-        "therapies": [
-            63,
-            68,
-            82
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 211,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            117
-        ],
-        "conditionQualifier_id": 1,
-        "therapies": [
-            63,
-            68,
-            82
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 212,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            118
-        ],
-        "conditionQualifier_id": 1,
-        "therapies": [
-            63,
-            68,
-            82
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 213,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            119
-        ],
-        "conditionQualifier_id": 1,
-        "therapies": [
-            63,
-            68,
-            82
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 214,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            120
-        ],
-        "conditionQualifier_id": 1,
-        "therapies": [
-            63,
-            68,
-            82
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 215,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            121
-        ],
-        "conditionQualifier_id": 1,
-        "therapies": [
-            63,
-            68,
-            82
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 216,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            123
-        ],
-        "conditionQualifier_id": 1,
-        "therapies": [
-            63,
-            68,
-            82
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 217,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            125
-        ],
-        "conditionQualifier_id": 1,
-        "therapies": [
-            63,
-            68,
-            82
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 218,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            86
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            130
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 219,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            20
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            70
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 220,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            20
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            38,
-            70
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 221,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            12
-        ],
-        "conditionQualifier_id": 13,
-        "therapies": [
-            88
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 222,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            12
-        ],
-        "conditionQualifier_id": 71,
-        "therapies": [
-            88
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 223,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            48
-        ],
-        "conditionQualifier_id": 51,
-        "therapies": [
-            6
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 224,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            50
-        ],
-        "conditionQualifier_id": 51,
-        "therapies": [
-            6
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 225,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            48
-        ],
-        "conditionQualifier_id": 27,
-        "therapies": [
-            6
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 226,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            50
-        ],
-        "conditionQualifier_id": 27,
-        "therapies": [
-            6
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 227,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            48
-        ],
-        "conditionQualifier_id": 54,
-        "therapies": [
-            6
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 228,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            50
-        ],
-        "conditionQualifier_id": 54,
-        "therapies": [
-            6
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 229,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            34,
-            35
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            37,
-            72,
-            35
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 230,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            33
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            71,
-            72
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 231,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            47
-        ],
-        "conditionQualifier_id": 51,
-        "therapies": [
-            46
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 232,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            48
-        ],
-        "conditionQualifier_id": 51,
-        "therapies": [
-            46
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 233,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            49
-        ],
-        "conditionQualifier_id": 51,
-        "therapies": [
-            46
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 234,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            50
-        ],
-        "conditionQualifier_id": 51,
-        "therapies": [
-            46
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 235,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            47
-        ],
-        "conditionQualifier_id": 27,
-        "therapies": [
-            46
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 236,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            48
-        ],
-        "conditionQualifier_id": 27,
-        "therapies": [
-            46
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 237,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            49
-        ],
-        "conditionQualifier_id": 27,
-        "therapies": [
-            46
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 238,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            50
-        ],
-        "conditionQualifier_id": 27,
-        "therapies": [
-            46
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 239,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            47
-        ],
-        "conditionQualifier_id": 54,
-        "therapies": [
-            46
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 240,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            48
-        ],
-        "conditionQualifier_id": 54,
-        "therapies": [
-            46
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 241,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            49
-        ],
-        "conditionQualifier_id": 54,
-        "therapies": [
-            46
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 242,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            50
-        ],
-        "conditionQualifier_id": 54,
-        "therapies": [
-            46
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 243,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            47
-        ],
-        "conditionQualifier_id": 51,
-        "therapies": [
-            11,
-            46
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 244,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            48
-        ],
-        "conditionQualifier_id": 51,
-        "therapies": [
-            11,
-            46
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 245,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            49
-        ],
-        "conditionQualifier_id": 51,
-        "therapies": [
-            11,
-            46
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 246,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            50
-        ],
-        "conditionQualifier_id": 51,
-        "therapies": [
-            11,
-            46
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 247,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            51
-        ],
-        "conditionQualifier_id": 51,
-        "therapies": [
-            11,
-            46
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 248,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            47
-        ],
-        "conditionQualifier_id": 27,
-        "therapies": [
-            11,
-            46
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 249,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            48
-        ],
-        "conditionQualifier_id": 27,
-        "therapies": [
-            11,
-            46
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 250,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            49
-        ],
-        "conditionQualifier_id": 27,
-        "therapies": [
-            11,
-            46
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 251,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            50
-        ],
-        "conditionQualifier_id": 27,
-        "therapies": [
-            11,
-            46
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 252,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            51
-        ],
-        "conditionQualifier_id": 27,
-        "therapies": [
-            11,
-            46
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 253,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            47
-        ],
-        "conditionQualifier_id": 54,
-        "therapies": [
-            11,
-            46
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 254,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            48
-        ],
-        "conditionQualifier_id": 54,
-        "therapies": [
-            11,
-            46
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 255,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            49
-        ],
-        "conditionQualifier_id": 54,
-        "therapies": [
-            11,
-            46
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 256,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            50
-        ],
-        "conditionQualifier_id": 54,
-        "therapies": [
-            11,
-            46
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 257,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            51
-        ],
-        "conditionQualifier_id": 54,
-        "therapies": [
-            11,
-            46
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 258,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            48,
-            2
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            46
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 259,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            50,
-            2
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            46
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 260,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            48
-        ],
-        "conditionQualifier_id": 52,
-        "therapies": [
-            46
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 261,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            50
-        ],
-        "conditionQualifier_id": 52,
-        "therapies": [
-            46
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 262,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            47
-        ],
-        "conditionQualifier_id": 55,
-        "therapies": [
-            138,
-            87
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 263,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            47
-        ],
-        "conditionQualifier_id": 55,
-        "therapies": [
-            46
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 264,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            48
-        ],
-        "conditionQualifier_id": 55,
-        "therapies": [
-            46
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 265,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            49
-        ],
-        "conditionQualifier_id": 55,
-        "therapies": [
-            46
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 266,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            50
-        ],
-        "conditionQualifier_id": 55,
-        "therapies": [
-            46
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 267,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            104
-        ],
-        "conditionQualifier_id": 55,
-        "therapies": [
-            46
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 268,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            105
-        ],
-        "conditionQualifier_id": 55,
-        "therapies": [
-            46
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 269,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            106
-        ],
-        "conditionQualifier_id": 55,
-        "therapies": [
-            46
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 270,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            4
-        ],
-        "conditionQualifier_id": 55,
-        "therapies": [
-            46
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 271,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            5
-        ],
-        "conditionQualifier_id": 55,
-        "therapies": [
-            46
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 272,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            6
-        ],
-        "conditionQualifier_id": 55,
-        "therapies": [
-            46
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 273,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            7
-        ],
-        "conditionQualifier_id": 55,
-        "therapies": [
-            46
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 274,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            125
-        ],
-        "conditionQualifier_id": 55,
-        "therapies": [
-            46
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 275,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            126
-        ],
-        "conditionQualifier_id": 55,
-        "therapies": [
-            46
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 276,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            127
-        ],
-        "conditionQualifier_id": 55,
-        "therapies": [
-            46
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 277,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            128
-        ],
-        "conditionQualifier_id": 55,
-        "therapies": [
-            46
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 278,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            129
-        ],
-        "conditionQualifier_id": 55,
-        "therapies": [
-            46
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 279,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            130
-        ],
-        "conditionQualifier_id": 55,
-        "therapies": [
-            46
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 280,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            131
-        ],
-        "conditionQualifier_id": 55,
-        "therapies": [
-            46
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 281,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            132
-        ],
-        "conditionQualifier_id": 55,
-        "therapies": [
-            46
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 282,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            133
-        ],
-        "conditionQualifier_id": 55,
-        "therapies": [
-            46
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 283,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            134
-        ],
-        "conditionQualifier_id": 55,
-        "therapies": [
-            46
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 284,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            135
-        ],
-        "conditionQualifier_id": 55,
-        "therapies": [
-            87
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 285,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            136
-        ],
-        "conditionQualifier_id": 55,
-        "therapies": [
-            46
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 286,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            137
-        ],
-        "conditionQualifier_id": 55,
-        "therapies": [
-            46
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 287,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            138
-        ],
-        "conditionQualifier_id": 55,
-        "therapies": [
-            46
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 288,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            139
-        ],
-        "conditionQualifier_id": 55,
-        "therapies": [
-            46
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 289,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            140
-        ],
-        "conditionQualifier_id": 55,
-        "therapies": [
-            46
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 290,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            141
-        ],
-        "conditionQualifier_id": 55,
-        "therapies": [
-            46
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 291,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            47
-        ],
-        "conditionQualifier_id": 55,
-        "therapies": [
-            7,
-            46,
-            8
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 292,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            48
-        ],
-        "conditionQualifier_id": 55,
-        "therapies": [
-            7,
-            46,
-            8
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 293,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            49
-        ],
-        "conditionQualifier_id": 55,
-        "therapies": [
-            7,
-            46,
-            8
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 294,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            50
-        ],
-        "conditionQualifier_id": 55,
-        "therapies": [
-            7,
-            46,
-            8
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 295,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            47
-        ],
-        "conditionQualifier_id": 55,
-        "therapies": [
-            7,
-            46,
-            122
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 296,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            48
-        ],
-        "conditionQualifier_id": 55,
-        "therapies": [
-            7,
-            46,
-            122
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 297,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            49
-        ],
-        "conditionQualifier_id": 55,
-        "therapies": [
-            7,
-            46,
-            122
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 298,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            50
-        ],
-        "conditionQualifier_id": 55,
-        "therapies": [
-            7,
-            46,
-            122
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 299,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            74
-        ],
-        "conditionQualifier_id": 1,
-        "therapies": [
-            131
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 300,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            75
-        ],
-        "conditionQualifier_id": 1,
-        "therapies": [
-            131
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 301,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            76
-        ],
-        "conditionQualifier_id": 1,
-        "therapies": [
-            131
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 302,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            77
-        ],
-        "conditionQualifier_id": 1,
-        "therapies": [
-            131
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 303,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            78
-        ],
-        "conditionQualifier_id": 1,
-        "therapies": [
-            131
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 304,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            10
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            86
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 305,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            9
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            86
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 306,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            9
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            39,
-            86,
-            49
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 307,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            9
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            37,
-            86,
-            49
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 308,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            10
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            37,
-            86,
-            49
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 309,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            10
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            39,
-            86,
-            49
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 310,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            70
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            86
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 311,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            1,
-            2
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            40,
-            31
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 312,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            2,
-            3
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            40,
-            31
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 313,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            1,
-            2,
-            3
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            40,
-            31
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 314,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            25,
-            26
-        ],
-        "conditionQualifier_id": 15,
-        "therapies": [
-            28,
-            97,
-            29
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 315,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            25,
-            26
-        ],
-        "conditionQualifier_id": 15,
-        "therapies": [
-            97
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 316,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            34,
-            35
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            37,
-            48,
-            49
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 317,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            34,
-            35
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            39,
-            48,
-            49
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 318,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            33,
-            34,
-            35
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            48
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 319,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            33
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            48
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 320,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            42
-        ],
-        "conditionQualifier_id": 25,
-        "therapies": [
-            48
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 321,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            36
-        ],
-        "conditionQualifier_id": 5,
-        "therapies": [
-            48
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 322,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            38
-        ],
-        "conditionQualifier_id": 5,
-        "therapies": [
-            48
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 323,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            36
-        ],
-        "conditionQualifier_id": 15,
-        "therapies": [
-            48
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 324,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            38
-        ],
-        "conditionQualifier_id": 15,
-        "therapies": [
-            48
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 325,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            20,
-            42
-        ],
-        "conditionQualifier_id": 2,
-        "therapies": [
-            39,
-            48,
-            25,
-            29
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 326,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            20,
-            42
-        ],
-        "conditionQualifier_id": 2,
-        "therapies": [
-            38,
-            28,
-            48,
-            25
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 327,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            2
-        ],
-        "conditionQualifier_id": 2,
-        "therapies": [
-            39,
-            48,
-            29
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 328,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            2
-        ],
-        "conditionQualifier_id": 2,
-        "therapies": [
-            38,
-            28,
-            48
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 329,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            41
-        ],
-        "conditionQualifier_id": 2,
-        "therapies": [
-            48
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 330,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            41
-        ],
-        "conditionQualifier_id": 74,
-        "therapies": [
-            48
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 331,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            42
-        ],
-        "conditionQualifier_id": 72,
-        "therapies": [
-            39,
-            35,
-            48
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 332,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            42
-        ],
-        "conditionQualifier_id": 73,
-        "therapies": [
-            39,
-            35,
-            48
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 333,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            42
-        ],
-        "conditionQualifier_id": 72,
-        "therapies": [
-            11,
-            39,
-            35,
-            48
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 334,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            42
-        ],
-        "conditionQualifier_id": 73,
-        "therapies": [
-            11,
-            39,
-            35,
-            48
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 335,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            42
-        ],
-        "conditionQualifier_id": 72,
-        "therapies": [
-            37,
-            35,
-            48
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 336,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            42
-        ],
-        "conditionQualifier_id": 73,
-        "therapies": [
-            37,
-            35,
-            48
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 337,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            42
-        ],
-        "conditionQualifier_id": 72,
-        "therapies": [
-            11,
-            37,
-            35,
-            48
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 338,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            42
-        ],
-        "conditionQualifier_id": 73,
-        "therapies": [
-            11,
-            37,
-            35,
-            48
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 339,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            42
-        ],
-        "conditionQualifier_id": 72,
-        "therapies": [
-            48
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 340,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            42
-        ],
-        "conditionQualifier_id": 73,
-        "therapies": [
-            48
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 341,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            142
-        ],
-        "conditionQualifier_id": 18,
-        "therapies": [
-            132,
-            48
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 342,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            37
-        ],
-        "conditionQualifier_id": 18,
-        "therapies": [
-            48
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 343,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            38
-        ],
-        "conditionQualifier_id": 18,
-        "therapies": [
-            48
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 344,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            144
-        ],
-        "conditionQualifier_id": 5,
-        "therapies": [
-            48
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 345,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            43,
-            2,
-            44
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            37,
-            59,
-            2,
-            35,
-            48
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 346,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            41,
-            43,
-            2,
-            44
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            35,
-            48
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 347,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            41,
-            43,
-            2,
-            44
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            37,
-            50,
-            48
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 348,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            52
-        ],
-        "conditionQualifier_id": 11,
-        "therapies": [
-            133
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 349,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            53
-        ],
-        "conditionQualifier_id": 11,
-        "therapies": [
-            133
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 350,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            69
-        ],
-        "conditionQualifier_id": 44,
-        "therapies": [
-            133
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 351,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            20
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            24,
-            75,
-            25
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 352,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            20
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            59,
-            2,
-            35,
-            75,
-            25
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 353,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            20
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            59,
-            24,
-            76,
-            75,
-            25,
-            29
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 354,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            20
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            59,
-            76,
-            35,
-            75,
-            25,
-            29
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 355,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            20
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            59,
-            24,
-            2,
-            75,
-            25,
-            29
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 356,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            20
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            59,
-            2,
-            35,
-            75,
-            25,
-            29
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 357,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            20
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            59,
-            24,
-            76,
-            75,
-            25
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 358,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            20
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            59,
-            76,
-            35,
-            75,
-            25
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 359,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            20
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            59,
-            24,
-            2,
-            75,
-            25
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 360,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            20
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            37,
-            24,
-            75,
-            25
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 361,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            12
-        ],
-        "conditionQualifier_id": 0,
-        "therapies": [
-            63,
-            65,
-            43,
-            122,
-            61
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 362,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            32,
-            12
-        ],
-        "conditionQualifier_id": 0,
-        "therapies": [
-            43
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 363,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            32
-        ],
-        "conditionQualifier_id": 13,
-        "therapies": [
-            43
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 364,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            18
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            32
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 365,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            18
-        ],
-        "conditionQualifier_id": 75,
-        "therapies": [
-            32
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 366,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            10
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            12,
-            23
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 367,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            9
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            12,
-            23
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 368,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            62
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            134
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 369,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            63
-        ],
-        "conditionQualifier_id": 5,
-        "therapies": [
-            134
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 370,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            64
-        ],
-        "conditionQualifier_id": 5,
-        "therapies": [
-            134
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 371,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            65
-        ],
-        "conditionQualifier_id": 5,
-        "therapies": [
-            134
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 372,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            1,
-            2
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            36,
-            53
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 373,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            2,
-            3
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            36,
-            53
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 374,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            1,
-            2,
-            3
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            36,
-            53
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 375,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            1,
-            2
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            40,
-            53
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 376,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            2,
-            3
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            40,
-            53
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 377,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            1,
-            2,
-            3
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            40,
-            53
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 378,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            54
-        ],
-        "conditionQualifier_id": 76,
-        "therapies": [
-            60
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 379,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            54
-        ],
-        "conditionQualifier_id": 76,
-        "therapies": [
-            59,
-            60,
-            8,
-            61
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 380,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            54
-        ],
-        "conditionQualifier_id": 76,
-        "therapies": [
-            59,
-            2,
-            60,
-            8,
-            61
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 381,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            54
-        ],
-        "conditionQualifier_id": 76,
-        "therapies": [
-            59,
-            135,
-            124,
-            60
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 382,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            54
-        ],
-        "conditionQualifier_id": 76,
-        "therapies": [
-            59,
-            2,
-            60,
-            122,
-            61
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 383,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            54
-        ],
-        "conditionQualifier_id": 77,
-        "therapies": [
-            59,
-            2,
-            60,
-            122,
-            61
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 384,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            54
-        ],
-        "conditionQualifier_id": 78,
-        "therapies": [
-            59,
-            2,
-            60,
-            122,
-            61
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 385,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            54
-        ],
-        "conditionQualifier_id": 79,
-        "therapies": [
-            59,
-            2,
-            60,
-            122,
-            61
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 386,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            54
-        ],
-        "conditionQualifier_id": 84,
-        "therapies": [
-            59,
-            135,
-            60
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 387,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            47
-        ],
-        "conditionQualifier_id": 51,
-        "therapies": [
-            136
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 388,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            48
-        ],
-        "conditionQualifier_id": 51,
-        "therapies": [
-            136
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 389,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            49
-        ],
-        "conditionQualifier_id": 51,
-        "therapies": [
-            136
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 390,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            50
-        ],
-        "conditionQualifier_id": 51,
-        "therapies": [
-            136
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 391,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            47
-        ],
-        "conditionQualifier_id": 27,
-        "therapies": [
-            136
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 392,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            48
-        ],
-        "conditionQualifier_id": 27,
-        "therapies": [
-            136
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 393,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            49
-        ],
-        "conditionQualifier_id": 27,
-        "therapies": [
-            136
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 394,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            50
-        ],
-        "conditionQualifier_id": 27,
-        "therapies": [
-            136
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 395,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            47
-        ],
-        "conditionQualifier_id": 54,
-        "therapies": [
-            136
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 396,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            48
-        ],
-        "conditionQualifier_id": 54,
-        "therapies": [
-            136
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 397,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            49
-        ],
-        "conditionQualifier_id": 54,
-        "therapies": [
-            136
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 398,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            50
-        ],
-        "conditionQualifier_id": 54,
-        "therapies": [
-            136
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 399,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            47
-        ],
-        "conditionQualifier_id": 55,
-        "therapies": [
-            136
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 400,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            48
-        ],
-        "conditionQualifier_id": 55,
-        "therapies": [
-            136
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 401,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            49
-        ],
-        "conditionQualifier_id": 55,
-        "therapies": [
-            136
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 402,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            50
-        ],
-        "conditionQualifier_id": 55,
-        "therapies": [
-            136
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 403,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            43,
-            2,
-            44
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            94
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 404,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            1,
-            2
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            94
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 405,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            2,
-            3
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            94
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 406,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            1,
-            2,
-            3
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            94
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 407,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            18
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            78
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 408,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            152
-        ],
-        "conditionQualifier_id": 38,
-        "therapies": [
-            78
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 409,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            18
-        ],
-        "conditionQualifier_id": 4,
-        "therapies": [
-            78
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 410,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            18
-        ],
-        "conditionQualifier_id": 5,
-        "therapies": [
-            78
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 411,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            45
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            57
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 412,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            48,
-            2
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            87
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 413,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            50,
-            2
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            87
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 414,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            67
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            90
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 415,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            68
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            90
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 416,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            16
-        ],
-        "conditionQualifier_id": 40,
-        "therapies": [
-            66
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 417,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            17
-        ],
-        "conditionQualifier_id": 40,
-        "therapies": [
-            66
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 418,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            20
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            25
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 419,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            20
-        ],
-        "conditionQualifier_id": 22,
-        "therapies": [
-            25
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 420,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            20
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            26
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 421,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            22
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            26
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 422,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            23
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            26
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 423,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            20
-        ],
-        "conditionQualifier_id": 2,
-        "therapies": [
-            26
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 424,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            20
-        ],
-        "conditionQualifier_id": 5,
-        "therapies": [
-            26
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 425,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            20
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            38,
-            25,
-            95
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 426,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            16
-        ],
-        "conditionQualifier_id": 40,
-        "therapies": [
-            22
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 427,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            16
-        ],
-        "conditionQualifier_id": 46,
-        "therapies": [
-            22
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 428,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            17
-        ],
-        "conditionQualifier_id": 46,
-        "therapies": [
-            22
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 429,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            145
-        ],
-        "conditionQualifier_id": 20,
-        "therapies": [
-            137
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 430,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            146
-        ],
-        "conditionQualifier_id": 20,
-        "therapies": [
-            137
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 431,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            147
-        ],
-        "conditionQualifier_id": 20,
-        "therapies": [
-            137
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 432,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            148
-        ],
-        "conditionQualifier_id": 20,
-        "therapies": [
-            137
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 433,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            149
-        ],
-        "conditionQualifier_id": 20,
-        "therapies": [
-            137
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 434,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            150
-        ],
-        "conditionQualifier_id": 20,
-        "therapies": [
-            137
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 435,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            151
-        ],
-        "conditionQualifier_id": 20,
-        "therapies": [
-            137
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 436,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            48
-        ],
-        "conditionQualifier_id": 55,
-        "therapies": [
-            138,
-            87
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 437,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            49
-        ],
-        "conditionQualifier_id": 55,
-        "therapies": [
-            138,
-            87
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 438,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            50
-        ],
-        "conditionQualifier_id": 55,
-        "therapies": [
-            138,
-            87
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 439,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            104
-        ],
-        "conditionQualifier_id": 55,
-        "therapies": [
-            138,
-            87
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 440,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            105
-        ],
-        "conditionQualifier_id": 55,
-        "therapies": [
-            138,
-            87
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 441,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            160
-        ],
-        "conditionQualifier_id": 55,
-        "therapies": [
-            138,
-            87
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 442,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            125
-        ],
-        "conditionQualifier_id": 55,
-        "therapies": [
-            138,
-            87
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 443,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            161
-        ],
-        "conditionQualifier_id": 55,
-        "therapies": [
-            138,
-            87
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 444,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            162
-        ],
-        "conditionQualifier_id": 55,
-        "therapies": [
-            138,
-            87
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 445,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            128
-        ],
-        "conditionQualifier_id": 55,
-        "therapies": [
-            138,
-            87
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 446,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            129
-        ],
-        "conditionQualifier_id": 55,
-        "therapies": [
-            138,
-            87
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 447,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            163
-        ],
-        "conditionQualifier_id": 55,
-        "therapies": [
-            138,
-            87
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 448,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            164
-        ],
-        "conditionQualifier_id": 55,
-        "therapies": [
-            138,
-            87
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 449,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            132
-        ],
-        "conditionQualifier_id": 55,
-        "therapies": [
-            138,
-            87
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 450,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            133
-        ],
-        "conditionQualifier_id": 55,
-        "therapies": [
-            138,
-            87
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 451,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            165
-        ],
-        "conditionQualifier_id": 55,
-        "therapies": [
-            138,
-            87
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 452,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            166
-        ],
-        "conditionQualifier_id": 55,
-        "therapies": [
-            138,
-            87
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 453,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            136
-        ],
-        "conditionQualifier_id": 55,
-        "therapies": [
-            138,
-            87
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 454,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            137
-        ],
-        "conditionQualifier_id": 55,
-        "therapies": [
-            138,
-            87
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 455,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            167
-        ],
-        "conditionQualifier_id": 55,
-        "therapies": [
-            138,
-            87
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 456,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            168
-        ],
-        "conditionQualifier_id": 55,
-        "therapies": [
-            138,
-            87
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 457,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            169
-        ],
-        "conditionQualifier_id": 55,
-        "therapies": [
-            138,
-            87
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 458,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            158
-        ],
-        "conditionQualifier_id": 88,
-        "therapies": [
-            4
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 459,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            159
-        ],
-        "conditionQualifier_id": 88,
-        "therapies": [
-            4
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 460,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            158
-        ],
-        "conditionQualifier_id": 4,
-        "therapies": [
-            4
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 461,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            159
-        ],
-        "conditionQualifier_id": 4,
-        "therapies": [
-            4
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 462,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            7
-        ],
-        "conditionQualifier_id": 55,
-        "therapies": [
-            138,
-            87
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 463,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            10
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            139,
-            108
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 464,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            9
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            139,
-            108
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 465,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            10
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            108,
-            37,
-            49
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 466,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            9
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            108,
-            37,
-            49
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 467,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            153
-        ],
-        "conditionQualifier_id": 51,
-        "therapies": [
-            140
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 468,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            153
-        ],
-        "conditionQualifier_id": 27,
-        "therapies": [
-            140
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 469,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            153
-        ],
-        "conditionQualifier_id": 54,
-        "therapies": [
-            140
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 470,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            155
-        ],
-        "conditionQualifier_id": 35,
-        "therapies": [
-            141
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 471,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            154
-        ],
-        "conditionQualifier_id": 35,
-        "therapies": [
-            141
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 472,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            16
-        ],
-        "conditionQualifier_id": 35,
-        "therapies": [
-            141
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 473,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            17
-        ],
-        "conditionQualifier_id": 35,
-        "therapies": [
-            141
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 474,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            34,
-            35
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            37,
-            44,
-            35
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 475,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            34,
-            35
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            39,
-            44,
-            50
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 476,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            34,
-            35
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            39,
-            44,
-            49
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 477,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            34,
-            35
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            37,
-            44,
-            49
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 478,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            45
-        ],
-        "conditionQualifier_id": 15,
-        "therapies": [
-            54,
-            19
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 479,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            74
-        ],
-        "conditionQualifier_id": 6,
-        "therapies": [
-            142
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 480,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            75
-        ],
-        "conditionQualifier_id": 6,
-        "therapies": [
-            142
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 481,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            76
-        ],
-        "conditionQualifier_id": 6,
-        "therapies": [
-            142
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 482,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            77
-        ],
-        "conditionQualifier_id": 6,
-        "therapies": [
-            142
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 483,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            78
-        ],
-        "conditionQualifier_id": 6,
-        "therapies": [
-            142
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 484,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            111
-        ],
-        "conditionQualifier_id": 6,
-        "therapies": [
-            142
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 485,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            112
-        ],
-        "conditionQualifier_id": 6,
-        "therapies": [
-            142
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 486,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            113
-        ],
-        "conditionQualifier_id": 6,
-        "therapies": [
-            142
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 487,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            114
-        ],
-        "conditionQualifier_id": 6,
-        "therapies": [
-            142
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 488,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            115
-        ],
-        "conditionQualifier_id": 6,
-        "therapies": [
-            142
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 489,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            74
-        ],
-        "conditionQualifier_id": 48,
-        "therapies": [
-            142
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 490,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            75
-        ],
-        "conditionQualifier_id": 48,
-        "therapies": [
-            142
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 491,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            76
-        ],
-        "conditionQualifier_id": 48,
-        "therapies": [
-            142
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 492,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            77
-        ],
-        "conditionQualifier_id": 48,
-        "therapies": [
-            142
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 493,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            78
-        ],
-        "conditionQualifier_id": 48,
-        "therapies": [
-            142
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 494,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            111
-        ],
-        "conditionQualifier_id": 48,
-        "therapies": [
-            142
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 495,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            112
-        ],
-        "conditionQualifier_id": 48,
-        "therapies": [
-            142
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 496,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            113
-        ],
-        "conditionQualifier_id": 48,
-        "therapies": [
-            142
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 497,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            114
-        ],
-        "conditionQualifier_id": 48,
-        "therapies": [
-            142
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 498,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            115
-        ],
-        "conditionQualifier_id": 48,
-        "therapies": [
-            142
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 499,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            1,
-            2
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            36,
-            143,
-            53
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 500,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            2,
-            3
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            36,
-            143,
-            53
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 501,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            1,
-            2,
-            3
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            36,
-            143,
-            53
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 502,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            1,
-            2
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            143,
-            40,
-            53
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 503,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            2,
-            3
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            143,
-            40,
-            53
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 504,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            1,
-            2,
-            3
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            143,
-            40,
-            53
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 505,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            34,
-            35
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            39,
-            72,
-            49
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 506,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            34,
-            35
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            39,
-            50,
-            72
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 507,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            36
-        ],
-        "conditionQualifier_id": 15,
-        "therapies": [
-            71,
-            72
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 508,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            38
-        ],
-        "conditionQualifier_id": 15,
-        "therapies": [
-            72
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 509,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            36
-        ],
-        "conditionQualifier_id": 15,
-        "therapies": [
-            72
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 510,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            1,
-            2,
-            59
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            30,
-            144,
-            31
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 511,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            2,
-            3,
-            59
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            30,
-            144,
-            31
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 512,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            1,
-            2,
-            3,
-            59
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            30,
-            144,
-            31
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 513,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            2,
-            103
-        ],
-        "conditionQualifier_id": 2,
-        "therapies": [
-            29,
-            28,
-            111
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 514,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            2,
-            103
-        ],
-        "conditionQualifier_id": 2,
-        "therapies": [
-            38,
-            28,
-            111
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 515,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            20
-        ],
-        "conditionQualifier_id": 85,
-        "therapies": [
-            145
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 516,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            20
-        ],
-        "conditionQualifier_id": 86,
-        "therapies": [
-            145
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 517,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            20
-        ],
-        "conditionQualifier_id": 11,
-        "therapies": [
-            145
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 518,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            156
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            146
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 519,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            156
-        ],
-        "conditionQualifier_id": 52,
-        "therapies": [
-            146
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 520,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            8
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            147
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 521,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            16
-        ],
-        "conditionQualifier_id": 15,
-        "therapies": [
-            29,
-            19,
-            18,
-            28
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 522,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            12
-        ],
-        "conditionQualifier_id": 71,
-        "therapies": [
-            83
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 523,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            34,
-            35
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            37,
-            44,
-            45,
-            49
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 524,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            34,
-            35
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            39,
-            44,
-            45,
-            49
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 525,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            34,
-            35
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            37,
-            44,
-            50,
-            45
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 526,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            34,
-            35
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            39,
-            44,
-            50,
-            45
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 527,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            34,
-            35
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            37,
-            44,
-            51,
-            45
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 528,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            157
-        ],
-        "conditionQualifier_id": 0,
-        "therapies": [
-            148
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 529,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            157
-        ],
-        "conditionQualifier_id": 1,
-        "therapies": [
-            148
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 530,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            157
-        ],
-        "conditionQualifier_id": 78,
-        "therapies": [
-            148
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 531,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            157
-        ],
-        "conditionQualifier_id": 87,
-        "therapies": [
-            148
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 532,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            0
-        ],
-        "conditionQualifier_id": 80,
-        "therapies": [
-            0,
-            1,
-            2,
-            3
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 533,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            0
-        ],
-        "conditionQualifier_id": 80,
-        "therapies": [
-            0
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 534,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            0
-        ],
-        "conditionQualifier_id": 30,
-        "therapies": [
-            0
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 535,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            3,
-            2
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            4,
-            5
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 536,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            1,
-            3,
-            2
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            4,
-            5
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 537,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            47
-        ],
-        "conditionQualifier_id": 55,
-        "therapies": [
-            6,
-            7,
-            8
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 538,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            49
-        ],
-        "conditionQualifier_id": 55,
-        "therapies": [
-            6,
-            7,
-            8
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 539,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            48
-        ],
-        "conditionQualifier_id": 55,
-        "therapies": [
-            6,
-            7,
-            8
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 540,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            50
-        ],
-        "conditionQualifier_id": 55,
-        "therapies": [
-            6,
-            7,
-            8
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 541,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            9
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            11,
-            12
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 542,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            10
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            11,
-            12
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 543,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            15,
-            13
-        ],
-        "conditionQualifier_id": 0,
-        "therapies": [
-            14
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 544,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            15,
-            14
-        ],
-        "conditionQualifier_id": 0,
-        "therapies": [
-            15
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 545,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            15
-        ],
-        "conditionQualifier_id": 13,
-        "therapies": [
-            16
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 546,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            16
-        ],
-        "conditionQualifier_id": 15,
-        "therapies": [
-            19,
-            18
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 547,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            18
-        ],
-        "conditionQualifier_id": 38,
-        "therapies": [
-            20
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 548,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            19
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            12,
-            23
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 549,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            20
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            24,
-            25
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 550,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            21
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            24,
-            25
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 551,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            21
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            26
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 552,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            21
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            26
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 553,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            21
-        ],
-        "conditionQualifier_id": 2,
-        "therapies": [
-            26
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 554,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            24,
-            25,
-            26,
-            27
-        ],
-        "conditionQualifier_id": 15,
-        "therapies": [
-            19
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 555,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            24,
-            25,
-            26,
-            27
-        ],
-        "conditionQualifier_id": 15,
-        "therapies": [
-            19,
-            27
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 556,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            24,
-            25,
-            26,
-            27
-        ],
-        "conditionQualifier_id": 15,
-        "therapies": [
-            19,
-            28,
-            29
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 557,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            3,
-            2
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            30,
-            31
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 558,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            1,
-            3,
-            2
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            30,
-            31
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 559,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            19
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            33
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 560,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            19
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            34
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 561,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            20
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            35,
-            25
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 562,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            20
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            36,
-            25
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 563,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            20
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            37,
-            24,
-            25
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 564,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            20
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            2,
-            25,
-            35
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 565,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            21
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            25
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 566,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            21
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            35,
-            25
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 567,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            21
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            36,
-            25
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 568,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            21
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            37,
-            24,
-            25
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 569,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            21
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            2,
-            35,
-            25
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 570,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            20
-        ],
-        "conditionQualifier_id": 81,
-        "therapies": [
-            38,
-            39,
-            25
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 571,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            20
-        ],
-        "conditionQualifier_id": 81,
-        "therapies": [
-            39,
-            25,
-            29
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 572,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            21
-        ],
-        "conditionQualifier_id": 81,
-        "therapies": [
-            38,
-            39,
-            25
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 573,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            21
-        ],
-        "conditionQualifier_id": 81,
-        "therapies": [
-            39,
-            25,
-            29
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 574,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            2,
-            1
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            40,
-            31
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 575,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            2,
-            1,
-            3
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            40,
-            31
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 576,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            2,
-            1
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            30,
-            31
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 577,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            2,
-            1,
-            3
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            30,
-            31
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 578,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            15
-        ],
-        "conditionQualifier_id": 13,
-        "therapies": [
-            41
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 579,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            15
-        ],
-        "conditionQualifier_id": 0,
-        "therapies": [
-            41
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 580,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            28
-        ],
-        "conditionQualifier_id": 45,
-        "therapies": [
-            41
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 581,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            29
-        ],
-        "conditionQualifier_id": 45,
-        "therapies": [
-            41
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 582,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            15
-        ],
-        "conditionQualifier_id": 0,
-        "therapies": [
-            43
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 583,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            15,
-            32
-        ],
-        "conditionQualifier_id": 0,
-        "therapies": [
-            43
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 584,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            33
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            44
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 585,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            34,
-            35
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            37,
-            44,
-            45
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 586,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            37
-        ],
-        "conditionQualifier_id": 18,
-        "therapies": [
-            37,
-            44,
-            46,
-            35
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 587,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            38
-        ],
-        "conditionQualifier_id": 18,
-        "therapies": [
-            47
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 588,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            39,
-            35,
-            34
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            48
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 589,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            40,
-            35,
-            34
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            48
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 590,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            35,
-            34
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            37,
-            48,
-            49
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 591,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            35,
-            34
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            39,
-            48,
-            49
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 592,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            35,
-            34
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            39,
-            50,
-            48
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 593,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            35,
-            34
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            37,
-            50,
-            48
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 594,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            35,
-            34
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            37,
-            35,
-            48
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 595,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            41
-        ],
-        "conditionQualifier_id": 8,
-        "therapies": [
-            48
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 596,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            42
-        ],
-        "conditionQualifier_id": 25,
-        "therapies": [
-            37,
-            48,
-            29
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 597,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            42
-        ],
-        "conditionQualifier_id": 25,
-        "therapies": [
-            39,
-            48,
-            29
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 598,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            39
-        ],
-        "conditionQualifier_id": 25,
-        "therapies": [
-            48
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 599,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            36
-        ],
-        "conditionQualifier_id": 18,
-        "therapies": [
-            48
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 600,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            38
-        ],
-        "conditionQualifier_id": 81,
-        "therapies": [
-            48
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 601,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            36
-        ],
-        "conditionQualifier_id": 81,
-        "therapies": [
-            48
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 602,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            38
-        ],
-        "conditionQualifier_id": 22,
-        "therapies": [
-            48
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 603,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            36
-        ],
-        "conditionQualifier_id": 22,
-        "therapies": [
-            48
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 604,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            38
-        ],
-        "conditionQualifier_id": 11,
-        "therapies": [
-            48
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 605,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            36
-        ],
-        "conditionQualifier_id": 11,
-        "therapies": [
-            48
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 606,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            41
-        ],
-        "conditionQualifier_id": 74,
-        "therapies": [
-            39,
-            48,
-            29
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 607,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            41
-        ],
-        "conditionQualifier_id": 74,
-        "therapies": [
-            37,
-            48,
-            29
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 608,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            43,
-            2,
-            44
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            48
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 609,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            41,
-            43,
-            2,
-            44
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            51,
-            48
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 610,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            20,
-            42
-        ],
-        "conditionQualifier_id": 2,
-        "therapies": [
-            37,
-            48,
-            25,
-            29
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 611,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            2,
-            42
-        ],
-        "conditionQualifier_id": 2,
-        "therapies": [
-            39,
-            48,
-            29
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 612,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            2,
-            42
-        ],
-        "conditionQualifier_id": 2,
-        "therapies": [
-            37,
-            48,
-            29
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 613,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            21
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            52
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 614,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            3,
-            2
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            40,
-            53
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 615,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            1,
-            3,
-            2
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            40,
-            53
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 616,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            3,
-            2
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            30,
-            53
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 617,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            1,
-            3,
-            2
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            30,
-            53
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 618,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            39,
-            34,
-            35,
-            46
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            55
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 619,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            33,
-            34,
-            35,
-            46
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            37,
-            55,
-            49
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 620,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            37
-        ],
-        "conditionQualifier_id": 18,
-        "therapies": [
-            44,
-            46
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 621,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            53
-        ],
-        "conditionQualifier_id": 29,
-        "therapies": [
-            58
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 622,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            54
-        ],
-        "conditionQualifier_id": 77,
-        "therapies": [
-            59,
-            60,
-            2,
-            8,
-            61
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 623,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            54
-        ],
-        "conditionQualifier_id": 76,
-        "therapies": [
-            59,
-            60,
-            2,
-            8,
-            61
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 624,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            54
-        ],
-        "conditionQualifier_id": 77,
-        "therapies": [
-            59,
-            62,
-            63,
-            2,
-            64,
-            65,
-            60,
-            61
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 625,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            54
-        ],
-        "conditionQualifier_id": 76,
-        "therapies": [
-            59,
-            62,
-            63,
-            2,
-            64,
-            65,
-            60,
-            61
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 626,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            54
-        ],
-        "conditionQualifier_id": 78,
-        "therapies": [
-            59,
-            62,
-            63,
-            2,
-            64,
-            65,
-            60,
-            61
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 627,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            17
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            67,
-            66
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 628,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            55
-        ],
-        "conditionQualifier_id": 1,
-        "therapies": [
-            63,
-            68,
-            69
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 629,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            20,
-            1,
-            3
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            112
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 630,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            20,
-            1
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            112
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 631,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            20,
-            3
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            112
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 632,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            21,
-            1,
-            3
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            112
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 633,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            21,
-            1
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            112
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 634,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            21,
-            3
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            112
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 635,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            35,
-            34
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            37,
-            71,
-            72,
-            49
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 636,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            35,
-            34
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            39,
-            71,
-            72,
-            49
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 637,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            35,
-            34
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            37,
-            71,
-            72,
-            35
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 638,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            33
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            37,
-            72,
-            35
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 639,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            33
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            37,
-            72,
-            49
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 640,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            33
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            39,
-            50,
-            72
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 641,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            33
-        ],
-        "conditionQualifier_id": 8,
-        "therapies": [
-            72
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 642,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            33
-        ],
-        "conditionQualifier_id": 82,
-        "therapies": [
-            71,
-            72
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 643,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            33
-        ],
-        "conditionQualifier_id": 82,
-        "therapies": [
-            39,
-            72,
-            29
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 644,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            2,
-            56
-        ],
-        "conditionQualifier_id": 74,
-        "therapies": [
-            72,
-            28,
-            29
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 645,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            2,
-            56
-        ],
-        "conditionQualifier_id": 74,
-        "therapies": [
-            72,
-            28
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 646,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            2,
-            56
-        ],
-        "conditionQualifier_id": 81,
-        "therapies": [
-            72,
-            28,
-            29
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 647,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            2,
-            56
-        ],
-        "conditionQualifier_id": 81,
-        "therapies": [
-            72,
-            28
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 648,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            2,
-            56
-        ],
-        "conditionQualifier_id": 2,
-        "therapies": [
-            72,
-            28,
-            29
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 649,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            2,
-            56
-        ],
-        "conditionQualifier_id": 2,
-        "therapies": [
-            72,
-            28
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 650,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            57
-        ],
-        "conditionQualifier_id": 40,
-        "therapies": [
-            72,
-            73
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 651,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            52
-        ],
-        "conditionQualifier_id": 29,
-        "therapies": [
-            74
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 652,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            53
-        ],
-        "conditionQualifier_id": 29,
-        "therapies": [
-            74
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 653,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            2,
-            1,
-            87
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            77,
-            30
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 654,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            2,
-            3,
-            87
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            77,
-            30
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 655,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            2,
-            1,
-            3,
-            87
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            77,
-            30
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 656,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            18
-        ],
-        "conditionQualifier_id": 75,
-        "therapies": [
-            78
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 657,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            60
-        ],
-        "conditionQualifier_id": 38,
-        "therapies": [
-            78
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 658,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            61
-        ],
-        "conditionQualifier_id": 45,
-        "therapies": [
-            79
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 659,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            15
-        ],
-        "conditionQualifier_id": 13,
-        "therapies": [
-            83
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 660,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            16
-        ],
-        "conditionQualifier_id": 83,
-        "therapies": [
-            67,
-            66
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 661,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            15
-        ],
-        "conditionQualifier_id": 13,
-        "therapies": [
-            84
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 662,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            15
-        ],
-        "conditionQualifier_id": 0,
-        "therapies": [
-            84
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 663,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            17
-        ],
-        "conditionQualifier_id": 40,
-        "therapies": [
-            67
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 664,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            19
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            86
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 665,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            10
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            39,
-            86
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 666,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            10
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            37,
-            86
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 667,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            9
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            39,
-            86
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 668,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            9
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            37,
-            86
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 669,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            19
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            12
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 670,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            15
-        ],
-        "conditionQualifier_id": 13,
-        "therapies": [
-            88
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 671,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            71
-        ],
-        "conditionQualifier_id": 8,
-        "therapies": [
-            89
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 672,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            39,
-            34,
-            35
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            89
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 673,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            72
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            89,
-            11,
-            37,
-            35
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 674,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            8
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            89,
-            11,
-            37,
-            35
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 675,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            35
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            89,
-            37,
-            51
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 676,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            34
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            89,
-            37,
-            51
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 677,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            34,
-            35
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            89,
-            37,
-            51
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 678,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            73,
-            34,
-            35
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            89
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 679,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            33,
-            43,
-            2,
-            44
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            89,
-            51
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 680,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            34,
-            35
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            37,
-            44,
-            49,
-            45
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 681,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            34,
-            35
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            39,
-            44,
-            49,
-            45
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 682,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            2,
-            43,
-            44
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            94
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 683,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            2,
-            1
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            94
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 684,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            2,
-            1,
-            3
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            94
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 685,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            20,
-            1,
-            44
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            96,
-            25
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 686,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            20,
-            1,
-            3
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            96,
-            40
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 687,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            21
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            38,
-            96
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 688,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            21,
-            1,
-            44
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            96,
-            25
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 689,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            21,
-            1,
-            3
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            96,
-            40
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 690,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            25,
-            27
-        ],
-        "conditionQualifier_id": 15,
-        "therapies": [
-            97,
-            28,
-            29
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 691,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            25,
-            27
-        ],
-        "conditionQualifier_id": 15,
-        "therapies": [
-            97,
-            27,
-            29
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 692,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            25,
-            27
-        ],
-        "conditionQualifier_id": 15,
-        "therapies": [
-            97
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 693,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            80
-        ],
-        "conditionQualifier_id": 84,
-        "therapies": [
-            98
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 694,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            81
-        ],
-        "conditionQualifier_id": 84,
-        "therapies": [
-            98
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 695,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            84
-        ],
-        "conditionQualifier_id": 84,
-        "therapies": [
-            98
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 696,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            83
-        ],
-        "conditionQualifier_id": 84,
-        "therapies": [
-            98
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 697,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            2,
-            1
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            99
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 698,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            2,
-            1,
-            3
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            99
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 699,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            2,
-            1
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            99,
-            36
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 700,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            2,
-            3
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            99,
-            36
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 701,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            2,
-            1,
-            3
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            99,
-            36
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 702,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            2,
-            1
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            99,
-            40
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 703,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            2,
-            3
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            99,
-            40
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 704,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            2,
-            1,
-            3
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            99,
-            40
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 705,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            2,
-            1
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            99,
-            30
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 706,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            2,
-            3
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            99,
-            30
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 707,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            2,
-            1,
-            3
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            99,
-            30
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 708,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            19
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            101
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 709,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            66
-        ],
-        "conditionQualifier_id": 1,
-        "therapies": [
-            104
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 710,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            85
-        ],
-        "conditionQualifier_id": 1,
-        "therapies": [
-            104
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 711,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            17
-        ],
-        "conditionQualifier_id": 40,
-        "therapies": [
-            22
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 712,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            81
-        ],
-        "conditionQualifier_id": 84,
-        "therapies": [
-            105,
-            60
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 713,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            80
-        ],
-        "conditionQualifier_id": 84,
-        "therapies": [
-            105,
-            60
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 714,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            84
-        ],
-        "conditionQualifier_id": 84,
-        "therapies": [
-            105,
-            60
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 715,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            39,
-            34,
-            35
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            37,
-            49,
-            107
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 716,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            39,
-            34,
-            35
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            39,
-            49,
-            107
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 717,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            1,
-            2,
-            87
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            109,
-            30
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 718,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            1,
-            2,
-            88
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            109,
-            30
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 719,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            95
-        ],
-        "conditionQualifier_id": 8,
-        "therapies": [
-            110
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 720,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            96
-        ],
-        "conditionQualifier_id": 8,
-        "therapies": [
-            110
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 721,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            98
-        ],
-        "conditionQualifier_id": 8,
-        "therapies": [
-            110
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 722,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            2,
-            103
-        ],
-        "conditionQualifier_id": 2,
-        "therapies": [
-            28,
-            111,
-            29
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 723,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            66
-        ],
-        "conditionQualifier_id": 1,
-        "therapies": [
-            82,
-            68,
-            63
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 724,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            47
-        ],
-        "conditionQualifier_id": 51,
-        "therapies": [
-            46,
-            11
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 725,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            49
-        ],
-        "conditionQualifier_id": 51,
-        "therapies": [
-            46,
-            11
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 726,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            48
-        ],
-        "conditionQualifier_id": 51,
-        "therapies": [
-            46,
-            11
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 727,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            50
-        ],
-        "conditionQualifier_id": 51,
-        "therapies": [
-            46,
-            11
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 728,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            47
-        ],
-        "conditionQualifier_id": 27,
-        "therapies": [
-            46,
-            11
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 729,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            49
-        ],
-        "conditionQualifier_id": 27,
-        "therapies": [
-            46,
-            11
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 730,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            48
-        ],
-        "conditionQualifier_id": 27,
-        "therapies": [
-            46,
-            11
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 731,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            50
-        ],
-        "conditionQualifier_id": 27,
-        "therapies": [
-            46,
-            11
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 732,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            47
-        ],
-        "conditionQualifier_id": 54,
-        "therapies": [
-            46,
-            11
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 733,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            50
-        ],
-        "conditionQualifier_id": 54,
-        "therapies": [
-            46,
-            11
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 734,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            48
-        ],
-        "conditionQualifier_id": 54,
-        "therapies": [
-            46,
-            11
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 735,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            51
-        ],
-        "conditionQualifier_id": 51,
-        "therapies": [
-            46,
-            11
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 736,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            51
-        ],
-        "conditionQualifier_id": 27,
-        "therapies": [
-            46,
-            11
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 737,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            51
-        ],
-        "conditionQualifier_id": 54,
-        "therapies": [
-            46,
-            11
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 738,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            32,
-            15
-        ],
-        "conditionQualifier_id": 0,
-        "therapies": [
-            43
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 739,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            16
-        ],
-        "conditionQualifier_id": 40,
-        "therapies": [
-            66,
-            67
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 740,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            17
-        ],
-        "conditionQualifier_id": 40,
-        "therapies": [
-            66,
-            67
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 741,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            80
-        ],
-        "conditionQualifier_id": 84,
-        "therapies": [
-            113
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 742,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            81
-        ],
-        "conditionQualifier_id": 84,
-        "therapies": [
-            113
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 743,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            84
-        ],
-        "conditionQualifier_id": 84,
-        "therapies": [
-            113
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 744,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            80
-        ],
-        "conditionQualifier_id": 84,
-        "therapies": [
-            114
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 745,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            81
-        ],
-        "conditionQualifier_id": 84,
-        "therapies": [
-            114
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 746,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            84
-        ],
-        "conditionQualifier_id": 84,
-        "therapies": [
-            114
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 747,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            80
-        ],
-        "conditionQualifier_id": 84,
-        "therapies": [
-            115
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 748,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            81
-        ],
-        "conditionQualifier_id": 84,
-        "therapies": [
-            115
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 749,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            84
-        ],
-        "conditionQualifier_id": 84,
-        "therapies": [
-            115
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 750,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            38
-        ],
-        "conditionQualifier_id": 15,
-        "therapies": [
-            72,
-            71
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 751,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            36
-        ],
-        "conditionQualifier_id": 15,
-        "therapies": [
-            72,
-            71
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 752,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            2,
-            1
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            40,
-            53
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 753,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            2,
-            1,
-            3
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            40,
-            53
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 754,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            2,
-            1
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            30,
-            53
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 755,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            2,
-            1,
-            3
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            30,
-            53
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 756,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            13,
-            15
-        ],
-        "conditionQualifier_id": 0,
-        "therapies": [
-            14
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 757,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            0
-        ],
-        "conditionQualifier_id": 80,
-        "therapies": [
-            0,
-            39,
-            63,
-            64
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 758,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            55
-        ],
-        "conditionQualifier_id": 0,
-        "therapies": [
-            63,
-            68,
-            69
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 759,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            20
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            37,
-            35,
-            75,
-            25
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 760,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            0,
-            2
-        ],
-        "conditionQualifier_id": 80,
-        "therapies": [
-            0,
-            37,
-            64,
-            116
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 761,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            41,
-            2
-        ],
-        "conditionQualifier_id": 2,
-        "therapies": [
-            39,
-            48,
-            29
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 762,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            41,
-            2
-        ],
-        "conditionQualifier_id": 2,
-        "therapies": [
-            28,
-            48,
-            29
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 763,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            15
-        ],
-        "conditionQualifier_id": 0,
-        "therapies": [
-            15
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 764,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            20
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            35,
-            75,
-            25
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 765,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            20
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            117,
-            75,
-            25
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 766,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            20
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            75,
-            25
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 767,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            33
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            37,
-            50,
-            72
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 768,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            33
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            39,
-            72,
-            49
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 769,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            2
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            11,
-            35
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 770,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            19
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            11,
-            12
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 771,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            43,
-            2,
-            44
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            38
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 772,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            1
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            119
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 773,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            20,
-            1,
-            3
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            36
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 774,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            20,
-            1
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            36
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 775,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            20,
-            3
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            36
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 776,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            20,
-            1,
-            3
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            36,
-            25
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 777,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            20,
-            1
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            36,
-            25
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 778,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            20,
-            3
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            36,
-            25
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 779,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            20
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            2,
-            35,
-            25
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 780,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            2,
-            1,
-            3
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            4,
-            5
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 781,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            2,
-            1
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            4,
-            5
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 782,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            2,
-            43,
-            44
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            37,
-            59,
-            2,
-            35
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 783,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            43
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            30
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 784,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            1,
-            3
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            40
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 785,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            1
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            40
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 786,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            3
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            40
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 787,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            1,
-            3
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            5
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 788,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            1
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            5
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 789,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            3
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            5
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 790,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            43,
-            2,
-            44
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            37,
-            50
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 791,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            20
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            59,
-            2,
-            35,
-            25
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 792,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            1,
-            2,
-            3
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            99,
-            5
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 793,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            1,
-            2
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            99,
-            5
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 794,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            2,
-            3
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            99,
-            5
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 795,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            43,
-            2,
-            44
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            37,
-            59,
-            2,
-            35
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 796,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            24,
-            25,
-            27
-        ],
-        "conditionQualifier_id": 15,
-        "therapies": [
-            19
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 797,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            25,
-            27
-        ],
-        "conditionQualifier_id": 15,
-        "therapies": [
-            19,
-            27,
-            29
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 798,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            25,
-            27
-        ],
-        "conditionQualifier_id": 15,
-        "therapies": [
-            19,
-            27
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 799,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            25,
-            27
-        ],
-        "conditionQualifier_id": 15,
-        "therapies": [
-            28,
-            97,
-            29
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 800,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            33
-        ],
-        "conditionQualifier_id": 82,
-        "therapies": [
-            72,
-            28,
-            29
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 801,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            80
-        ],
-        "conditionQualifier_id": 84,
-        "therapies": [
-            105,
-            120
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 802,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            81
-        ],
-        "conditionQualifier_id": 84,
-        "therapies": [
-            105,
-            120
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 803,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            84
-        ],
-        "conditionQualifier_id": 84,
-        "therapies": [
-            105,
-            120
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 804,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            66
-        ],
-        "conditionQualifier_id": 1,
-        "therapies": [
-            82
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 805,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            33
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            37,
-            35,
-            72
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 806,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            33
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            39,
-            49,
-            72
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 807,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            33
-        ],
-        "conditionQualifier_id": 47,
-        "therapies": [
-            37,
-            49,
-            72
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 808,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            54
-        ],
-        "conditionQualifier_id": 76,
-        "therapies": [
-            121,
-            60
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 809,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            54
-        ],
-        "conditionQualifier_id": 76,
-        "therapies": [
-            39,
-            63,
-            60
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 810,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            54
-        ],
-        "conditionQualifier_id": 77,
-        "therapies": [
-            59,
-            2,
-            64,
-            8,
-            60,
-            61
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 811,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            54
-        ],
-        "conditionQualifier_id": 76,
-        "therapies": [
-            59,
-            2,
-            64,
-            8,
-            60,
-            61
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 812,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            54
-        ],
-        "conditionQualifier_id": 76,
-        "therapies": [
-            37,
-            64,
-            116,
-            60
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 813,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            54
-        ],
-        "conditionQualifier_id": 76,
-        "therapies": [
-            59,
-            2,
-            8,
-            60,
-            117
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 814,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            54
-        ],
-        "conditionQualifier_id": 77,
-        "therapies": [
-            50,
-            28,
-            60
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 815,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            54
-        ],
-        "conditionQualifier_id": 76,
-        "therapies": [
-            50,
-            28,
-            60
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 816,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            54
-        ],
-        "conditionQualifier_id": 76,
-        "therapies": [
-            59,
-            64,
-            8,
-            60,
-            61
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 817,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            0
-        ],
-        "conditionQualifier_id": 80,
-        "therapies": [
-            121,
-            0
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 818,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            54
-        ],
-        "conditionQualifier_id": 20,
-        "therapies": [
-            59,
-            8,
-            60,
-            61
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 819,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            54
-        ],
-        "conditionQualifier_id": 20,
-        "therapies": [
-            59,
-            2,
-            8,
-            60,
-            61
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 820,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            54
-        ],
-        "conditionQualifier_id": 20,
-        "therapies": [
-            123,
-            124,
-            8,
-            60
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 821,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            54
-        ],
-        "conditionQualifier_id": 20,
-        "therapies": [
-            59,
-            2,
-            64,
-            125,
-            8,
-            60
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 822,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            54
-        ],
-        "conditionQualifier_id": 20,
-        "therapies": [
-            60
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 823,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            54
-        ],
-        "conditionQualifier_id": 76,
-        "therapies": [
-            59,
-            8,
-            60,
-            61
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 824,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            1
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            36
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 825,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            3
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            36
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 826,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            1,
-            3
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            36
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 827,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            1,
-            2
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            40
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 828,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            2,
-            3
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            40
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 829,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            1,
-            2,
-            3
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            40
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 830,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            1,
-            2,
-            3
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            99,
-            40
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 831,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            1,
-            2
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            99,
-            40
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 832,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            2,
-            3
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            99,
-            40
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 833,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            1,
-            2,
-            3
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            99,
-            36
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 834,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            1,
-            2
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            99,
-            36
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    },
-    {
-        "id": 835,
-        "type": "VariantTherapeuticResponseProposition",
-        "predicate": "predictSensitivityTo",
-        "biomarkers": [
-            2,
-            3
-        ],
-        "conditionQualifier_id": 9,
-        "therapies": [
-            99,
-            36
-        ],
-        "objectTherapeutic": {},
-        "subjectVariant": {}
-    }
+  {
+    "id": 0,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      1,
+      2
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      99,
+      119
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 1,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      2,
+      3
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      99,
+      119
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 2,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      1,
+      2,
+      3
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      99,
+      119
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 3,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      1,
+      2
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      36,
+      99
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 4,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      2,
+      3
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      36,
+      99
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 5,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      1,
+      2,
+      3
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      36,
+      99
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 6,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      1,
+      2
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      40,
+      99
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 7,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      2,
+      3
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      40,
+      99
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 8,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      1,
+      2,
+      3
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      40,
+      99
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 9,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      1,
+      2
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      30,
+      99
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 10,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      2,
+      3
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      30,
+      99
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 11,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      1,
+      2,
+      3
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      30,
+      99
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 12,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      1,
+      2
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      99
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 13,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      2,
+      3
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      99
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 14,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      1,
+      2,
+      3
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      99
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 15,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      4
+    ],
+    "conditionQualifier_id": 55,
+    "objectTherapeutic": [
+      7,
+      6,
+      122
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 16,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      5
+    ],
+    "conditionQualifier_id": 55,
+    "objectTherapeutic": [
+      7,
+      6,
+      122
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 17,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      6
+    ],
+    "conditionQualifier_id": 55,
+    "objectTherapeutic": [
+      7,
+      6,
+      122
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 18,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      7
+    ],
+    "conditionQualifier_id": 55,
+    "objectTherapeutic": [
+      7,
+      6,
+      122
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 19,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      45
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      54
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 20,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      20
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      52
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 21,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      72
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      34
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 22,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      8
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      9
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 23,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      1,
+      2,
+      59
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      77,
+      30
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 24,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      2,
+      3,
+      59
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      77,
+      30
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 25,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      1,
+      2,
+      3,
+      59
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      77,
+      30
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 26,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      86
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      37,
+      49,
+      108
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 27,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      86
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      108
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 28,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      79
+    ],
+    "conditionQualifier_id": 10,
+    "objectTherapeutic": [
+      93
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 29,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      12
+    ],
+    "conditionQualifier_id": 13,
+    "objectTherapeutic": [
+      83
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 30,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      12,
+      32
+    ],
+    "conditionQualifier_id": 13,
+    "objectTherapeutic": [
+      83
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 31,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      33
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      89
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 32,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      39
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      89
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 33,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      73
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      89
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 34,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      34,
+      35
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      89,
+      11,
+      35,
+      37
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 35,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      34,
+      35
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      89,
+      35,
+      37
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 36,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      72
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      89
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 37,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      8
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      89
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 38,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      16
+    ],
+    "conditionQualifier_id": 40,
+    "objectTherapeutic": [
+      89,
+      21,
+      22
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 39,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      17
+    ],
+    "conditionQualifier_id": 40,
+    "objectTherapeutic": [
+      89,
+      21,
+      22
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 40,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      11
+    ],
+    "conditionQualifier_id": 22,
+    "objectTherapeutic": [
+      13
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 41,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      16
+    ],
+    "conditionQualifier_id": 40,
+    "objectTherapeutic": [
+      17,
+      18
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 42,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      17
+    ],
+    "conditionQualifier_id": 40,
+    "objectTherapeutic": [
+      17,
+      18
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 43,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      16
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      17,
+      18
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 45,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      14
+    ],
+    "conditionQualifier_id": 0,
+    "objectTherapeutic": [
+      15
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 46,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      14,
+      15
+    ],
+    "conditionQualifier_id": 0,
+    "objectTherapeutic": [
+      15
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 47,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      12
+    ],
+    "conditionQualifier_id": 13,
+    "objectTherapeutic": [
+      16
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 48,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      0
+    ],
+    "conditionQualifier_id": 3,
+    "objectTherapeutic": [
+      0,
+      59,
+      2,
+      122
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 49,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      0
+    ],
+    "conditionQualifier_id": 3,
+    "objectTherapeutic": [
+      0
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 50,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      8
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      10
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 51,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      20
+    ],
+    "conditionQualifier_id": 2,
+    "objectTherapeutic": [
+      38
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 52,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      1,
+      2,
+      59
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      109,
+      30
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 53,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      2,
+      3,
+      59
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      109,
+      30
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 54,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      1,
+      2,
+      3,
+      59
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      109,
+      30
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 55,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      1,
+      2,
+      90
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      109,
+      30
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 56,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      2,
+      3,
+      90
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      109,
+      30
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 57,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      1,
+      2,
+      3,
+      90
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      109,
+      30
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 58,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      1,
+      2,
+      89
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      109,
+      30
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 59,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      2,
+      3,
+      89
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      109,
+      30
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 60,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      1,
+      2,
+      3,
+      89
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      109,
+      30
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 61,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      1,
+      2,
+      91
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      109,
+      30
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 62,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      2,
+      3,
+      91
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      109,
+      30
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 63,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      1,
+      2,
+      3,
+      91
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      109,
+      30
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 64,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      1,
+      2,
+      92
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      109,
+      30
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 65,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      2,
+      3,
+      92
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      109,
+      30
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 66,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      1,
+      2,
+      3,
+      92
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      109,
+      30
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 67,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      1,
+      2,
+      93
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      109,
+      30
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 68,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      2,
+      3,
+      93
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      109,
+      30
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 69,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      1,
+      2,
+      3,
+      93
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      109,
+      30
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 70,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      1,
+      2,
+      94
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      109,
+      30
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 71,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      2,
+      3,
+      94
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      109,
+      30
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 72,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      1,
+      2,
+      3,
+      94
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      109,
+      30
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 73,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      67
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      85
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 74,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      68
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      85
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 75,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      34,
+      35,
+      46
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      37,
+      55,
+      49
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 76,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      34,
+      35,
+      36,
+      39
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      55
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 77,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      8
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      106
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 78,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      24,
+      25
+    ],
+    "conditionQualifier_id": 15,
+    "objectTherapeutic": [
+      19,
+      27,
+      29
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 79,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      24,
+      25
+    ],
+    "conditionQualifier_id": 15,
+    "objectTherapeutic": [
+      19,
+      27
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 80,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      24,
+      25
+    ],
+    "conditionQualifier_id": 15,
+    "objectTherapeutic": [
+      19
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 81,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      16
+    ],
+    "conditionQualifier_id": 15,
+    "objectTherapeutic": [
+      18,
+      19
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 82,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      16
+    ],
+    "conditionQualifier_id": 40,
+    "objectTherapeutic": [
+      21,
+      22
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 83,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      17
+    ],
+    "conditionQualifier_id": 40,
+    "objectTherapeutic": [
+      21,
+      22
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 84,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      8
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      102
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 85,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      62
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      102
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 86,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      8
+    ],
+    "conditionQualifier_id": 3,
+    "objectTherapeutic": [
+      102
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 87,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      8
+    ],
+    "conditionQualifier_id": 28,
+    "objectTherapeutic": [
+      102
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 88,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      16
+    ],
+    "conditionQualifier_id": 40,
+    "objectTherapeutic": [
+      67
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 89,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      16
+    ],
+    "conditionQualifier_id": 40,
+    "objectTherapeutic": [
+      67,
+      66
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 90,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      17
+    ],
+    "conditionQualifier_id": 40,
+    "objectTherapeutic": [
+      67,
+      66
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 91,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      16
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      67,
+      66
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 92,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      16
+    ],
+    "conditionQualifier_id": 4,
+    "objectTherapeutic": [
+      67,
+      66
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 93,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      16
+    ],
+    "conditionQualifier_id": 5,
+    "objectTherapeutic": [
+      67,
+      66
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 94,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      16
+    ],
+    "conditionQualifier_id": 35,
+    "objectTherapeutic": [
+      67,
+      66
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 95,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      10
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      101
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 96,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      9
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      101
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 97,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      12
+    ],
+    "conditionQualifier_id": 13,
+    "objectTherapeutic": [
+      84
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 98,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      12
+    ],
+    "conditionQualifier_id": 71,
+    "objectTherapeutic": [
+      84
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 99,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      12
+    ],
+    "conditionQualifier_id": 0,
+    "objectTherapeutic": [
+      84
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 100,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      36
+    ],
+    "conditionQualifier_id": 18,
+    "objectTherapeutic": [
+      37,
+      47,
+      35
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 101,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      38
+    ],
+    "conditionQualifier_id": 18,
+    "objectTherapeutic": [
+      37,
+      47,
+      35
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 102,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      36
+    ],
+    "conditionQualifier_id": 18,
+    "objectTherapeutic": [
+      47
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 103,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      36
+    ],
+    "conditionQualifier_id": 5,
+    "objectTherapeutic": [
+      47
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 104,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      34,
+      35
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      44,
+      45,
+      49,
+      37
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 105,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      34,
+      35
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      44,
+      45,
+      49,
+      39
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 106,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      34,
+      35
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      44,
+      45,
+      50,
+      37
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 107,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      34,
+      35
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      44,
+      45,
+      50,
+      39
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 108,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      34,
+      35
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      44,
+      45,
+      51,
+      37
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 109,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      36
+    ],
+    "conditionQualifier_id": 18,
+    "objectTherapeutic": [
+      37,
+      44,
+      35
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 110,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      1,
+      2,
+      58
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      74
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 111,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      107
+    ],
+    "conditionQualifier_id": 1,
+    "objectTherapeutic": [
+      126
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 112,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      108
+    ],
+    "conditionQualifier_id": 1,
+    "objectTherapeutic": [
+      126
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 113,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      109
+    ],
+    "conditionQualifier_id": 1,
+    "objectTherapeutic": [
+      126
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 114,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      110
+    ],
+    "conditionQualifier_id": 1,
+    "objectTherapeutic": [
+      126
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 115,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      111
+    ],
+    "conditionQualifier_id": 1,
+    "objectTherapeutic": [
+      126
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 116,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      112
+    ],
+    "conditionQualifier_id": 1,
+    "objectTherapeutic": [
+      126
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 117,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      113
+    ],
+    "conditionQualifier_id": 1,
+    "objectTherapeutic": [
+      126
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 118,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      114
+    ],
+    "conditionQualifier_id": 1,
+    "objectTherapeutic": [
+      126
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 119,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      115
+    ],
+    "conditionQualifier_id": 1,
+    "objectTherapeutic": [
+      126
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 120,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      62
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      80
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 121,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      63
+    ],
+    "conditionQualifier_id": 5,
+    "objectTherapeutic": [
+      80
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 122,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      64
+    ],
+    "conditionQualifier_id": 5,
+    "objectTherapeutic": [
+      80
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 123,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      65
+    ],
+    "conditionQualifier_id": 5,
+    "objectTherapeutic": [
+      80
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 124,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      99
+    ],
+    "conditionQualifier_id": 8,
+    "objectTherapeutic": [
+      110
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 125,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      100
+    ],
+    "conditionQualifier_id": 8,
+    "objectTherapeutic": [
+      110
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 126,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      101
+    ],
+    "conditionQualifier_id": 8,
+    "objectTherapeutic": [
+      110
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 127,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      102
+    ],
+    "conditionQualifier_id": 8,
+    "objectTherapeutic": [
+      110
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 128,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      97
+    ],
+    "conditionQualifier_id": 8,
+    "objectTherapeutic": [
+      110
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 129,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      10
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      12
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 130,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      9
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      12
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 131,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      1,
+      2
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      4,
+      5
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 132,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      2,
+      3
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      4,
+      5
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 133,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      1,
+      2,
+      3
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      4,
+      5
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 134,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      1,
+      2
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      30
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 135,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      2,
+      3
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      30
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 136,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      1,
+      2,
+      3
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      30
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 137,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      1
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      30
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 138,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      3
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      30
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 139,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      1,
+      3
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      30
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 140,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      1,
+      2
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      30,
+      53
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 141,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      2,
+      3
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      30,
+      53
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 142,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      1,
+      2,
+      3
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      30,
+      53
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 143,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      1,
+      2
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      30,
+      31
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 144,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      2,
+      3
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      30,
+      31
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 145,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      1,
+      2,
+      3
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      30,
+      31
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 146,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      52
+    ],
+    "conditionQualifier_id": 29,
+    "objectTherapeutic": [
+      58
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 147,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      10
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      33
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 148,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      9
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      33
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 149,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      55
+    ],
+    "conditionQualifier_id": 0,
+    "objectTherapeutic": [
+      69
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 150,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      66
+    ],
+    "conditionQualifier_id": 0,
+    "objectTherapeutic": [
+      104
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 151,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      85
+    ],
+    "conditionQualifier_id": 0,
+    "objectTherapeutic": [
+      104
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 152,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      116
+    ],
+    "conditionQualifier_id": 0,
+    "objectTherapeutic": [
+      104
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 153,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      117
+    ],
+    "conditionQualifier_id": 0,
+    "objectTherapeutic": [
+      104
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 154,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      118
+    ],
+    "conditionQualifier_id": 0,
+    "objectTherapeutic": [
+      104
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 155,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      119
+    ],
+    "conditionQualifier_id": 0,
+    "objectTherapeutic": [
+      104
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 156,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      120
+    ],
+    "conditionQualifier_id": 0,
+    "objectTherapeutic": [
+      104
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 157,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      121
+    ],
+    "conditionQualifier_id": 0,
+    "objectTherapeutic": [
+      104
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 158,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      12
+    ],
+    "conditionQualifier_id": 13,
+    "objectTherapeutic": [
+      41
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 159,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      12
+    ],
+    "conditionQualifier_id": 71,
+    "objectTherapeutic": [
+      41
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 160,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      12
+    ],
+    "conditionQualifier_id": 0,
+    "objectTherapeutic": [
+      41
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 161,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      28
+    ],
+    "conditionQualifier_id": 43,
+    "objectTherapeutic": [
+      41
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 162,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      29
+    ],
+    "conditionQualifier_id": 43,
+    "objectTherapeutic": [
+      41
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 163,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      122
+    ],
+    "conditionQualifier_id": 42,
+    "objectTherapeutic": [
+      41
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 164,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      30
+    ],
+    "conditionQualifier_id": 12,
+    "objectTherapeutic": [
+      41
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 165,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      31
+    ],
+    "conditionQualifier_id": 22,
+    "objectTherapeutic": [
+      41
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 166,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      30
+    ],
+    "conditionQualifier_id": 22,
+    "objectTherapeutic": [
+      41
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 167,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      52
+    ],
+    "conditionQualifier_id": 11,
+    "objectTherapeutic": [
+      127
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 168,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      13
+    ],
+    "conditionQualifier_id": 0,
+    "objectTherapeutic": [
+      14
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 169,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      38
+    ],
+    "conditionQualifier_id": 15,
+    "objectTherapeutic": [
+      71,
+      72
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 170,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      37
+    ],
+    "conditionQualifier_id": 15,
+    "objectTherapeutic": [
+      71,
+      72
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 171,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      33,
+      34,
+      35
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      71,
+      72
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 172,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      34,
+      35
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      37,
+      71,
+      72,
+      49
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 173,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      34,
+      35
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      39,
+      71,
+      72,
+      49
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 174,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      34,
+      35
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      37,
+      71,
+      72,
+      35
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 175,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      74
+    ],
+    "conditionQualifier_id": 1,
+    "objectTherapeutic": [
+      92
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 176,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      75
+    ],
+    "conditionQualifier_id": 1,
+    "objectTherapeutic": [
+      92
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 177,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      76
+    ],
+    "conditionQualifier_id": 1,
+    "objectTherapeutic": [
+      92
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 178,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      77
+    ],
+    "conditionQualifier_id": 1,
+    "objectTherapeutic": [
+      92
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 179,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      78
+    ],
+    "conditionQualifier_id": 1,
+    "objectTherapeutic": [
+      92
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 180,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      74
+    ],
+    "conditionQualifier_id": 1,
+    "objectTherapeutic": [
+      91,
+      92
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 181,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      75
+    ],
+    "conditionQualifier_id": 1,
+    "objectTherapeutic": [
+      91,
+      92
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 182,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      76
+    ],
+    "conditionQualifier_id": 1,
+    "objectTherapeutic": [
+      91,
+      92
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 183,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      77
+    ],
+    "conditionQualifier_id": 1,
+    "objectTherapeutic": [
+      91,
+      92
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 184,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      78
+    ],
+    "conditionQualifier_id": 1,
+    "objectTherapeutic": [
+      91,
+      92
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 185,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      74
+    ],
+    "conditionQualifier_id": 43,
+    "objectTherapeutic": [
+      92
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 186,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      75
+    ],
+    "conditionQualifier_id": 43,
+    "objectTherapeutic": [
+      92
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 187,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      76
+    ],
+    "conditionQualifier_id": 43,
+    "objectTherapeutic": [
+      92
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 188,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      77
+    ],
+    "conditionQualifier_id": 43,
+    "objectTherapeutic": [
+      92
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 189,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      78
+    ],
+    "conditionQualifier_id": 43,
+    "objectTherapeutic": [
+      92
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 190,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      74
+    ],
+    "conditionQualifier_id": 11,
+    "objectTherapeutic": [
+      92
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 191,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      75
+    ],
+    "conditionQualifier_id": 11,
+    "objectTherapeutic": [
+      92
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 192,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      76
+    ],
+    "conditionQualifier_id": 11,
+    "objectTherapeutic": [
+      92
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 193,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      77
+    ],
+    "conditionQualifier_id": 11,
+    "objectTherapeutic": [
+      92
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 194,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      78
+    ],
+    "conditionQualifier_id": 11,
+    "objectTherapeutic": [
+      92
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 195,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      20
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      38,
+      96
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 196,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      1,
+      20
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      96,
+      40
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 197,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      3,
+      20
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      96,
+      40
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 198,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      1,
+      3,
+      20
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      96,
+      40
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 199,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      63
+    ],
+    "conditionQualifier_id": 5,
+    "objectTherapeutic": [
+      100
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 200,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      64
+    ],
+    "conditionQualifier_id": 5,
+    "objectTherapeutic": [
+      100
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 201,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      65
+    ],
+    "conditionQualifier_id": 5,
+    "objectTherapeutic": [
+      100
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 202,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      61
+    ],
+    "conditionQualifier_id": 43,
+    "objectTherapeutic": [
+      79
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 203,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      8
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      56
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 204,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      20
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      38,
+      128
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 205,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      20
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      129,
+      128
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 206,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      20
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      50,
+      128
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 207,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      20
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      128,
+      117
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 208,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      66
+    ],
+    "conditionQualifier_id": 1,
+    "objectTherapeutic": [
+      63,
+      68,
+      82
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 209,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      85
+    ],
+    "conditionQualifier_id": 1,
+    "objectTherapeutic": [
+      63,
+      68,
+      82
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 210,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      116
+    ],
+    "conditionQualifier_id": 1,
+    "objectTherapeutic": [
+      63,
+      68,
+      82
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 211,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      117
+    ],
+    "conditionQualifier_id": 1,
+    "objectTherapeutic": [
+      63,
+      68,
+      82
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 212,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      118
+    ],
+    "conditionQualifier_id": 1,
+    "objectTherapeutic": [
+      63,
+      68,
+      82
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 213,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      119
+    ],
+    "conditionQualifier_id": 1,
+    "objectTherapeutic": [
+      63,
+      68,
+      82
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 214,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      120
+    ],
+    "conditionQualifier_id": 1,
+    "objectTherapeutic": [
+      63,
+      68,
+      82
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 215,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      121
+    ],
+    "conditionQualifier_id": 1,
+    "objectTherapeutic": [
+      63,
+      68,
+      82
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 216,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      123
+    ],
+    "conditionQualifier_id": 1,
+    "objectTherapeutic": [
+      63,
+      68,
+      82
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 217,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      125
+    ],
+    "conditionQualifier_id": 1,
+    "objectTherapeutic": [
+      63,
+      68,
+      82
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 218,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      86
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      130
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 219,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      20
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      70
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 220,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      20
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      38,
+      70
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 221,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      12
+    ],
+    "conditionQualifier_id": 13,
+    "objectTherapeutic": [
+      88
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 222,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      12
+    ],
+    "conditionQualifier_id": 71,
+    "objectTherapeutic": [
+      88
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 223,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      48
+    ],
+    "conditionQualifier_id": 51,
+    "objectTherapeutic": [
+      6
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 224,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      50
+    ],
+    "conditionQualifier_id": 51,
+    "objectTherapeutic": [
+      6
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 225,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      48
+    ],
+    "conditionQualifier_id": 27,
+    "objectTherapeutic": [
+      6
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 226,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      50
+    ],
+    "conditionQualifier_id": 27,
+    "objectTherapeutic": [
+      6
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 227,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      48
+    ],
+    "conditionQualifier_id": 54,
+    "objectTherapeutic": [
+      6
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 228,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      50
+    ],
+    "conditionQualifier_id": 54,
+    "objectTherapeutic": [
+      6
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 229,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      34,
+      35
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      37,
+      72,
+      35
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 230,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      33
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      71,
+      72
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 231,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      47
+    ],
+    "conditionQualifier_id": 51,
+    "objectTherapeutic": [
+      46
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 232,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      48
+    ],
+    "conditionQualifier_id": 51,
+    "objectTherapeutic": [
+      46
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 233,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      49
+    ],
+    "conditionQualifier_id": 51,
+    "objectTherapeutic": [
+      46
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 234,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      50
+    ],
+    "conditionQualifier_id": 51,
+    "objectTherapeutic": [
+      46
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 235,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      47
+    ],
+    "conditionQualifier_id": 27,
+    "objectTherapeutic": [
+      46
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 236,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      48
+    ],
+    "conditionQualifier_id": 27,
+    "objectTherapeutic": [
+      46
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 237,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      49
+    ],
+    "conditionQualifier_id": 27,
+    "objectTherapeutic": [
+      46
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 238,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      50
+    ],
+    "conditionQualifier_id": 27,
+    "objectTherapeutic": [
+      46
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 239,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      47
+    ],
+    "conditionQualifier_id": 54,
+    "objectTherapeutic": [
+      46
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 240,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      48
+    ],
+    "conditionQualifier_id": 54,
+    "objectTherapeutic": [
+      46
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 241,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      49
+    ],
+    "conditionQualifier_id": 54,
+    "objectTherapeutic": [
+      46
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 242,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      50
+    ],
+    "conditionQualifier_id": 54,
+    "objectTherapeutic": [
+      46
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 243,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      47
+    ],
+    "conditionQualifier_id": 51,
+    "objectTherapeutic": [
+      11,
+      46
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 244,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      48
+    ],
+    "conditionQualifier_id": 51,
+    "objectTherapeutic": [
+      11,
+      46
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 245,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      49
+    ],
+    "conditionQualifier_id": 51,
+    "objectTherapeutic": [
+      11,
+      46
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 246,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      50
+    ],
+    "conditionQualifier_id": 51,
+    "objectTherapeutic": [
+      11,
+      46
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 247,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      51
+    ],
+    "conditionQualifier_id": 51,
+    "objectTherapeutic": [
+      11,
+      46
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 248,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      47
+    ],
+    "conditionQualifier_id": 27,
+    "objectTherapeutic": [
+      11,
+      46
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 249,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      48
+    ],
+    "conditionQualifier_id": 27,
+    "objectTherapeutic": [
+      11,
+      46
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 250,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      49
+    ],
+    "conditionQualifier_id": 27,
+    "objectTherapeutic": [
+      11,
+      46
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 251,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      50
+    ],
+    "conditionQualifier_id": 27,
+    "objectTherapeutic": [
+      11,
+      46
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 252,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      51
+    ],
+    "conditionQualifier_id": 27,
+    "objectTherapeutic": [
+      11,
+      46
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 253,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      47
+    ],
+    "conditionQualifier_id": 54,
+    "objectTherapeutic": [
+      11,
+      46
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 254,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      48
+    ],
+    "conditionQualifier_id": 54,
+    "objectTherapeutic": [
+      11,
+      46
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 255,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      49
+    ],
+    "conditionQualifier_id": 54,
+    "objectTherapeutic": [
+      11,
+      46
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 256,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      50
+    ],
+    "conditionQualifier_id": 54,
+    "objectTherapeutic": [
+      11,
+      46
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 257,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      51
+    ],
+    "conditionQualifier_id": 54,
+    "objectTherapeutic": [
+      11,
+      46
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 258,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      48,
+      2
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      46
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 259,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      50,
+      2
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      46
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 260,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      48
+    ],
+    "conditionQualifier_id": 52,
+    "objectTherapeutic": [
+      46
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 261,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      50
+    ],
+    "conditionQualifier_id": 52,
+    "objectTherapeutic": [
+      46
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 262,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      47
+    ],
+    "conditionQualifier_id": 55,
+    "objectTherapeutic": [
+      138,
+      87
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 263,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      47
+    ],
+    "conditionQualifier_id": 55,
+    "objectTherapeutic": [
+      46
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 264,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      48
+    ],
+    "conditionQualifier_id": 55,
+    "objectTherapeutic": [
+      46
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 265,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      49
+    ],
+    "conditionQualifier_id": 55,
+    "objectTherapeutic": [
+      46
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 266,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      50
+    ],
+    "conditionQualifier_id": 55,
+    "objectTherapeutic": [
+      46
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 267,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      104
+    ],
+    "conditionQualifier_id": 55,
+    "objectTherapeutic": [
+      46
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 268,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      105
+    ],
+    "conditionQualifier_id": 55,
+    "objectTherapeutic": [
+      46
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 269,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      106
+    ],
+    "conditionQualifier_id": 55,
+    "objectTherapeutic": [
+      46
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 270,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      4
+    ],
+    "conditionQualifier_id": 55,
+    "objectTherapeutic": [
+      46
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 271,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      5
+    ],
+    "conditionQualifier_id": 55,
+    "objectTherapeutic": [
+      46
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 272,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      6
+    ],
+    "conditionQualifier_id": 55,
+    "objectTherapeutic": [
+      46
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 273,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      7
+    ],
+    "conditionQualifier_id": 55,
+    "objectTherapeutic": [
+      46
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 274,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      125
+    ],
+    "conditionQualifier_id": 55,
+    "objectTherapeutic": [
+      46
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 275,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      126
+    ],
+    "conditionQualifier_id": 55,
+    "objectTherapeutic": [
+      46
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 276,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      127
+    ],
+    "conditionQualifier_id": 55,
+    "objectTherapeutic": [
+      46
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 277,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      128
+    ],
+    "conditionQualifier_id": 55,
+    "objectTherapeutic": [
+      46
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 278,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      129
+    ],
+    "conditionQualifier_id": 55,
+    "objectTherapeutic": [
+      46
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 279,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      130
+    ],
+    "conditionQualifier_id": 55,
+    "objectTherapeutic": [
+      46
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 280,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      131
+    ],
+    "conditionQualifier_id": 55,
+    "objectTherapeutic": [
+      46
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 281,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      132
+    ],
+    "conditionQualifier_id": 55,
+    "objectTherapeutic": [
+      46
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 282,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      133
+    ],
+    "conditionQualifier_id": 55,
+    "objectTherapeutic": [
+      46
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 283,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      134
+    ],
+    "conditionQualifier_id": 55,
+    "objectTherapeutic": [
+      46
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 284,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      135
+    ],
+    "conditionQualifier_id": 55,
+    "objectTherapeutic": [
+      87
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 285,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      136
+    ],
+    "conditionQualifier_id": 55,
+    "objectTherapeutic": [
+      46
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 286,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      137
+    ],
+    "conditionQualifier_id": 55,
+    "objectTherapeutic": [
+      46
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 287,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      138
+    ],
+    "conditionQualifier_id": 55,
+    "objectTherapeutic": [
+      46
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 288,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      139
+    ],
+    "conditionQualifier_id": 55,
+    "objectTherapeutic": [
+      46
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 289,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      140
+    ],
+    "conditionQualifier_id": 55,
+    "objectTherapeutic": [
+      46
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 290,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      141
+    ],
+    "conditionQualifier_id": 55,
+    "objectTherapeutic": [
+      46
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 291,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      47
+    ],
+    "conditionQualifier_id": 55,
+    "objectTherapeutic": [
+      7,
+      46,
+      8
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 292,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      48
+    ],
+    "conditionQualifier_id": 55,
+    "objectTherapeutic": [
+      7,
+      46,
+      8
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 293,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      49
+    ],
+    "conditionQualifier_id": 55,
+    "objectTherapeutic": [
+      7,
+      46,
+      8
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 294,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      50
+    ],
+    "conditionQualifier_id": 55,
+    "objectTherapeutic": [
+      7,
+      46,
+      8
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 295,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      47
+    ],
+    "conditionQualifier_id": 55,
+    "objectTherapeutic": [
+      7,
+      46,
+      122
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 296,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      48
+    ],
+    "conditionQualifier_id": 55,
+    "objectTherapeutic": [
+      7,
+      46,
+      122
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 297,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      49
+    ],
+    "conditionQualifier_id": 55,
+    "objectTherapeutic": [
+      7,
+      46,
+      122
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 298,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      50
+    ],
+    "conditionQualifier_id": 55,
+    "objectTherapeutic": [
+      7,
+      46,
+      122
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 299,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      74
+    ],
+    "conditionQualifier_id": 1,
+    "objectTherapeutic": [
+      131
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 300,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      75
+    ],
+    "conditionQualifier_id": 1,
+    "objectTherapeutic": [
+      131
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 301,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      76
+    ],
+    "conditionQualifier_id": 1,
+    "objectTherapeutic": [
+      131
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 302,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      77
+    ],
+    "conditionQualifier_id": 1,
+    "objectTherapeutic": [
+      131
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 303,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      78
+    ],
+    "conditionQualifier_id": 1,
+    "objectTherapeutic": [
+      131
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 304,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      10
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      86
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 305,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      9
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      86
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 306,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      9
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      39,
+      86,
+      49
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 307,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      9
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      37,
+      86,
+      49
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 308,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      10
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      37,
+      86,
+      49
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 309,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      10
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      39,
+      86,
+      49
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 310,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      70
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      86
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 311,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      1,
+      2
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      40,
+      31
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 312,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      2,
+      3
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      40,
+      31
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 313,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      1,
+      2,
+      3
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      40,
+      31
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 314,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      25,
+      26
+    ],
+    "conditionQualifier_id": 15,
+    "objectTherapeutic": [
+      28,
+      97,
+      29
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 315,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      25,
+      26
+    ],
+    "conditionQualifier_id": 15,
+    "objectTherapeutic": [
+      97
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 316,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      34,
+      35
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      37,
+      48,
+      49
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 317,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      34,
+      35
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      39,
+      48,
+      49
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 318,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      33,
+      34,
+      35
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      48
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 319,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      33
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      48
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 320,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      42
+    ],
+    "conditionQualifier_id": 25,
+    "objectTherapeutic": [
+      48
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 321,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      36
+    ],
+    "conditionQualifier_id": 5,
+    "objectTherapeutic": [
+      48
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 322,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      38
+    ],
+    "conditionQualifier_id": 5,
+    "objectTherapeutic": [
+      48
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 323,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      36
+    ],
+    "conditionQualifier_id": 15,
+    "objectTherapeutic": [
+      48
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 324,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      38
+    ],
+    "conditionQualifier_id": 15,
+    "objectTherapeutic": [
+      48
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 325,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      20,
+      42
+    ],
+    "conditionQualifier_id": 2,
+    "objectTherapeutic": [
+      39,
+      48,
+      25,
+      29
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 326,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      20,
+      42
+    ],
+    "conditionQualifier_id": 2,
+    "objectTherapeutic": [
+      38,
+      28,
+      48,
+      25
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 327,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      2
+    ],
+    "conditionQualifier_id": 2,
+    "objectTherapeutic": [
+      39,
+      48,
+      29
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 328,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      2
+    ],
+    "conditionQualifier_id": 2,
+    "objectTherapeutic": [
+      38,
+      28,
+      48
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 329,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      41
+    ],
+    "conditionQualifier_id": 2,
+    "objectTherapeutic": [
+      48
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 330,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      41
+    ],
+    "conditionQualifier_id": 74,
+    "objectTherapeutic": [
+      48
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 331,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      42
+    ],
+    "conditionQualifier_id": 72,
+    "objectTherapeutic": [
+      39,
+      35,
+      48
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 332,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      42
+    ],
+    "conditionQualifier_id": 73,
+    "objectTherapeutic": [
+      39,
+      35,
+      48
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 333,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      42
+    ],
+    "conditionQualifier_id": 72,
+    "objectTherapeutic": [
+      11,
+      39,
+      35,
+      48
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 334,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      42
+    ],
+    "conditionQualifier_id": 73,
+    "objectTherapeutic": [
+      11,
+      39,
+      35,
+      48
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 335,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      42
+    ],
+    "conditionQualifier_id": 72,
+    "objectTherapeutic": [
+      37,
+      35,
+      48
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 336,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      42
+    ],
+    "conditionQualifier_id": 73,
+    "objectTherapeutic": [
+      37,
+      35,
+      48
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 337,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      42
+    ],
+    "conditionQualifier_id": 72,
+    "objectTherapeutic": [
+      11,
+      37,
+      35,
+      48
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 338,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      42
+    ],
+    "conditionQualifier_id": 73,
+    "objectTherapeutic": [
+      11,
+      37,
+      35,
+      48
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 339,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      42
+    ],
+    "conditionQualifier_id": 72,
+    "objectTherapeutic": [
+      48
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 340,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      42
+    ],
+    "conditionQualifier_id": 73,
+    "objectTherapeutic": [
+      48
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 341,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      142
+    ],
+    "conditionQualifier_id": 18,
+    "objectTherapeutic": [
+      132,
+      48
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 342,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      37
+    ],
+    "conditionQualifier_id": 18,
+    "objectTherapeutic": [
+      48
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 343,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      38
+    ],
+    "conditionQualifier_id": 18,
+    "objectTherapeutic": [
+      48
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 344,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      144
+    ],
+    "conditionQualifier_id": 5,
+    "objectTherapeutic": [
+      48
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 345,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      43,
+      2,
+      44
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      37,
+      59,
+      2,
+      35,
+      48
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 346,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      41,
+      43,
+      2,
+      44
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      35,
+      48
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 347,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      41,
+      43,
+      2,
+      44
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      37,
+      50,
+      48
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 348,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      52
+    ],
+    "conditionQualifier_id": 11,
+    "objectTherapeutic": [
+      133
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 349,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      53
+    ],
+    "conditionQualifier_id": 11,
+    "objectTherapeutic": [
+      133
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 350,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      69
+    ],
+    "conditionQualifier_id": 44,
+    "objectTherapeutic": [
+      133
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 351,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      20
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      24,
+      75,
+      25
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 352,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      20
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      59,
+      2,
+      35,
+      75,
+      25
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 353,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      20
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      59,
+      24,
+      76,
+      75,
+      25,
+      29
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 354,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      20
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      59,
+      76,
+      35,
+      75,
+      25,
+      29
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 355,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      20
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      59,
+      24,
+      2,
+      75,
+      25,
+      29
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 356,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      20
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      59,
+      2,
+      35,
+      75,
+      25,
+      29
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 357,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      20
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      59,
+      24,
+      76,
+      75,
+      25
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 358,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      20
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      59,
+      76,
+      35,
+      75,
+      25
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 359,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      20
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      59,
+      24,
+      2,
+      75,
+      25
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 360,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      20
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      37,
+      24,
+      75,
+      25
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 361,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      12
+    ],
+    "conditionQualifier_id": 0,
+    "objectTherapeutic": [
+      63,
+      65,
+      43,
+      122,
+      61
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 362,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      32,
+      12
+    ],
+    "conditionQualifier_id": 0,
+    "objectTherapeutic": [
+      43
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 363,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      32
+    ],
+    "conditionQualifier_id": 13,
+    "objectTherapeutic": [
+      43
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 364,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      18
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      32
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 365,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      18
+    ],
+    "conditionQualifier_id": 75,
+    "objectTherapeutic": [
+      32
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 366,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      10
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      12,
+      23
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 367,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      9
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      12,
+      23
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 368,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      62
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      134
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 369,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      63
+    ],
+    "conditionQualifier_id": 5,
+    "objectTherapeutic": [
+      134
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 370,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      64
+    ],
+    "conditionQualifier_id": 5,
+    "objectTherapeutic": [
+      134
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 371,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      65
+    ],
+    "conditionQualifier_id": 5,
+    "objectTherapeutic": [
+      134
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 372,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      1,
+      2
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      36,
+      53
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 373,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      2,
+      3
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      36,
+      53
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 374,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      1,
+      2,
+      3
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      36,
+      53
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 375,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      1,
+      2
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      40,
+      53
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 376,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      2,
+      3
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      40,
+      53
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 377,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      1,
+      2,
+      3
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      40,
+      53
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 378,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      54
+    ],
+    "conditionQualifier_id": 76,
+    "objectTherapeutic": [
+      60
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 379,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      54
+    ],
+    "conditionQualifier_id": 76,
+    "objectTherapeutic": [
+      59,
+      60,
+      8,
+      61
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 380,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      54
+    ],
+    "conditionQualifier_id": 76,
+    "objectTherapeutic": [
+      59,
+      2,
+      60,
+      8,
+      61
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 381,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      54
+    ],
+    "conditionQualifier_id": 76,
+    "objectTherapeutic": [
+      59,
+      135,
+      124,
+      60
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 382,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      54
+    ],
+    "conditionQualifier_id": 76,
+    "objectTherapeutic": [
+      59,
+      2,
+      60,
+      122,
+      61
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 383,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      54
+    ],
+    "conditionQualifier_id": 77,
+    "objectTherapeutic": [
+      59,
+      2,
+      60,
+      122,
+      61
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 384,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      54
+    ],
+    "conditionQualifier_id": 78,
+    "objectTherapeutic": [
+      59,
+      2,
+      60,
+      122,
+      61
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 385,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      54
+    ],
+    "conditionQualifier_id": 79,
+    "objectTherapeutic": [
+      59,
+      2,
+      60,
+      122,
+      61
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 386,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      54
+    ],
+    "conditionQualifier_id": 84,
+    "objectTherapeutic": [
+      59,
+      135,
+      60
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 387,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      47
+    ],
+    "conditionQualifier_id": 51,
+    "objectTherapeutic": [
+      136
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 388,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      48
+    ],
+    "conditionQualifier_id": 51,
+    "objectTherapeutic": [
+      136
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 389,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      49
+    ],
+    "conditionQualifier_id": 51,
+    "objectTherapeutic": [
+      136
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 390,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      50
+    ],
+    "conditionQualifier_id": 51,
+    "objectTherapeutic": [
+      136
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 391,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      47
+    ],
+    "conditionQualifier_id": 27,
+    "objectTherapeutic": [
+      136
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 392,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      48
+    ],
+    "conditionQualifier_id": 27,
+    "objectTherapeutic": [
+      136
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 393,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      49
+    ],
+    "conditionQualifier_id": 27,
+    "objectTherapeutic": [
+      136
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 394,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      50
+    ],
+    "conditionQualifier_id": 27,
+    "objectTherapeutic": [
+      136
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 395,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      47
+    ],
+    "conditionQualifier_id": 54,
+    "objectTherapeutic": [
+      136
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 396,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      48
+    ],
+    "conditionQualifier_id": 54,
+    "objectTherapeutic": [
+      136
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 397,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      49
+    ],
+    "conditionQualifier_id": 54,
+    "objectTherapeutic": [
+      136
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 398,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      50
+    ],
+    "conditionQualifier_id": 54,
+    "objectTherapeutic": [
+      136
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 399,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      47
+    ],
+    "conditionQualifier_id": 55,
+    "objectTherapeutic": [
+      136
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 400,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      48
+    ],
+    "conditionQualifier_id": 55,
+    "objectTherapeutic": [
+      136
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 401,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      49
+    ],
+    "conditionQualifier_id": 55,
+    "objectTherapeutic": [
+      136
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 402,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      50
+    ],
+    "conditionQualifier_id": 55,
+    "objectTherapeutic": [
+      136
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 403,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      43,
+      2,
+      44
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      94
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 404,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      1,
+      2
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      94
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 405,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      2,
+      3
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      94
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 406,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      1,
+      2,
+      3
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      94
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 407,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      18
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      78
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 408,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      152
+    ],
+    "conditionQualifier_id": 38,
+    "objectTherapeutic": [
+      78
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 409,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      18
+    ],
+    "conditionQualifier_id": 4,
+    "objectTherapeutic": [
+      78
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 410,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      18
+    ],
+    "conditionQualifier_id": 5,
+    "objectTherapeutic": [
+      78
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 411,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      45
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      57
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 412,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      48,
+      2
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      87
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 413,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      50,
+      2
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      87
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 414,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      67
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      90
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 415,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      68
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      90
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 416,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      16
+    ],
+    "conditionQualifier_id": 40,
+    "objectTherapeutic": [
+      66
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 417,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      17
+    ],
+    "conditionQualifier_id": 40,
+    "objectTherapeutic": [
+      66
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 418,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      20
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      25
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 419,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      20
+    ],
+    "conditionQualifier_id": 22,
+    "objectTherapeutic": [
+      25
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 420,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      20
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      26
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 421,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      22
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      26
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 422,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      23
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      26
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 423,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      20
+    ],
+    "conditionQualifier_id": 2,
+    "objectTherapeutic": [
+      26
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 424,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      20
+    ],
+    "conditionQualifier_id": 5,
+    "objectTherapeutic": [
+      26
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 425,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      20
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      38,
+      25,
+      95
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 426,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      16
+    ],
+    "conditionQualifier_id": 40,
+    "objectTherapeutic": [
+      22
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 427,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      16
+    ],
+    "conditionQualifier_id": 46,
+    "objectTherapeutic": [
+      22
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 428,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      17
+    ],
+    "conditionQualifier_id": 46,
+    "objectTherapeutic": [
+      22
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 429,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      145
+    ],
+    "conditionQualifier_id": 20,
+    "objectTherapeutic": [
+      137
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 430,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      146
+    ],
+    "conditionQualifier_id": 20,
+    "objectTherapeutic": [
+      137
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 431,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      147
+    ],
+    "conditionQualifier_id": 20,
+    "objectTherapeutic": [
+      137
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 432,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      148
+    ],
+    "conditionQualifier_id": 20,
+    "objectTherapeutic": [
+      137
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 433,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      149
+    ],
+    "conditionQualifier_id": 20,
+    "objectTherapeutic": [
+      137
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 434,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      150
+    ],
+    "conditionQualifier_id": 20,
+    "objectTherapeutic": [
+      137
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 435,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      151
+    ],
+    "conditionQualifier_id": 20,
+    "objectTherapeutic": [
+      137
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 436,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      48
+    ],
+    "conditionQualifier_id": 55,
+    "objectTherapeutic": [
+      138,
+      87
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 437,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      49
+    ],
+    "conditionQualifier_id": 55,
+    "objectTherapeutic": [
+      138,
+      87
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 438,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      50
+    ],
+    "conditionQualifier_id": 55,
+    "objectTherapeutic": [
+      138,
+      87
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 439,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      104
+    ],
+    "conditionQualifier_id": 55,
+    "objectTherapeutic": [
+      138,
+      87
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 440,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      105
+    ],
+    "conditionQualifier_id": 55,
+    "objectTherapeutic": [
+      138,
+      87
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 441,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      160
+    ],
+    "conditionQualifier_id": 55,
+    "objectTherapeutic": [
+      138,
+      87
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 442,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      125
+    ],
+    "conditionQualifier_id": 55,
+    "objectTherapeutic": [
+      138,
+      87
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 443,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      161
+    ],
+    "conditionQualifier_id": 55,
+    "objectTherapeutic": [
+      138,
+      87
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 444,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      162
+    ],
+    "conditionQualifier_id": 55,
+    "objectTherapeutic": [
+      138,
+      87
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 445,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      128
+    ],
+    "conditionQualifier_id": 55,
+    "objectTherapeutic": [
+      138,
+      87
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 446,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      129
+    ],
+    "conditionQualifier_id": 55,
+    "objectTherapeutic": [
+      138,
+      87
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 447,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      163
+    ],
+    "conditionQualifier_id": 55,
+    "objectTherapeutic": [
+      138,
+      87
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 448,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      164
+    ],
+    "conditionQualifier_id": 55,
+    "objectTherapeutic": [
+      138,
+      87
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 449,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      132
+    ],
+    "conditionQualifier_id": 55,
+    "objectTherapeutic": [
+      138,
+      87
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 450,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      133
+    ],
+    "conditionQualifier_id": 55,
+    "objectTherapeutic": [
+      138,
+      87
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 451,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      165
+    ],
+    "conditionQualifier_id": 55,
+    "objectTherapeutic": [
+      138,
+      87
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 452,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      166
+    ],
+    "conditionQualifier_id": 55,
+    "objectTherapeutic": [
+      138,
+      87
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 453,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      136
+    ],
+    "conditionQualifier_id": 55,
+    "objectTherapeutic": [
+      138,
+      87
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 454,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      137
+    ],
+    "conditionQualifier_id": 55,
+    "objectTherapeutic": [
+      138,
+      87
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 455,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      167
+    ],
+    "conditionQualifier_id": 55,
+    "objectTherapeutic": [
+      138,
+      87
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 456,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      168
+    ],
+    "conditionQualifier_id": 55,
+    "objectTherapeutic": [
+      138,
+      87
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 457,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      169
+    ],
+    "conditionQualifier_id": 55,
+    "objectTherapeutic": [
+      138,
+      87
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 458,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      158
+    ],
+    "conditionQualifier_id": 88,
+    "objectTherapeutic": [
+      4
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 459,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      159
+    ],
+    "conditionQualifier_id": 88,
+    "objectTherapeutic": [
+      4
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 460,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      158
+    ],
+    "conditionQualifier_id": 4,
+    "objectTherapeutic": [
+      4
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 461,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      159
+    ],
+    "conditionQualifier_id": 4,
+    "objectTherapeutic": [
+      4
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 462,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      7
+    ],
+    "conditionQualifier_id": 55,
+    "objectTherapeutic": [
+      138,
+      87
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 463,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      10
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      139,
+      108
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 464,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      9
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      139,
+      108
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 465,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      10
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      108,
+      37,
+      49
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 466,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      9
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      108,
+      37,
+      49
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 467,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      153
+    ],
+    "conditionQualifier_id": 51,
+    "objectTherapeutic": [
+      140
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 468,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      153
+    ],
+    "conditionQualifier_id": 27,
+    "objectTherapeutic": [
+      140
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 469,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      153
+    ],
+    "conditionQualifier_id": 54,
+    "objectTherapeutic": [
+      140
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 470,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      155
+    ],
+    "conditionQualifier_id": 35,
+    "objectTherapeutic": [
+      141
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 471,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      154
+    ],
+    "conditionQualifier_id": 35,
+    "objectTherapeutic": [
+      141
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 472,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      16
+    ],
+    "conditionQualifier_id": 35,
+    "objectTherapeutic": [
+      141
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 473,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      17
+    ],
+    "conditionQualifier_id": 35,
+    "objectTherapeutic": [
+      141
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 474,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      34,
+      35
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      37,
+      44,
+      35
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 475,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      34,
+      35
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      39,
+      44,
+      50
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 476,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      34,
+      35
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      39,
+      44,
+      49
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 477,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      34,
+      35
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      37,
+      44,
+      49
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 478,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      45
+    ],
+    "conditionQualifier_id": 15,
+    "objectTherapeutic": [
+      54,
+      19
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 479,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      74
+    ],
+    "conditionQualifier_id": 6,
+    "objectTherapeutic": [
+      142
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 480,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      75
+    ],
+    "conditionQualifier_id": 6,
+    "objectTherapeutic": [
+      142
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 481,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      76
+    ],
+    "conditionQualifier_id": 6,
+    "objectTherapeutic": [
+      142
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 482,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      77
+    ],
+    "conditionQualifier_id": 6,
+    "objectTherapeutic": [
+      142
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 483,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      78
+    ],
+    "conditionQualifier_id": 6,
+    "objectTherapeutic": [
+      142
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 484,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      111
+    ],
+    "conditionQualifier_id": 6,
+    "objectTherapeutic": [
+      142
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 485,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      112
+    ],
+    "conditionQualifier_id": 6,
+    "objectTherapeutic": [
+      142
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 486,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      113
+    ],
+    "conditionQualifier_id": 6,
+    "objectTherapeutic": [
+      142
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 487,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      114
+    ],
+    "conditionQualifier_id": 6,
+    "objectTherapeutic": [
+      142
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 488,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      115
+    ],
+    "conditionQualifier_id": 6,
+    "objectTherapeutic": [
+      142
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 489,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      74
+    ],
+    "conditionQualifier_id": 48,
+    "objectTherapeutic": [
+      142
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 490,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      75
+    ],
+    "conditionQualifier_id": 48,
+    "objectTherapeutic": [
+      142
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 491,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      76
+    ],
+    "conditionQualifier_id": 48,
+    "objectTherapeutic": [
+      142
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 492,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      77
+    ],
+    "conditionQualifier_id": 48,
+    "objectTherapeutic": [
+      142
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 493,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      78
+    ],
+    "conditionQualifier_id": 48,
+    "objectTherapeutic": [
+      142
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 494,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      111
+    ],
+    "conditionQualifier_id": 48,
+    "objectTherapeutic": [
+      142
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 495,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      112
+    ],
+    "conditionQualifier_id": 48,
+    "objectTherapeutic": [
+      142
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 496,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      113
+    ],
+    "conditionQualifier_id": 48,
+    "objectTherapeutic": [
+      142
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 497,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      114
+    ],
+    "conditionQualifier_id": 48,
+    "objectTherapeutic": [
+      142
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 498,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      115
+    ],
+    "conditionQualifier_id": 48,
+    "objectTherapeutic": [
+      142
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 499,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      1,
+      2
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      36,
+      143,
+      53
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 500,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      2,
+      3
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      36,
+      143,
+      53
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 501,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      1,
+      2,
+      3
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      36,
+      143,
+      53
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 502,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      1,
+      2
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      143,
+      40,
+      53
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 503,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      2,
+      3
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      143,
+      40,
+      53
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 504,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      1,
+      2,
+      3
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      143,
+      40,
+      53
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 505,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      34,
+      35
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      39,
+      72,
+      49
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 506,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      34,
+      35
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      39,
+      50,
+      72
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 507,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      36
+    ],
+    "conditionQualifier_id": 15,
+    "objectTherapeutic": [
+      71,
+      72
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 508,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      38
+    ],
+    "conditionQualifier_id": 15,
+    "objectTherapeutic": [
+      72
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 509,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      36
+    ],
+    "conditionQualifier_id": 15,
+    "objectTherapeutic": [
+      72
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 510,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      1,
+      2,
+      59
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      30,
+      144,
+      31
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 511,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      2,
+      3,
+      59
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      30,
+      144,
+      31
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 512,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      1,
+      2,
+      3,
+      59
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      30,
+      144,
+      31
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 513,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      2,
+      103
+    ],
+    "conditionQualifier_id": 2,
+    "objectTherapeutic": [
+      29,
+      28,
+      111
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 514,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      2,
+      103
+    ],
+    "conditionQualifier_id": 2,
+    "objectTherapeutic": [
+      38,
+      28,
+      111
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 515,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      20
+    ],
+    "conditionQualifier_id": 85,
+    "objectTherapeutic": [
+      145
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 516,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      20
+    ],
+    "conditionQualifier_id": 86,
+    "objectTherapeutic": [
+      145
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 517,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      20
+    ],
+    "conditionQualifier_id": 11,
+    "objectTherapeutic": [
+      145
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 518,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      156
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      146
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 519,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      156
+    ],
+    "conditionQualifier_id": 52,
+    "objectTherapeutic": [
+      146
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 520,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      8
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      147
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 521,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      16
+    ],
+    "conditionQualifier_id": 15,
+    "objectTherapeutic": [
+      29,
+      19,
+      18,
+      28
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 522,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      12
+    ],
+    "conditionQualifier_id": 71,
+    "objectTherapeutic": [
+      83
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 523,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      34,
+      35
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      37,
+      44,
+      45,
+      49
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 524,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      34,
+      35
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      39,
+      44,
+      45,
+      49
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 525,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      34,
+      35
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      37,
+      44,
+      50,
+      45
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 526,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      34,
+      35
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      39,
+      44,
+      50,
+      45
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 527,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      34,
+      35
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      37,
+      44,
+      51,
+      45
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 528,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      157
+    ],
+    "conditionQualifier_id": 0,
+    "objectTherapeutic": [
+      148
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 529,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      157
+    ],
+    "conditionQualifier_id": 1,
+    "objectTherapeutic": [
+      148
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 530,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      157
+    ],
+    "conditionQualifier_id": 78,
+    "objectTherapeutic": [
+      148
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 531,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      157
+    ],
+    "conditionQualifier_id": 87,
+    "objectTherapeutic": [
+      148
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 532,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      0
+    ],
+    "conditionQualifier_id": 80,
+    "objectTherapeutic": [
+      0,
+      1,
+      2,
+      3
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 533,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      0
+    ],
+    "conditionQualifier_id": 80,
+    "objectTherapeutic": [
+      0
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 534,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      0
+    ],
+    "conditionQualifier_id": 30,
+    "objectTherapeutic": [
+      0
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 535,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      3,
+      2
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      4,
+      5
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 536,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      1,
+      3,
+      2
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      4,
+      5
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 537,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      47
+    ],
+    "conditionQualifier_id": 55,
+    "objectTherapeutic": [
+      6,
+      7,
+      8
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 538,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      49
+    ],
+    "conditionQualifier_id": 55,
+    "objectTherapeutic": [
+      6,
+      7,
+      8
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 539,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      48
+    ],
+    "conditionQualifier_id": 55,
+    "objectTherapeutic": [
+      6,
+      7,
+      8
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 540,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      50
+    ],
+    "conditionQualifier_id": 55,
+    "objectTherapeutic": [
+      6,
+      7,
+      8
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 541,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      9
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      11,
+      12
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 542,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      10
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      11,
+      12
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 543,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      15,
+      13
+    ],
+    "conditionQualifier_id": 0,
+    "objectTherapeutic": [
+      14
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 544,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      15,
+      14
+    ],
+    "conditionQualifier_id": 0,
+    "objectTherapeutic": [
+      15
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 545,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      15
+    ],
+    "conditionQualifier_id": 13,
+    "objectTherapeutic": [
+      16
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 546,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      16
+    ],
+    "conditionQualifier_id": 15,
+    "objectTherapeutic": [
+      19,
+      18
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 547,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      18
+    ],
+    "conditionQualifier_id": 38,
+    "objectTherapeutic": [
+      20
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 548,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      19
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      12,
+      23
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 549,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      20
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      24,
+      25
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 550,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      21
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      24,
+      25
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 551,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      21
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      26
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 552,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      21
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      26
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 553,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      21
+    ],
+    "conditionQualifier_id": 2,
+    "objectTherapeutic": [
+      26
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 554,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      24,
+      25,
+      26,
+      27
+    ],
+    "conditionQualifier_id": 15,
+    "objectTherapeutic": [
+      19
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 555,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      24,
+      25,
+      26,
+      27
+    ],
+    "conditionQualifier_id": 15,
+    "objectTherapeutic": [
+      19,
+      27
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 556,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      24,
+      25,
+      26,
+      27
+    ],
+    "conditionQualifier_id": 15,
+    "objectTherapeutic": [
+      19,
+      28,
+      29
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 557,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      3,
+      2
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      30,
+      31
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 558,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      1,
+      3,
+      2
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      30,
+      31
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 559,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      19
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      33
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 560,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      19
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      34
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 561,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      20
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      35,
+      25
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 562,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      20
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      36,
+      25
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 563,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      20
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      37,
+      24,
+      25
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 564,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      20
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      2,
+      25,
+      35
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 565,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      21
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      25
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 566,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      21
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      35,
+      25
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 567,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      21
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      36,
+      25
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 568,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      21
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      37,
+      24,
+      25
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 569,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      21
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      2,
+      35,
+      25
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 570,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      20
+    ],
+    "conditionQualifier_id": 81,
+    "objectTherapeutic": [
+      38,
+      39,
+      25
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 571,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      20
+    ],
+    "conditionQualifier_id": 81,
+    "objectTherapeutic": [
+      39,
+      25,
+      29
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 572,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      21
+    ],
+    "conditionQualifier_id": 81,
+    "objectTherapeutic": [
+      38,
+      39,
+      25
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 573,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      21
+    ],
+    "conditionQualifier_id": 81,
+    "objectTherapeutic": [
+      39,
+      25,
+      29
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 574,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      2,
+      1
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      40,
+      31
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 575,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      2,
+      1,
+      3
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      40,
+      31
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 576,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      2,
+      1
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      30,
+      31
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 577,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      2,
+      1,
+      3
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      30,
+      31
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 578,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      15
+    ],
+    "conditionQualifier_id": 13,
+    "objectTherapeutic": [
+      41
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 579,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      15
+    ],
+    "conditionQualifier_id": 0,
+    "objectTherapeutic": [
+      41
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 580,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      28
+    ],
+    "conditionQualifier_id": 45,
+    "objectTherapeutic": [
+      41
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 581,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      29
+    ],
+    "conditionQualifier_id": 45,
+    "objectTherapeutic": [
+      41
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 582,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      15
+    ],
+    "conditionQualifier_id": 0,
+    "objectTherapeutic": [
+      43
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 583,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      15,
+      32
+    ],
+    "conditionQualifier_id": 0,
+    "objectTherapeutic": [
+      43
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 584,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      33
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      44
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 585,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      34,
+      35
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      37,
+      44,
+      45
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 586,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      37
+    ],
+    "conditionQualifier_id": 18,
+    "objectTherapeutic": [
+      37,
+      44,
+      46,
+      35
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 587,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      38
+    ],
+    "conditionQualifier_id": 18,
+    "objectTherapeutic": [
+      47
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 588,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      39,
+      35,
+      34
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      48
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 589,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      40,
+      35,
+      34
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      48
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 590,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      35,
+      34
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      37,
+      48,
+      49
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 591,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      35,
+      34
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      39,
+      48,
+      49
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 592,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      35,
+      34
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      39,
+      50,
+      48
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 593,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      35,
+      34
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      37,
+      50,
+      48
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 594,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      35,
+      34
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      37,
+      35,
+      48
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 595,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      41
+    ],
+    "conditionQualifier_id": 8,
+    "objectTherapeutic": [
+      48
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 596,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      42
+    ],
+    "conditionQualifier_id": 25,
+    "objectTherapeutic": [
+      37,
+      48,
+      29
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 597,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      42
+    ],
+    "conditionQualifier_id": 25,
+    "objectTherapeutic": [
+      39,
+      48,
+      29
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 598,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      39
+    ],
+    "conditionQualifier_id": 25,
+    "objectTherapeutic": [
+      48
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 599,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      36
+    ],
+    "conditionQualifier_id": 18,
+    "objectTherapeutic": [
+      48
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 600,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      38
+    ],
+    "conditionQualifier_id": 81,
+    "objectTherapeutic": [
+      48
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 601,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      36
+    ],
+    "conditionQualifier_id": 81,
+    "objectTherapeutic": [
+      48
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 602,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      38
+    ],
+    "conditionQualifier_id": 22,
+    "objectTherapeutic": [
+      48
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 603,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      36
+    ],
+    "conditionQualifier_id": 22,
+    "objectTherapeutic": [
+      48
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 604,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      38
+    ],
+    "conditionQualifier_id": 11,
+    "objectTherapeutic": [
+      48
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 605,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      36
+    ],
+    "conditionQualifier_id": 11,
+    "objectTherapeutic": [
+      48
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 606,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      41
+    ],
+    "conditionQualifier_id": 74,
+    "objectTherapeutic": [
+      39,
+      48,
+      29
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 607,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      41
+    ],
+    "conditionQualifier_id": 74,
+    "objectTherapeutic": [
+      37,
+      48,
+      29
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 608,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      43,
+      2,
+      44
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      48
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 609,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      41,
+      43,
+      2,
+      44
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      51,
+      48
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 610,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      20,
+      42
+    ],
+    "conditionQualifier_id": 2,
+    "objectTherapeutic": [
+      37,
+      48,
+      25,
+      29
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 611,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      2,
+      42
+    ],
+    "conditionQualifier_id": 2,
+    "objectTherapeutic": [
+      39,
+      48,
+      29
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 612,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      2,
+      42
+    ],
+    "conditionQualifier_id": 2,
+    "objectTherapeutic": [
+      37,
+      48,
+      29
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 613,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      21
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      52
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 614,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      3,
+      2
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      40,
+      53
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 615,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      1,
+      3,
+      2
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      40,
+      53
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 616,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      3,
+      2
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      30,
+      53
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 617,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      1,
+      3,
+      2
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      30,
+      53
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 618,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      39,
+      34,
+      35,
+      46
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      55
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 619,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      33,
+      34,
+      35,
+      46
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      37,
+      55,
+      49
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 620,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      37
+    ],
+    "conditionQualifier_id": 18,
+    "objectTherapeutic": [
+      44,
+      46
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 621,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      53
+    ],
+    "conditionQualifier_id": 29,
+    "objectTherapeutic": [
+      58
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 622,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      54
+    ],
+    "conditionQualifier_id": 77,
+    "objectTherapeutic": [
+      59,
+      60,
+      2,
+      8,
+      61
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 623,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      54
+    ],
+    "conditionQualifier_id": 76,
+    "objectTherapeutic": [
+      59,
+      60,
+      2,
+      8,
+      61
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 624,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      54
+    ],
+    "conditionQualifier_id": 77,
+    "objectTherapeutic": [
+      59,
+      62,
+      63,
+      2,
+      64,
+      65,
+      60,
+      61
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 625,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      54
+    ],
+    "conditionQualifier_id": 76,
+    "objectTherapeutic": [
+      59,
+      62,
+      63,
+      2,
+      64,
+      65,
+      60,
+      61
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 626,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      54
+    ],
+    "conditionQualifier_id": 78,
+    "objectTherapeutic": [
+      59,
+      62,
+      63,
+      2,
+      64,
+      65,
+      60,
+      61
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 627,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      17
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      67,
+      66
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 628,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      55
+    ],
+    "conditionQualifier_id": 1,
+    "objectTherapeutic": [
+      63,
+      68,
+      69
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 629,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      20,
+      1,
+      3
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      112
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 630,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      20,
+      1
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      112
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 631,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      20,
+      3
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      112
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 632,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      21,
+      1,
+      3
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      112
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 633,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      21,
+      1
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      112
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 634,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      21,
+      3
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      112
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 635,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      35,
+      34
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      37,
+      71,
+      72,
+      49
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 636,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      35,
+      34
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      39,
+      71,
+      72,
+      49
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 637,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      35,
+      34
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      37,
+      71,
+      72,
+      35
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 638,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      33
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      37,
+      72,
+      35
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 639,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      33
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      37,
+      72,
+      49
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 640,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      33
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      39,
+      50,
+      72
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 641,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      33
+    ],
+    "conditionQualifier_id": 8,
+    "objectTherapeutic": [
+      72
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 642,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      33
+    ],
+    "conditionQualifier_id": 82,
+    "objectTherapeutic": [
+      71,
+      72
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 643,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      33
+    ],
+    "conditionQualifier_id": 82,
+    "objectTherapeutic": [
+      39,
+      72,
+      29
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 644,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      2,
+      56
+    ],
+    "conditionQualifier_id": 74,
+    "objectTherapeutic": [
+      72,
+      28,
+      29
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 645,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      2,
+      56
+    ],
+    "conditionQualifier_id": 74,
+    "objectTherapeutic": [
+      72,
+      28
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 646,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      2,
+      56
+    ],
+    "conditionQualifier_id": 81,
+    "objectTherapeutic": [
+      72,
+      28,
+      29
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 647,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      2,
+      56
+    ],
+    "conditionQualifier_id": 81,
+    "objectTherapeutic": [
+      72,
+      28
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 648,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      2,
+      56
+    ],
+    "conditionQualifier_id": 2,
+    "objectTherapeutic": [
+      72,
+      28,
+      29
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 649,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      2,
+      56
+    ],
+    "conditionQualifier_id": 2,
+    "objectTherapeutic": [
+      72,
+      28
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 650,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      57
+    ],
+    "conditionQualifier_id": 40,
+    "objectTherapeutic": [
+      72,
+      73
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 651,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      52
+    ],
+    "conditionQualifier_id": 29,
+    "objectTherapeutic": [
+      74
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 652,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      53
+    ],
+    "conditionQualifier_id": 29,
+    "objectTherapeutic": [
+      74
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 653,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      2,
+      1,
+      87
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      77,
+      30
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 654,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      2,
+      3,
+      87
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      77,
+      30
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 655,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      2,
+      1,
+      3,
+      87
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      77,
+      30
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 656,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      18
+    ],
+    "conditionQualifier_id": 75,
+    "objectTherapeutic": [
+      78
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 657,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      60
+    ],
+    "conditionQualifier_id": 38,
+    "objectTherapeutic": [
+      78
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 658,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      61
+    ],
+    "conditionQualifier_id": 45,
+    "objectTherapeutic": [
+      79
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 659,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      15
+    ],
+    "conditionQualifier_id": 13,
+    "objectTherapeutic": [
+      83
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 660,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      16
+    ],
+    "conditionQualifier_id": 83,
+    "objectTherapeutic": [
+      67,
+      66
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 661,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      15
+    ],
+    "conditionQualifier_id": 13,
+    "objectTherapeutic": [
+      84
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 662,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      15
+    ],
+    "conditionQualifier_id": 0,
+    "objectTherapeutic": [
+      84
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 663,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      17
+    ],
+    "conditionQualifier_id": 40,
+    "objectTherapeutic": [
+      67
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 664,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      19
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      86
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 665,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      10
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      39,
+      86
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 666,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      10
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      37,
+      86
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 667,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      9
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      39,
+      86
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 668,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      9
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      37,
+      86
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 669,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      19
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      12
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 670,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      15
+    ],
+    "conditionQualifier_id": 13,
+    "objectTherapeutic": [
+      88
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 671,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      71
+    ],
+    "conditionQualifier_id": 8,
+    "objectTherapeutic": [
+      89
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 672,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      39,
+      34,
+      35
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      89
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 673,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      72
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      89,
+      11,
+      37,
+      35
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 674,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      8
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      89,
+      11,
+      37,
+      35
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 675,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      35
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      89,
+      37,
+      51
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 676,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      34
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      89,
+      37,
+      51
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 677,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      34,
+      35
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      89,
+      37,
+      51
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 678,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      73,
+      34,
+      35
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      89
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 679,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      33,
+      43,
+      2,
+      44
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      89,
+      51
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 680,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      34,
+      35
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      37,
+      44,
+      49,
+      45
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 681,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      34,
+      35
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      39,
+      44,
+      49,
+      45
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 682,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      2,
+      43,
+      44
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      94
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 683,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      2,
+      1
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      94
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 684,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      2,
+      1,
+      3
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      94
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 685,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      20,
+      1,
+      44
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      96,
+      25
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 686,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      20,
+      1,
+      3
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      96,
+      40
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 687,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      21
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      38,
+      96
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 688,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      21,
+      1,
+      44
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      96,
+      25
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 689,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      21,
+      1,
+      3
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      96,
+      40
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 690,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      25,
+      27
+    ],
+    "conditionQualifier_id": 15,
+    "objectTherapeutic": [
+      97,
+      28,
+      29
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 691,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      25,
+      27
+    ],
+    "conditionQualifier_id": 15,
+    "objectTherapeutic": [
+      97,
+      27,
+      29
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 692,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      25,
+      27
+    ],
+    "conditionQualifier_id": 15,
+    "objectTherapeutic": [
+      97
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 693,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      80
+    ],
+    "conditionQualifier_id": 84,
+    "objectTherapeutic": [
+      98
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 694,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      81
+    ],
+    "conditionQualifier_id": 84,
+    "objectTherapeutic": [
+      98
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 695,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      84
+    ],
+    "conditionQualifier_id": 84,
+    "objectTherapeutic": [
+      98
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 696,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      83
+    ],
+    "conditionQualifier_id": 84,
+    "objectTherapeutic": [
+      98
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 697,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      2,
+      1
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      99
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 698,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      2,
+      1,
+      3
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      99
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 699,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      2,
+      1
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      99,
+      36
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 700,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      2,
+      3
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      99,
+      36
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 701,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      2,
+      1,
+      3
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      99,
+      36
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 702,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      2,
+      1
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      99,
+      40
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 703,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      2,
+      3
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      99,
+      40
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 704,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      2,
+      1,
+      3
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      99,
+      40
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 705,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      2,
+      1
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      99,
+      30
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 706,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      2,
+      3
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      99,
+      30
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 707,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      2,
+      1,
+      3
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      99,
+      30
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 708,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      19
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      101
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 709,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      66
+    ],
+    "conditionQualifier_id": 1,
+    "objectTherapeutic": [
+      104
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 710,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      85
+    ],
+    "conditionQualifier_id": 1,
+    "objectTherapeutic": [
+      104
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 711,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      17
+    ],
+    "conditionQualifier_id": 40,
+    "objectTherapeutic": [
+      22
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 712,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      81
+    ],
+    "conditionQualifier_id": 84,
+    "objectTherapeutic": [
+      105,
+      60
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 713,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      80
+    ],
+    "conditionQualifier_id": 84,
+    "objectTherapeutic": [
+      105,
+      60
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 714,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      84
+    ],
+    "conditionQualifier_id": 84,
+    "objectTherapeutic": [
+      105,
+      60
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 715,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      39,
+      34,
+      35
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      37,
+      49,
+      107
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 716,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      39,
+      34,
+      35
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      39,
+      49,
+      107
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 717,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      1,
+      2,
+      87
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      109,
+      30
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 718,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      1,
+      2,
+      88
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      109,
+      30
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 719,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      95
+    ],
+    "conditionQualifier_id": 8,
+    "objectTherapeutic": [
+      110
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 720,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      96
+    ],
+    "conditionQualifier_id": 8,
+    "objectTherapeutic": [
+      110
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 721,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      98
+    ],
+    "conditionQualifier_id": 8,
+    "objectTherapeutic": [
+      110
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 722,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      2,
+      103
+    ],
+    "conditionQualifier_id": 2,
+    "objectTherapeutic": [
+      28,
+      111,
+      29
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 723,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      66
+    ],
+    "conditionQualifier_id": 1,
+    "objectTherapeutic": [
+      82,
+      68,
+      63
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 724,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      47
+    ],
+    "conditionQualifier_id": 51,
+    "objectTherapeutic": [
+      46,
+      11
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 725,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      49
+    ],
+    "conditionQualifier_id": 51,
+    "objectTherapeutic": [
+      46,
+      11
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 726,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      48
+    ],
+    "conditionQualifier_id": 51,
+    "objectTherapeutic": [
+      46,
+      11
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 727,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      50
+    ],
+    "conditionQualifier_id": 51,
+    "objectTherapeutic": [
+      46,
+      11
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 728,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      47
+    ],
+    "conditionQualifier_id": 27,
+    "objectTherapeutic": [
+      46,
+      11
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 729,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      49
+    ],
+    "conditionQualifier_id": 27,
+    "objectTherapeutic": [
+      46,
+      11
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 730,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      48
+    ],
+    "conditionQualifier_id": 27,
+    "objectTherapeutic": [
+      46,
+      11
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 731,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      50
+    ],
+    "conditionQualifier_id": 27,
+    "objectTherapeutic": [
+      46,
+      11
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 732,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      47
+    ],
+    "conditionQualifier_id": 54,
+    "objectTherapeutic": [
+      46,
+      11
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 733,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      50
+    ],
+    "conditionQualifier_id": 54,
+    "objectTherapeutic": [
+      46,
+      11
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 734,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      48
+    ],
+    "conditionQualifier_id": 54,
+    "objectTherapeutic": [
+      46,
+      11
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 735,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      51
+    ],
+    "conditionQualifier_id": 51,
+    "objectTherapeutic": [
+      46,
+      11
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 736,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      51
+    ],
+    "conditionQualifier_id": 27,
+    "objectTherapeutic": [
+      46,
+      11
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 737,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      51
+    ],
+    "conditionQualifier_id": 54,
+    "objectTherapeutic": [
+      46,
+      11
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 738,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      32,
+      15
+    ],
+    "conditionQualifier_id": 0,
+    "objectTherapeutic": [
+      43
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 739,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      16
+    ],
+    "conditionQualifier_id": 40,
+    "objectTherapeutic": [
+      66,
+      67
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 740,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      17
+    ],
+    "conditionQualifier_id": 40,
+    "objectTherapeutic": [
+      66,
+      67
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 741,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      80
+    ],
+    "conditionQualifier_id": 84,
+    "objectTherapeutic": [
+      113
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 742,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      81
+    ],
+    "conditionQualifier_id": 84,
+    "objectTherapeutic": [
+      113
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 743,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      84
+    ],
+    "conditionQualifier_id": 84,
+    "objectTherapeutic": [
+      113
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 744,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      80
+    ],
+    "conditionQualifier_id": 84,
+    "objectTherapeutic": [
+      114
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 745,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      81
+    ],
+    "conditionQualifier_id": 84,
+    "objectTherapeutic": [
+      114
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 746,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      84
+    ],
+    "conditionQualifier_id": 84,
+    "objectTherapeutic": [
+      114
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 747,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      80
+    ],
+    "conditionQualifier_id": 84,
+    "objectTherapeutic": [
+      115
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 748,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      81
+    ],
+    "conditionQualifier_id": 84,
+    "objectTherapeutic": [
+      115
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 749,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      84
+    ],
+    "conditionQualifier_id": 84,
+    "objectTherapeutic": [
+      115
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 750,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      38
+    ],
+    "conditionQualifier_id": 15,
+    "objectTherapeutic": [
+      72,
+      71
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 751,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      36
+    ],
+    "conditionQualifier_id": 15,
+    "objectTherapeutic": [
+      72,
+      71
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 752,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      2,
+      1
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      40,
+      53
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 753,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      2,
+      1,
+      3
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      40,
+      53
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 754,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      2,
+      1
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      30,
+      53
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 755,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      2,
+      1,
+      3
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      30,
+      53
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 756,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      13,
+      15
+    ],
+    "conditionQualifier_id": 0,
+    "objectTherapeutic": [
+      14
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 757,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      0
+    ],
+    "conditionQualifier_id": 80,
+    "objectTherapeutic": [
+      0,
+      39,
+      63,
+      64
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 758,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      55
+    ],
+    "conditionQualifier_id": 0,
+    "objectTherapeutic": [
+      63,
+      68,
+      69
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 759,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      20
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      37,
+      35,
+      75,
+      25
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 760,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      0,
+      2
+    ],
+    "conditionQualifier_id": 80,
+    "objectTherapeutic": [
+      0,
+      37,
+      64,
+      116
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 761,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      41,
+      2
+    ],
+    "conditionQualifier_id": 2,
+    "objectTherapeutic": [
+      39,
+      48,
+      29
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 762,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      41,
+      2
+    ],
+    "conditionQualifier_id": 2,
+    "objectTherapeutic": [
+      28,
+      48,
+      29
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 763,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      15
+    ],
+    "conditionQualifier_id": 0,
+    "objectTherapeutic": [
+      15
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 764,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      20
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      35,
+      75,
+      25
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 765,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      20
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      117,
+      75,
+      25
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 766,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      20
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      75,
+      25
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 767,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      33
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      37,
+      50,
+      72
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 768,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      33
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      39,
+      72,
+      49
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 769,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      2
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      11,
+      35
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 770,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      19
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      11,
+      12
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 771,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      43,
+      2,
+      44
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      38
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 772,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      1
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      119
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 773,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      20,
+      1,
+      3
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      36
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 774,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      20,
+      1
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      36
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 775,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      20,
+      3
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      36
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 776,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      20,
+      1,
+      3
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      36,
+      25
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 777,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      20,
+      1
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      36,
+      25
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 778,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      20,
+      3
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      36,
+      25
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 779,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      20
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      2,
+      35,
+      25
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 780,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      2,
+      1,
+      3
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      4,
+      5
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 781,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      2,
+      1
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      4,
+      5
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 782,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      2,
+      43,
+      44
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      37,
+      59,
+      2,
+      35
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 783,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      43
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      30
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 784,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      1,
+      3
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      40
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 785,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      1
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      40
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 786,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      3
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      40
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 787,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      1,
+      3
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      5
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 788,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      1
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      5
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 789,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      3
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      5
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 790,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      43,
+      2,
+      44
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      37,
+      50
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 791,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      20
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      59,
+      2,
+      35,
+      25
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 792,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      1,
+      2,
+      3
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      99,
+      5
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 793,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      1,
+      2
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      99,
+      5
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 794,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      2,
+      3
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      99,
+      5
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 795,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      43,
+      2,
+      44
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      37,
+      59,
+      2,
+      35
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 796,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      24,
+      25,
+      27
+    ],
+    "conditionQualifier_id": 15,
+    "objectTherapeutic": [
+      19
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 797,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      25,
+      27
+    ],
+    "conditionQualifier_id": 15,
+    "objectTherapeutic": [
+      19,
+      27,
+      29
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 798,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      25,
+      27
+    ],
+    "conditionQualifier_id": 15,
+    "objectTherapeutic": [
+      19,
+      27
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 799,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      25,
+      27
+    ],
+    "conditionQualifier_id": 15,
+    "objectTherapeutic": [
+      28,
+      97,
+      29
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 800,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      33
+    ],
+    "conditionQualifier_id": 82,
+    "objectTherapeutic": [
+      72,
+      28,
+      29
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 801,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      80
+    ],
+    "conditionQualifier_id": 84,
+    "objectTherapeutic": [
+      105,
+      120
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 802,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      81
+    ],
+    "conditionQualifier_id": 84,
+    "objectTherapeutic": [
+      105,
+      120
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 803,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      84
+    ],
+    "conditionQualifier_id": 84,
+    "objectTherapeutic": [
+      105,
+      120
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 804,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      66
+    ],
+    "conditionQualifier_id": 1,
+    "objectTherapeutic": [
+      82
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 805,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      33
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      37,
+      35,
+      72
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 806,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      33
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      39,
+      49,
+      72
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 807,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      33
+    ],
+    "conditionQualifier_id": 47,
+    "objectTherapeutic": [
+      37,
+      49,
+      72
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 808,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      54
+    ],
+    "conditionQualifier_id": 76,
+    "objectTherapeutic": [
+      121,
+      60
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 809,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      54
+    ],
+    "conditionQualifier_id": 76,
+    "objectTherapeutic": [
+      39,
+      63,
+      60
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 810,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      54
+    ],
+    "conditionQualifier_id": 77,
+    "objectTherapeutic": [
+      59,
+      2,
+      64,
+      8,
+      60,
+      61
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 811,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      54
+    ],
+    "conditionQualifier_id": 76,
+    "objectTherapeutic": [
+      59,
+      2,
+      64,
+      8,
+      60,
+      61
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 812,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      54
+    ],
+    "conditionQualifier_id": 76,
+    "objectTherapeutic": [
+      37,
+      64,
+      116,
+      60
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 813,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      54
+    ],
+    "conditionQualifier_id": 76,
+    "objectTherapeutic": [
+      59,
+      2,
+      8,
+      60,
+      117
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 814,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      54
+    ],
+    "conditionQualifier_id": 77,
+    "objectTherapeutic": [
+      50,
+      28,
+      60
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 815,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      54
+    ],
+    "conditionQualifier_id": 76,
+    "objectTherapeutic": [
+      50,
+      28,
+      60
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 816,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      54
+    ],
+    "conditionQualifier_id": 76,
+    "objectTherapeutic": [
+      59,
+      64,
+      8,
+      60,
+      61
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 817,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      0
+    ],
+    "conditionQualifier_id": 80,
+    "objectTherapeutic": [
+      121,
+      0
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 818,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      54
+    ],
+    "conditionQualifier_id": 20,
+    "objectTherapeutic": [
+      59,
+      8,
+      60,
+      61
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 819,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      54
+    ],
+    "conditionQualifier_id": 20,
+    "objectTherapeutic": [
+      59,
+      2,
+      8,
+      60,
+      61
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 820,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      54
+    ],
+    "conditionQualifier_id": 20,
+    "objectTherapeutic": [
+      123,
+      124,
+      8,
+      60
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 821,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      54
+    ],
+    "conditionQualifier_id": 20,
+    "objectTherapeutic": [
+      59,
+      2,
+      64,
+      125,
+      8,
+      60
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 822,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      54
+    ],
+    "conditionQualifier_id": 20,
+    "objectTherapeutic": [
+      60
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 823,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      54
+    ],
+    "conditionQualifier_id": 76,
+    "objectTherapeutic": [
+      59,
+      8,
+      60,
+      61
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 824,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      1
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      36
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 825,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      3
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      36
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 826,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      1,
+      3
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      36
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 827,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      1,
+      2
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      40
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 828,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      2,
+      3
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      40
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 829,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      1,
+      2,
+      3
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      40
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 830,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      1,
+      2,
+      3
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      99,
+      40
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 831,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      1,
+      2
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      99,
+      40
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 832,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      2,
+      3
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      99,
+      40
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 833,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      1,
+      2,
+      3
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      99,
+      36
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 834,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      1,
+      2
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      99,
+      36
+    ],
+    "subjectVariant": {}
+  },
+  {
+    "id": 835,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      2,
+      3
+    ],
+    "conditionQualifier_id": 9,
+    "objectTherapeutic": [
+      99,
+      36
+    ],
+    "subjectVariant": {}
+  }
 ]

--- a/referenced/therapy_groups.json
+++ b/referenced/therapy_groups.json
@@ -1,0 +1,1664 @@
+[
+  {
+    "id": 0,
+    "membershipOperator": "AND",
+    "therapies": [
+      99,
+      119
+    ]
+  },
+  {
+    "id": 1,
+    "membershipOperator": "AND",
+    "therapies": [
+      36,
+      99
+    ]
+  },
+  {
+    "id": 2,
+    "membershipOperator": "AND",
+    "therapies": [
+      40,
+      99
+    ]
+  },
+  {
+    "id": 3,
+    "membershipOperator": "AND",
+    "therapies": [
+      30,
+      99
+    ]
+  },
+  {
+    "id": 4,
+    "membershipOperator": "AND",
+    "therapies": [
+      7,
+      6,
+      122
+    ]
+  },
+  {
+    "id": 5,
+    "membershipOperator": "AND",
+    "therapies": [
+      77,
+      30
+    ]
+  },
+  {
+    "id": 6,
+    "membershipOperator": "AND",
+    "therapies": [
+      37,
+      49,
+      108
+    ]
+  },
+  {
+    "id": 7,
+    "membershipOperator": "AND",
+    "therapies": [
+      89,
+      11,
+      35,
+      37
+    ]
+  },
+  {
+    "id": 8,
+    "membershipOperator": "AND",
+    "therapies": [
+      89,
+      35,
+      37
+    ]
+  },
+  {
+    "id": 9,
+    "membershipOperator": "AND",
+    "therapies": [
+      89,
+      21,
+      22
+    ]
+  },
+  {
+    "id": 10,
+    "membershipOperator": "AND",
+    "therapies": [
+      17,
+      18
+    ]
+  },
+  {
+    "id": 11,
+    "membershipOperator": "AND",
+    "therapies": [
+      0,
+      59,
+      2,
+      122
+    ]
+  },
+  {
+    "id": 12,
+    "membershipOperator": "AND",
+    "therapies": [
+      109,
+      30
+    ]
+  },
+  {
+    "id": 13,
+    "membershipOperator": "AND",
+    "therapies": [
+      37,
+      55,
+      49
+    ]
+  },
+  {
+    "id": 14,
+    "membershipOperator": "AND",
+    "therapies": [
+      19,
+      27,
+      29
+    ]
+  },
+  {
+    "id": 15,
+    "membershipOperator": "AND",
+    "therapies": [
+      19,
+      27
+    ]
+  },
+  {
+    "id": 16,
+    "membershipOperator": "AND",
+    "therapies": [
+      18,
+      19
+    ]
+  },
+  {
+    "id": 17,
+    "membershipOperator": "AND",
+    "therapies": [
+      21,
+      22
+    ]
+  },
+  {
+    "id": 18,
+    "membershipOperator": "AND",
+    "therapies": [
+      67,
+      66
+    ]
+  },
+  {
+    "id": 19,
+    "membershipOperator": "AND",
+    "therapies": [
+      37,
+      47,
+      35
+    ]
+  },
+  {
+    "id": 20,
+    "membershipOperator": "AND",
+    "therapies": [
+      44,
+      45,
+      49,
+      37
+    ]
+  },
+  {
+    "id": 21,
+    "membershipOperator": "AND",
+    "therapies": [
+      44,
+      45,
+      49,
+      39
+    ]
+  },
+  {
+    "id": 22,
+    "membershipOperator": "AND",
+    "therapies": [
+      44,
+      45,
+      50,
+      37
+    ]
+  },
+  {
+    "id": 23,
+    "membershipOperator": "AND",
+    "therapies": [
+      44,
+      45,
+      50,
+      39
+    ]
+  },
+  {
+    "id": 24,
+    "membershipOperator": "AND",
+    "therapies": [
+      44,
+      45,
+      51,
+      37
+    ]
+  },
+  {
+    "id": 25,
+    "membershipOperator": "AND",
+    "therapies": [
+      37,
+      44,
+      35
+    ]
+  },
+  {
+    "id": 26,
+    "membershipOperator": "AND",
+    "therapies": [
+      4,
+      5
+    ]
+  },
+  {
+    "id": 27,
+    "membershipOperator": "AND",
+    "therapies": [
+      30,
+      53
+    ]
+  },
+  {
+    "id": 28,
+    "membershipOperator": "AND",
+    "therapies": [
+      30,
+      31
+    ]
+  },
+  {
+    "id": 29,
+    "membershipOperator": "AND",
+    "therapies": [
+      71,
+      72
+    ]
+  },
+  {
+    "id": 30,
+    "membershipOperator": "AND",
+    "therapies": [
+      37,
+      71,
+      72,
+      49
+    ]
+  },
+  {
+    "id": 31,
+    "membershipOperator": "AND",
+    "therapies": [
+      39,
+      71,
+      72,
+      49
+    ]
+  },
+  {
+    "id": 32,
+    "membershipOperator": "AND",
+    "therapies": [
+      37,
+      71,
+      72,
+      35
+    ]
+  },
+  {
+    "id": 33,
+    "membershipOperator": "AND",
+    "therapies": [
+      91,
+      92
+    ]
+  },
+  {
+    "id": 34,
+    "membershipOperator": "AND",
+    "therapies": [
+      38,
+      96
+    ]
+  },
+  {
+    "id": 35,
+    "membershipOperator": "AND",
+    "therapies": [
+      96,
+      40
+    ]
+  },
+  {
+    "id": 36,
+    "membershipOperator": "AND",
+    "therapies": [
+      38,
+      128
+    ]
+  },
+  {
+    "id": 37,
+    "membershipOperator": "AND",
+    "therapies": [
+      129,
+      128
+    ]
+  },
+  {
+    "id": 38,
+    "membershipOperator": "AND",
+    "therapies": [
+      50,
+      128
+    ]
+  },
+  {
+    "id": 39,
+    "membershipOperator": "AND",
+    "therapies": [
+      128,
+      117
+    ]
+  },
+  {
+    "id": 40,
+    "membershipOperator": "AND",
+    "therapies": [
+      63,
+      68,
+      82
+    ]
+  },
+  {
+    "id": 41,
+    "membershipOperator": "AND",
+    "therapies": [
+      38,
+      70
+    ]
+  },
+  {
+    "id": 42,
+    "membershipOperator": "AND",
+    "therapies": [
+      37,
+      72,
+      35
+    ]
+  },
+  {
+    "id": 43,
+    "membershipOperator": "AND",
+    "therapies": [
+      11,
+      46
+    ]
+  },
+  {
+    "id": 44,
+    "membershipOperator": "AND",
+    "therapies": [
+      138,
+      87
+    ]
+  },
+  {
+    "id": 45,
+    "membershipOperator": "AND",
+    "therapies": [
+      7,
+      46,
+      8
+    ]
+  },
+  {
+    "id": 46,
+    "membershipOperator": "AND",
+    "therapies": [
+      7,
+      46,
+      122
+    ]
+  },
+  {
+    "id": 47,
+    "membershipOperator": "AND",
+    "therapies": [
+      39,
+      86,
+      49
+    ]
+  },
+  {
+    "id": 48,
+    "membershipOperator": "AND",
+    "therapies": [
+      37,
+      86,
+      49
+    ]
+  },
+  {
+    "id": 49,
+    "membershipOperator": "AND",
+    "therapies": [
+      40,
+      31
+    ]
+  },
+  {
+    "id": 50,
+    "membershipOperator": "AND",
+    "therapies": [
+      28,
+      97,
+      29
+    ]
+  },
+  {
+    "id": 51,
+    "membershipOperator": "AND",
+    "therapies": [
+      37,
+      48,
+      49
+    ]
+  },
+  {
+    "id": 52,
+    "membershipOperator": "AND",
+    "therapies": [
+      39,
+      48,
+      49
+    ]
+  },
+  {
+    "id": 53,
+    "membershipOperator": "AND",
+    "therapies": [
+      39,
+      48,
+      25,
+      29
+    ]
+  },
+  {
+    "id": 54,
+    "membershipOperator": "AND",
+    "therapies": [
+      38,
+      28,
+      48,
+      25
+    ]
+  },
+  {
+    "id": 55,
+    "membershipOperator": "AND",
+    "therapies": [
+      39,
+      48,
+      29
+    ]
+  },
+  {
+    "id": 56,
+    "membershipOperator": "AND",
+    "therapies": [
+      38,
+      28,
+      48
+    ]
+  },
+  {
+    "id": 57,
+    "membershipOperator": "AND",
+    "therapies": [
+      39,
+      35,
+      48
+    ]
+  },
+  {
+    "id": 58,
+    "membershipOperator": "AND",
+    "therapies": [
+      11,
+      39,
+      35,
+      48
+    ]
+  },
+  {
+    "id": 59,
+    "membershipOperator": "AND",
+    "therapies": [
+      37,
+      35,
+      48
+    ]
+  },
+  {
+    "id": 60,
+    "membershipOperator": "AND",
+    "therapies": [
+      11,
+      37,
+      35,
+      48
+    ]
+  },
+  {
+    "id": 61,
+    "membershipOperator": "AND",
+    "therapies": [
+      132,
+      48
+    ]
+  },
+  {
+    "id": 62,
+    "membershipOperator": "AND",
+    "therapies": [
+      37,
+      59,
+      2,
+      35,
+      48
+    ]
+  },
+  {
+    "id": 63,
+    "membershipOperator": "AND",
+    "therapies": [
+      35,
+      48
+    ]
+  },
+  {
+    "id": 64,
+    "membershipOperator": "AND",
+    "therapies": [
+      37,
+      50,
+      48
+    ]
+  },
+  {
+    "id": 65,
+    "membershipOperator": "AND",
+    "therapies": [
+      24,
+      75,
+      25
+    ]
+  },
+  {
+    "id": 66,
+    "membershipOperator": "AND",
+    "therapies": [
+      59,
+      2,
+      35,
+      75,
+      25
+    ]
+  },
+  {
+    "id": 67,
+    "membershipOperator": "AND",
+    "therapies": [
+      59,
+      24,
+      76,
+      75,
+      25,
+      29
+    ]
+  },
+  {
+    "id": 68,
+    "membershipOperator": "AND",
+    "therapies": [
+      59,
+      76,
+      35,
+      75,
+      25,
+      29
+    ]
+  },
+  {
+    "id": 69,
+    "membershipOperator": "AND",
+    "therapies": [
+      59,
+      24,
+      2,
+      75,
+      25,
+      29
+    ]
+  },
+  {
+    "id": 70,
+    "membershipOperator": "AND",
+    "therapies": [
+      59,
+      2,
+      35,
+      75,
+      25,
+      29
+    ]
+  },
+  {
+    "id": 71,
+    "membershipOperator": "AND",
+    "therapies": [
+      59,
+      24,
+      76,
+      75,
+      25
+    ]
+  },
+  {
+    "id": 72,
+    "membershipOperator": "AND",
+    "therapies": [
+      59,
+      76,
+      35,
+      75,
+      25
+    ]
+  },
+  {
+    "id": 73,
+    "membershipOperator": "AND",
+    "therapies": [
+      59,
+      24,
+      2,
+      75,
+      25
+    ]
+  },
+  {
+    "id": 74,
+    "membershipOperator": "AND",
+    "therapies": [
+      37,
+      24,
+      75,
+      25
+    ]
+  },
+  {
+    "id": 75,
+    "membershipOperator": "AND",
+    "therapies": [
+      63,
+      65,
+      43,
+      122,
+      61
+    ]
+  },
+  {
+    "id": 76,
+    "membershipOperator": "AND",
+    "therapies": [
+      12,
+      23
+    ]
+  },
+  {
+    "id": 77,
+    "membershipOperator": "AND",
+    "therapies": [
+      36,
+      53
+    ]
+  },
+  {
+    "id": 78,
+    "membershipOperator": "AND",
+    "therapies": [
+      40,
+      53
+    ]
+  },
+  {
+    "id": 79,
+    "membershipOperator": "AND",
+    "therapies": [
+      59,
+      60,
+      8,
+      61
+    ]
+  },
+  {
+    "id": 80,
+    "membershipOperator": "AND",
+    "therapies": [
+      59,
+      2,
+      60,
+      8,
+      61
+    ]
+  },
+  {
+    "id": 81,
+    "membershipOperator": "AND",
+    "therapies": [
+      59,
+      135,
+      124,
+      60
+    ]
+  },
+  {
+    "id": 82,
+    "membershipOperator": "AND",
+    "therapies": [
+      59,
+      2,
+      60,
+      122,
+      61
+    ]
+  },
+  {
+    "id": 83,
+    "membershipOperator": "AND",
+    "therapies": [
+      59,
+      135,
+      60
+    ]
+  },
+  {
+    "id": 84,
+    "membershipOperator": "AND",
+    "therapies": [
+      38,
+      25,
+      95
+    ]
+  },
+  {
+    "id": 85,
+    "membershipOperator": "AND",
+    "therapies": [
+      139,
+      108
+    ]
+  },
+  {
+    "id": 86,
+    "membershipOperator": "AND",
+    "therapies": [
+      108,
+      37,
+      49
+    ]
+  },
+  {
+    "id": 87,
+    "membershipOperator": "AND",
+    "therapies": [
+      39,
+      44,
+      50
+    ]
+  },
+  {
+    "id": 88,
+    "membershipOperator": "AND",
+    "therapies": [
+      39,
+      44,
+      49
+    ]
+  },
+  {
+    "id": 89,
+    "membershipOperator": "AND",
+    "therapies": [
+      37,
+      44,
+      49
+    ]
+  },
+  {
+    "id": 90,
+    "membershipOperator": "AND",
+    "therapies": [
+      54,
+      19
+    ]
+  },
+  {
+    "id": 91,
+    "membershipOperator": "AND",
+    "therapies": [
+      36,
+      143,
+      53
+    ]
+  },
+  {
+    "id": 92,
+    "membershipOperator": "AND",
+    "therapies": [
+      143,
+      40,
+      53
+    ]
+  },
+  {
+    "id": 93,
+    "membershipOperator": "AND",
+    "therapies": [
+      39,
+      72,
+      49
+    ]
+  },
+  {
+    "id": 94,
+    "membershipOperator": "AND",
+    "therapies": [
+      39,
+      50,
+      72
+    ]
+  },
+  {
+    "id": 95,
+    "membershipOperator": "AND",
+    "therapies": [
+      30,
+      144,
+      31
+    ]
+  },
+  {
+    "id": 96,
+    "membershipOperator": "AND",
+    "therapies": [
+      29,
+      28,
+      111
+    ]
+  },
+  {
+    "id": 97,
+    "membershipOperator": "AND",
+    "therapies": [
+      38,
+      28,
+      111
+    ]
+  },
+  {
+    "id": 98,
+    "membershipOperator": "AND",
+    "therapies": [
+      29,
+      19,
+      18,
+      28
+    ]
+  },
+  {
+    "id": 99,
+    "membershipOperator": "AND",
+    "therapies": [
+      37,
+      44,
+      45,
+      49
+    ]
+  },
+  {
+    "id": 100,
+    "membershipOperator": "AND",
+    "therapies": [
+      39,
+      44,
+      45,
+      49
+    ]
+  },
+  {
+    "id": 101,
+    "membershipOperator": "AND",
+    "therapies": [
+      37,
+      44,
+      50,
+      45
+    ]
+  },
+  {
+    "id": 102,
+    "membershipOperator": "AND",
+    "therapies": [
+      39,
+      44,
+      50,
+      45
+    ]
+  },
+  {
+    "id": 103,
+    "membershipOperator": "AND",
+    "therapies": [
+      37,
+      44,
+      51,
+      45
+    ]
+  },
+  {
+    "id": 104,
+    "membershipOperator": "AND",
+    "therapies": [
+      0,
+      1,
+      2,
+      3
+    ]
+  },
+  {
+    "id": 105,
+    "membershipOperator": "AND",
+    "therapies": [
+      6,
+      7,
+      8
+    ]
+  },
+  {
+    "id": 106,
+    "membershipOperator": "AND",
+    "therapies": [
+      11,
+      12
+    ]
+  },
+  {
+    "id": 107,
+    "membershipOperator": "AND",
+    "therapies": [
+      19,
+      18
+    ]
+  },
+  {
+    "id": 108,
+    "membershipOperator": "AND",
+    "therapies": [
+      24,
+      25
+    ]
+  },
+  {
+    "id": 109,
+    "membershipOperator": "AND",
+    "therapies": [
+      19,
+      28,
+      29
+    ]
+  },
+  {
+    "id": 110,
+    "membershipOperator": "AND",
+    "therapies": [
+      35,
+      25
+    ]
+  },
+  {
+    "id": 111,
+    "membershipOperator": "AND",
+    "therapies": [
+      36,
+      25
+    ]
+  },
+  {
+    "id": 112,
+    "membershipOperator": "AND",
+    "therapies": [
+      37,
+      24,
+      25
+    ]
+  },
+  {
+    "id": 113,
+    "membershipOperator": "AND",
+    "therapies": [
+      2,
+      25,
+      35
+    ]
+  },
+  {
+    "id": 114,
+    "membershipOperator": "AND",
+    "therapies": [
+      2,
+      35,
+      25
+    ]
+  },
+  {
+    "id": 115,
+    "membershipOperator": "AND",
+    "therapies": [
+      38,
+      39,
+      25
+    ]
+  },
+  {
+    "id": 116,
+    "membershipOperator": "AND",
+    "therapies": [
+      39,
+      25,
+      29
+    ]
+  },
+  {
+    "id": 117,
+    "membershipOperator": "AND",
+    "therapies": [
+      37,
+      44,
+      45
+    ]
+  },
+  {
+    "id": 118,
+    "membershipOperator": "AND",
+    "therapies": [
+      37,
+      44,
+      46,
+      35
+    ]
+  },
+  {
+    "id": 119,
+    "membershipOperator": "AND",
+    "therapies": [
+      39,
+      50,
+      48
+    ]
+  },
+  {
+    "id": 120,
+    "membershipOperator": "AND",
+    "therapies": [
+      37,
+      48,
+      29
+    ]
+  },
+  {
+    "id": 121,
+    "membershipOperator": "AND",
+    "therapies": [
+      51,
+      48
+    ]
+  },
+  {
+    "id": 122,
+    "membershipOperator": "AND",
+    "therapies": [
+      37,
+      48,
+      25,
+      29
+    ]
+  },
+  {
+    "id": 123,
+    "membershipOperator": "AND",
+    "therapies": [
+      44,
+      46
+    ]
+  },
+  {
+    "id": 124,
+    "membershipOperator": "AND",
+    "therapies": [
+      59,
+      60,
+      2,
+      8,
+      61
+    ]
+  },
+  {
+    "id": 125,
+    "membershipOperator": "AND",
+    "therapies": [
+      59,
+      62,
+      63,
+      2,
+      64,
+      65,
+      60,
+      61
+    ]
+  },
+  {
+    "id": 126,
+    "membershipOperator": "AND",
+    "therapies": [
+      63,
+      68,
+      69
+    ]
+  },
+  {
+    "id": 127,
+    "membershipOperator": "AND",
+    "therapies": [
+      37,
+      72,
+      49
+    ]
+  },
+  {
+    "id": 128,
+    "membershipOperator": "AND",
+    "therapies": [
+      39,
+      72,
+      29
+    ]
+  },
+  {
+    "id": 129,
+    "membershipOperator": "AND",
+    "therapies": [
+      72,
+      28,
+      29
+    ]
+  },
+  {
+    "id": 130,
+    "membershipOperator": "AND",
+    "therapies": [
+      72,
+      28
+    ]
+  },
+  {
+    "id": 131,
+    "membershipOperator": "AND",
+    "therapies": [
+      72,
+      73
+    ]
+  },
+  {
+    "id": 132,
+    "membershipOperator": "AND",
+    "therapies": [
+      39,
+      86
+    ]
+  },
+  {
+    "id": 133,
+    "membershipOperator": "AND",
+    "therapies": [
+      37,
+      86
+    ]
+  },
+  {
+    "id": 134,
+    "membershipOperator": "AND",
+    "therapies": [
+      89,
+      11,
+      37,
+      35
+    ]
+  },
+  {
+    "id": 135,
+    "membershipOperator": "AND",
+    "therapies": [
+      89,
+      37,
+      51
+    ]
+  },
+  {
+    "id": 136,
+    "membershipOperator": "AND",
+    "therapies": [
+      89,
+      51
+    ]
+  },
+  {
+    "id": 137,
+    "membershipOperator": "AND",
+    "therapies": [
+      37,
+      44,
+      49,
+      45
+    ]
+  },
+  {
+    "id": 138,
+    "membershipOperator": "AND",
+    "therapies": [
+      39,
+      44,
+      49,
+      45
+    ]
+  },
+  {
+    "id": 139,
+    "membershipOperator": "AND",
+    "therapies": [
+      96,
+      25
+    ]
+  },
+  {
+    "id": 140,
+    "membershipOperator": "AND",
+    "therapies": [
+      97,
+      28,
+      29
+    ]
+  },
+  {
+    "id": 141,
+    "membershipOperator": "AND",
+    "therapies": [
+      97,
+      27,
+      29
+    ]
+  },
+  {
+    "id": 142,
+    "membershipOperator": "AND",
+    "therapies": [
+      99,
+      36
+    ]
+  },
+  {
+    "id": 143,
+    "membershipOperator": "AND",
+    "therapies": [
+      99,
+      40
+    ]
+  },
+  {
+    "id": 144,
+    "membershipOperator": "AND",
+    "therapies": [
+      99,
+      30
+    ]
+  },
+  {
+    "id": 145,
+    "membershipOperator": "AND",
+    "therapies": [
+      105,
+      60
+    ]
+  },
+  {
+    "id": 146,
+    "membershipOperator": "AND",
+    "therapies": [
+      37,
+      49,
+      107
+    ]
+  },
+  {
+    "id": 147,
+    "membershipOperator": "AND",
+    "therapies": [
+      39,
+      49,
+      107
+    ]
+  },
+  {
+    "id": 148,
+    "membershipOperator": "AND",
+    "therapies": [
+      28,
+      111,
+      29
+    ]
+  },
+  {
+    "id": 149,
+    "membershipOperator": "AND",
+    "therapies": [
+      82,
+      68,
+      63
+    ]
+  },
+  {
+    "id": 150,
+    "membershipOperator": "AND",
+    "therapies": [
+      46,
+      11
+    ]
+  },
+  {
+    "id": 151,
+    "membershipOperator": "AND",
+    "therapies": [
+      66,
+      67
+    ]
+  },
+  {
+    "id": 152,
+    "membershipOperator": "AND",
+    "therapies": [
+      72,
+      71
+    ]
+  },
+  {
+    "id": 153,
+    "membershipOperator": "AND",
+    "therapies": [
+      0,
+      39,
+      63,
+      64
+    ]
+  },
+  {
+    "id": 154,
+    "membershipOperator": "AND",
+    "therapies": [
+      37,
+      35,
+      75,
+      25
+    ]
+  },
+  {
+    "id": 155,
+    "membershipOperator": "AND",
+    "therapies": [
+      0,
+      37,
+      64,
+      116
+    ]
+  },
+  {
+    "id": 156,
+    "membershipOperator": "AND",
+    "therapies": [
+      28,
+      48,
+      29
+    ]
+  },
+  {
+    "id": 157,
+    "membershipOperator": "AND",
+    "therapies": [
+      35,
+      75,
+      25
+    ]
+  },
+  {
+    "id": 158,
+    "membershipOperator": "AND",
+    "therapies": [
+      117,
+      75,
+      25
+    ]
+  },
+  {
+    "id": 159,
+    "membershipOperator": "AND",
+    "therapies": [
+      75,
+      25
+    ]
+  },
+  {
+    "id": 160,
+    "membershipOperator": "AND",
+    "therapies": [
+      37,
+      50,
+      72
+    ]
+  },
+  {
+    "id": 161,
+    "membershipOperator": "AND",
+    "therapies": [
+      11,
+      35
+    ]
+  },
+  {
+    "id": 162,
+    "membershipOperator": "AND",
+    "therapies": [
+      37,
+      59,
+      2,
+      35
+    ]
+  },
+  {
+    "id": 163,
+    "membershipOperator": "AND",
+    "therapies": [
+      37,
+      50
+    ]
+  },
+  {
+    "id": 164,
+    "membershipOperator": "AND",
+    "therapies": [
+      59,
+      2,
+      35,
+      25
+    ]
+  },
+  {
+    "id": 165,
+    "membershipOperator": "AND",
+    "therapies": [
+      99,
+      5
+    ]
+  },
+  {
+    "id": 166,
+    "membershipOperator": "AND",
+    "therapies": [
+      105,
+      120
+    ]
+  },
+  {
+    "id": 167,
+    "membershipOperator": "AND",
+    "therapies": [
+      37,
+      35,
+      72
+    ]
+  },
+  {
+    "id": 168,
+    "membershipOperator": "AND",
+    "therapies": [
+      39,
+      49,
+      72
+    ]
+  },
+  {
+    "id": 169,
+    "membershipOperator": "AND",
+    "therapies": [
+      37,
+      49,
+      72
+    ]
+  },
+  {
+    "id": 170,
+    "membershipOperator": "AND",
+    "therapies": [
+      121,
+      60
+    ]
+  },
+  {
+    "id": 171,
+    "membershipOperator": "AND",
+    "therapies": [
+      39,
+      63,
+      60
+    ]
+  },
+  {
+    "id": 172,
+    "membershipOperator": "AND",
+    "therapies": [
+      59,
+      2,
+      64,
+      8,
+      60,
+      61
+    ]
+  },
+  {
+    "id": 173,
+    "membershipOperator": "AND",
+    "therapies": [
+      37,
+      64,
+      116,
+      60
+    ]
+  },
+  {
+    "id": 174,
+    "membershipOperator": "AND",
+    "therapies": [
+      59,
+      2,
+      8,
+      60,
+      117
+    ]
+  },
+  {
+    "id": 175,
+    "membershipOperator": "AND",
+    "therapies": [
+      50,
+      28,
+      60
+    ]
+  },
+  {
+    "id": 176,
+    "membershipOperator": "AND",
+    "therapies": [
+      59,
+      64,
+      8,
+      60,
+      61
+    ]
+  },
+  {
+    "id": 177,
+    "membershipOperator": "AND",
+    "therapies": [
+      121,
+      0
+    ]
+  },
+  {
+    "id": 178,
+    "membershipOperator": "AND",
+    "therapies": [
+      59,
+      8,
+      60,
+      61
+    ]
+  },
+  {
+    "id": 179,
+    "membershipOperator": "AND",
+    "therapies": [
+      59,
+      2,
+      8,
+      60,
+      61
+    ]
+  },
+  {
+    "id": 180,
+    "membershipOperator": "AND",
+    "therapies": [
+      123,
+      124,
+      8,
+      60
+    ]
+  },
+  {
+    "id": 181,
+    "membershipOperator": "AND",
+    "therapies": [
+      59,
+      2,
+      64,
+      125,
+      8,
+      60
+    ]
+  }
+]

--- a/utils/README.md
+++ b/utils/README.md
@@ -28,6 +28,7 @@ Optional arguments:
     --propositions    <string>    referenced JSON for propositions. Default: referenced/propositions.json
     --statements      <string>    referenced JSON for statements. Default: referenced/statements.json
     --therapies       <string>    referenced JSON for therapies. Default: referenced/therapies.json
+    --therapy-groups  <string>    referenced JSON for therapy groups. Default: referenced/therapy_groups.json
     --output          <string>    file path for dereferenced JSON output by this script. Default: moalmanac-draft.dereferenced.json
 ```
 
@@ -46,6 +47,7 @@ python dereference.py \
   --propositions referenced/propositions.json \
   --statements referenced/statements.json \
   --therapies referenced/therapies.json \
+  --therapy-groups referenced/therapy-groups.json \
   --output  moalmanac-draft.dereferenced.json
 ```
 

--- a/utils/dereference.py
+++ b/utils/dereference.py
@@ -22,7 +22,7 @@ class BaseTable:
         """
         self.records = records
 
-    def dereference_integer(self, referenced_key: str, referenced_records: list[dict], new_key_name: str) -> None:
+    def dereference_single(self, referenced_key: str, referenced_records: list[dict], new_key_name: str) -> None:
         """
         Dereferences a key for each record in records, where the key's value references a single record.
 
@@ -146,7 +146,7 @@ class Contributions(BaseTable):
         Raises:
             KeyError: If the referenced_key, `agent_id`, is not found in a record.
         """
-        self.dereference_integer(
+        self.dereference_single(
             referenced_key='agent_id',
             referenced_records=agents,
             new_key_name='agent'
@@ -187,7 +187,7 @@ class Documents(BaseTable):
         Raises:
             KeyError: If the referenced_key, `organization_id`, is not found in a record.
         """
-        self.dereference_integer(
+        self.dereference_single(
             referenced_key='organization_id',
             referenced_records=organizations,
             new_key_name='organization'
@@ -228,7 +228,7 @@ class Indications(BaseTable):
         Raises:
             KeyError: If the referenced_key, `document_id`, is not found in a record.
         """
-        self.dereference_integer(
+        self.dereference_single(
             referenced_key='document_id',
             referenced_records=documents,
             new_key_name='document'
@@ -291,7 +291,7 @@ class Propositions(BaseTable):
         Raises:
             KeyError: If the referenced_key, `conditionQualifier_id`, is not found in a record.
         """
-        self.dereference_integer(
+        self.dereference_single(
             referenced_key='conditionQualifier_id',
             referenced_records=diseases,
             new_key_name='conditionQualifier'
@@ -385,7 +385,7 @@ class Statements(BaseTable):
         Raises:
             KeyError: If the referenced_key, `proposition_id`, is not found in a record.
         """
-        self.dereference_integer(
+        self.dereference_single(
             referenced_key='proposition_id',
             referenced_records=propositions,
             new_key_name='proposition'
@@ -406,7 +406,7 @@ class Statements(BaseTable):
         Raises:
             KeyError: If the referenced_key, `indication_id`, is not found in a record.
         """
-        self.dereference_integer(
+        self.dereference_single(
             referenced_key='indication_id',
             referenced_records=indications,
             new_key_name='indication'

--- a/utils/dereference.py
+++ b/utils/dereference.py
@@ -335,9 +335,27 @@ class Propositions(BaseTable):
         self.dereference_list(
             referenced_key='therapies',
             referenced_records=therapies,
-            key_always_present=True
-            # This will not be True once we re-expand beyond sensitive relationships
+            key_always_present=False
         )
+
+    def format_therapies(self, referenced_key: str = 'therapies', new_key_name: str = 'objectTherapeutic') -> None:
+        for record in self.records:
+            if referenced_key not in record:
+                continue
+
+            if len(record[referenced_key]) == 1:
+                record[new_key_name] = record[referenced_key][0]
+            elif len(record[referenced_key]) > 1:
+                record[new_key_name] = {
+                    'id': '...',
+                    'therapies': [therapy for therapy in record[referenced_key]],
+                    'membershipOperator': 'AND',
+                    'extensions': []
+                }
+            else:
+                raise ValueError(f"Proposition record: {record['id']} has the {referenced_key} key with no items.")
+
+
 
 class Statements(BaseTable):
     """
@@ -509,6 +527,7 @@ def main(input_paths):
     propositions.dereference_biomarkers(biomarkers=biomarkers.records)
     propositions.dereference_diseases(diseases=diseases.records)
     propositions.dereference_therapies(therapies=therapies.records)
+    #propositions.format_therapies()
 
     # statements; references contributions.json, documents.json, propositions.json, and indications.json
     statements.dereference_contributions(contributions=contributions.records)

--- a/utils/dereference.py
+++ b/utils/dereference.py
@@ -44,7 +44,6 @@ class BaseTable:
                 key='id',
                 value=record[referenced_key]
             )
-            referenced_record = referenced_record[0]
 
             new_record = {}
             for key, value in record.items():
@@ -82,7 +81,7 @@ class BaseTable:
                     key='id',
                     value=value
                 )
-                _values.append(_value[0])
+                _values.append(_value)
             record[referenced_key] = _values
 
 class Agents(BaseTable):

--- a/utils/dereference.py
+++ b/utils/dereference.py
@@ -104,6 +104,9 @@ class Biomarkers(BaseTable):
     Attributes:
         records (list[dict]): A list of dictionaries representing the document records.
     """
+    def dereference(self, genes: list[dict]):
+        """Dereference all keys for this table."""
+        self.dereference_genes(genes=genes)
 
     def dereference_genes(self, genes: list[dict]) -> None:
         """
@@ -131,6 +134,9 @@ class Contributions(BaseTable):
     Attributes:
         records (list[dict]): A list of dictionaries representing the contribution records.
     """
+    def dereference(self, agents: list[dict]):
+        """Dereference all keys for this table."""
+        self.dereference_agents(agents=agents)
 
     def dereference_agents(self, agents: list[dict]) -> None:
         """
@@ -173,6 +179,10 @@ class Documents(BaseTable):
         records (list[dict]): A list of dictionaries representing the document records.
     """
 
+    def dereference(self, organizations: list[dict]):
+        """Dereference all keys for this table."""
+        self.dereference_organizations(organizations=organizations)
+
     def dereference_organizations(self, organizations: list[dict]) -> None:
         """
         Dereferences the `organization_id` key in each proposition record.
@@ -213,6 +223,11 @@ class Indications(BaseTable):
     Attributes:
         records (list[dict]): A list of dictionaries representing the indication records.
     """
+
+    def dereference(self, documents: list[dict], organizations: list[dict]):
+        """Dereference all keys for this table."""
+        #Documents.dereference(organizations=organizations)
+        self.dereference_documents(documents=documents)
 
     def dereference_documents(self, documents: list[dict]) -> None:
         """
@@ -256,6 +271,12 @@ class Propositions(BaseTable):
     Attributes:
         records (list[dict]): A list of dictionaries representing the proposition records.
     """
+
+    def dereference(self, biomarkers: list[dict], diseases: list[dict], genes: list[dict], therapies: list[dict]) -> None:
+        """Dereferences all keys for this table."""
+        self.dereference_biomarkers(biomarkers=biomarkers)
+        self.dereference_diseases(diseases=diseases)
+        self.dereference_therapies(therapies=therapies)
 
     def dereference_biomarkers(self, biomarkers: list[dict]) -> None:
         """
@@ -330,6 +351,13 @@ class Statements(BaseTable):
     Attributes:
         records (list[dict]): A list of dictionaries representing the statement records.
     """
+
+    def dereference(self, agents: list[dict], biomarkers: list[dict], contributions: list[dict], diseases: list[dict], documents: list[dict], genes: list[dict], indications: list[dict], propositions: list[dict], therapies: list[dict]):
+        """Dereferences all keys for this table."""
+        self.dereference_contributions(contributions=contributions)
+        self.dereference_documents(documents=documents)
+        self.dereference_indications(indications=indications)
+        self.dereference_propositions(propositions=propositions)
 
     def dereference_contributions(self, contributions: list[dict]) -> None:
         """
@@ -436,6 +464,8 @@ def main(input_paths):
             - about (dict): Dictionary containing database metadata, from referenced/about.json.
             - content (list[dict]): List of dictionaries containing dereferenced database.
     """
+
+    # Step 1: Read json files
     about = json_utils.load(file=input_paths['about'])
     agents = json_utils.load(file=input_paths['agents'])
     biomarkers = json_utils.load(file=input_paths['biomarkers'])
@@ -449,6 +479,7 @@ def main(input_paths):
     statements = json_utils.load(file=input_paths['statements'])
     therapies = json_utils.load(file=input_paths['therapies'])
 
+    # Step 2: Generate table objects
     agents = Agents(records=agents)
     biomarkers = Biomarkers(records=biomarkers)
     contributions = Contributions(records=contributions)
@@ -461,6 +492,7 @@ def main(input_paths):
     statements = Statements(records=statements)
     therapies = Therapies(records=therapies)
 
+    # Step 3: dereference relevant tables
     # biomarkers; references genes.json
     biomarkers.dereference_genes(genes=genes.records)
 

--- a/utils/dereference.py
+++ b/utils/dereference.py
@@ -6,7 +6,7 @@ import json_utils # Local import
 class BaseTable:
     """
     A base class for managing and dereferencing records across database tables. This class provides common
-    functionality for dereferencing fields that reference other tables. It serves as a template for specific table
+    functionality for dereferencing keys that reference other tables. It serves as a template for specific table
     classes, which inherit from BaseTable and implement additional table-specific logic.
 
     Attributes:
@@ -87,7 +87,7 @@ class BaseTable:
 class Agents(BaseTable):
     """
     Represents the Agents table. This class inherits common functionality from the BaseTable class and
-    dereferences fields that reference other tables. This table does not currently reference any other tables.
+    dereferences keys that reference other tables. This table does not currently reference any other tables.
 
     Attributes:
         records (list[dict]): A list of dictionaries representing the agent records.
@@ -98,8 +98,8 @@ class Agents(BaseTable):
 class Biomarkers(BaseTable):
     """
     Represents the Biomarkers table. This class inherits common functionality from the BaseTable class and
-    dereferences fields that reference other tables. This table references the following tables:
-    - Genes (initial field: `genes`, resulting field: `genes`)
+    dereferences keys that reference other tables. This table references the following tables:
+    - Genes (initial key: `genes`, resulting key: `genes`)
 
     Attributes:
         records (list[dict]): A list of dictionaries representing the document records.
@@ -107,7 +107,7 @@ class Biomarkers(BaseTable):
 
     def dereference_genes(self, genes: list[dict]) -> None:
         """
-        Dereferences the `genes` field in each biomarker record.
+        Dereferences the `genes` key in each biomarker record.
 
         Utilizes the `dereference_list` function from the BaseTable class to replace the value associated with the
         `gene` key within each record. This key is not expected to be present within each record, so no KeyError will
@@ -125,8 +125,8 @@ class Biomarkers(BaseTable):
 class Contributions(BaseTable):
     """
     Represents the Contributions table. This class inherits common functionality from the BaseTable class and
-    dereferences fields that reference other tables. This table references the following tables:
-    - Agents (field: `agent_id`, resulting field: `agents`)
+    dereferences keys that reference other tables. This table references the following tables:
+    - Agents (key: `agent_id`, resulting key: `agents`)
 
     Attributes:
         records (list[dict]): A list of dictionaries representing the contribution records.
@@ -134,7 +134,7 @@ class Contributions(BaseTable):
 
     def dereference_agents(self, agents: list[dict]) -> None:
         """
-        Dereferences the `agent_id` field in each contribution record.
+        Dereferences the `agent_id` key in each contribution record.
 
         Utilizes the `dereference_list` function from the BaseTable class to replace the value associated with the
         `agent_id` key within each record. This key is expected to be present within each record, so a
@@ -155,7 +155,7 @@ class Contributions(BaseTable):
 class Diseases(BaseTable):
     """
     Represents the Diseases table. This class inherits common functionality from the BaseTable class and
-    dereferences fields that reference other tables. This table does not currently reference any other tables.
+    dereferences keys that reference other tables. This table does not currently reference any other tables.
 
     Attributes:
         records (list[dict]): A list of dictionaries representing the disease records.
@@ -166,8 +166,8 @@ class Diseases(BaseTable):
 class Documents(BaseTable):
     """
     Represents the Documents table. This class inherits common functionality from the BaseTable class and
-    dereferences fields that reference other tables. This table references the following tables:
-    - Organizations (field: `organization_id`)
+    dereferences keys that reference other tables. This table references the following tables:
+    - Organizations (key: `organization_id`)
 
     Attributes:
         records (list[dict]): A list of dictionaries representing the document records.
@@ -175,7 +175,7 @@ class Documents(BaseTable):
 
     def dereference_organizations(self, organizations: list[dict]) -> None:
         """
-        Dereferences the `organization_id` field in each proposition record.
+        Dereferences the `organization_id` key in each proposition record.
 
         Utilizes the `dereference_list` function from the BaseTable class to replace the value associated with the
         `organization_id` key within each record. This key is expected to be present within each record, so a
@@ -196,7 +196,7 @@ class Documents(BaseTable):
 class Genes(BaseTable):
     """
     Represents the Genes table. This class inherits common functionality from the BaseTable class and
-    dereferences fields that reference other tables. This table does not currently reference any other tables.
+    dereferences keys that reference other tables. This table does not currently reference any other tables.
 
     Attributes:
         records (list[dict]): A list of dictionaries representing the gene records.
@@ -207,8 +207,8 @@ class Genes(BaseTable):
 class Indications(BaseTable):
     """
     Represents the Indications table. This class inherits common functionality from the BaseTable class and
-    dereferences fields that reference other tables. This table references the following tables:
-    - Documents (field: `document_id`)
+    dereferences keys that reference other tables. This table references the following tables:
+    - Documents (key: `document_id`)
 
     Attributes:
         records (list[dict]): A list of dictionaries representing the indication records.
@@ -216,7 +216,7 @@ class Indications(BaseTable):
 
     def dereference_documents(self, documents: list[dict]) -> None:
         """
-        Dereferences the `document_id` field in each proposition record.
+        Dereferences the `document_id` key in each proposition record.
 
         Utilizes the `dereference_list` function from the BaseTable class to replace the value associated with the
         `document_id` key within each record. This key is expected to be present within each record, so a
@@ -237,7 +237,7 @@ class Indications(BaseTable):
 class Organizations(BaseTable):
     """
     Represents the Organizations table. This class inherits common functionality from the BaseTable class and
-    dereferences fields that reference other tables. This table does not currently reference any other tables.
+    dereferences keys that reference other tables. This table does not currently reference any other tables.
 
     Attributes:
         records (list[dict]): A list of dictionaries representing the organization records.
@@ -248,10 +248,10 @@ class Organizations(BaseTable):
 class Propositions(BaseTable):
     """
     Represents the Propositions table. This class inherits common functionality from the BaseTable class and
-    dereferences fields that reference other tables. This table references the following tables:
-    - Biomarkers (initial field: `biomarkers`, resulting field: `biomarkers`)
-    - Diseases (initial field: `conditionQualifier_id`, resulting field: `conditionQualifier`)
-    - Therapies (initial field: `therapies`, resulting field: `objectTherapeutic`)
+    dereferences keys that reference other tables. This table references the following tables:
+    - Biomarkers (initial key: `biomarkers`, resulting key: `biomarkers`)
+    - Diseases (initial key: `conditionQualifier_id`, resulting key: `conditionQualifier`)
+    - Therapies (initial key: `therapies`, resulting key: `objectTherapeutic`)
 
     Attributes:
         records (list[dict]): A list of dictionaries representing the proposition records.
@@ -259,7 +259,7 @@ class Propositions(BaseTable):
 
     def dereference_biomarkers(self, biomarkers: list[dict]) -> None:
         """
-        Dereferences the `biomarkers` field in each proposition record.
+        Dereferences the `biomarkers` key in each proposition record.
 
         Utilizes the `dereference_list` function from the BaseTable class to replace the value associated with the
         `biomarkers` key within each record. This key is expected to be present within each record, so a KeyError will
@@ -279,7 +279,7 @@ class Propositions(BaseTable):
 
     def dereference_diseases(self, diseases: list[dict]) -> None:
         """
-        Dereferences the `conditionQualifier_id` field in each proposition record.
+        Dereferences the `conditionQualifier_id` key in each proposition record.
 
         Utilizes the `dereference_list` function from the BaseTable class to replace the value associated with the
         `conditionQualifier_id` key within each record. This key is expected to be present within each record, so a
@@ -299,7 +299,7 @@ class Propositions(BaseTable):
 
     def dereference_therapies(self, therapies: list[dict]) -> None:
         """
-        Dereferences the `therapies` field in each proposition record.
+        Dereferences the `therapies` key in each proposition record.
 
         Utilizes the `dereference_list` function from the BaseTable class to replace the value associated with the
         `therapies` key within each record. This key is expected to be present within each record, so a
@@ -321,11 +321,11 @@ class Propositions(BaseTable):
 class Statements(BaseTable):
     """
     Represents the Statements table. This class inherits common functionality from the BaseTable class and
-    dereferences fields that reference other tables. This table references the following tables:
-    - Contributions (field: `contributions`)
-    - Documents (field: `reportedIn`)
-    - Propositions (field: `proposition_id`)
-    - Indications (field: `indications`)
+    dereferences keys that reference other tables. This table references the following tables:
+    - Contributions (key: `contributions`)
+    - Documents (key: `reportedIn`)
+    - Propositions (key: `proposition_id`)
+    - Indications (key: `indications`)
 
     Attributes:
         records (list[dict]): A list of dictionaries representing the statement records.
@@ -333,7 +333,7 @@ class Statements(BaseTable):
 
     def dereference_contributions(self, contributions: list[dict]) -> None:
         """
-        Dereferences the `contributions` field in each statement record.
+        Dereferences the `contributions` key in each statement record.
 
         Utilizes the `dereference_list` function from the BaseTable class to replace the value associated with the
         `contributions` key within each record. This key is expected to be present within each record, so a
@@ -353,7 +353,7 @@ class Statements(BaseTable):
 
     def dereference_documents(self, documents: list[dict]) -> None:
         """
-        Dereferences the `reportedIn` field in each statement record.
+        Dereferences the `reportedIn` key in each statement record.
 
         Utilizes the `dereference_list` function from the BaseTable class to replace the value associated with the
         `reportedIn` key within each record. This key is expected to be present within each record, so a
@@ -373,7 +373,7 @@ class Statements(BaseTable):
 
     def dereference_propositions(self, propositions: list[dict]) -> None:
         """
-        Dereferences the `proposition_id` field in each statement record.
+        Dereferences the `proposition_id` key in each statement record.
 
         Utilizes the `dereference_list` function from the BaseTable class to replace the value associated with the
         `proposition_id` key within each record. This key is expected to be present within each record, so a
@@ -393,7 +393,7 @@ class Statements(BaseTable):
 
     def dereference_indications(self, indications: list[dict]) -> None:
         """
-        Dereferences the `indication_id` field in each statement record.
+        Dereferences the `indication_id` key in each statement record.
 
         Utilizes the `dereference_list` function from the BaseTable class to replace the value associated with the
         `indication_id` key within each record. This key is expected to be present within each record, so a
@@ -415,7 +415,7 @@ class Statements(BaseTable):
 class Therapies(BaseTable):
     """
     Represents the Therapies table. This class inherits common functionality from the BaseTable class and
-    dereferences fields that reference other tables. This table does not currently reference any other tables.
+    dereferences keys that reference other tables. This table does not currently reference any other tables.
 
     Attributes:
         records (list[dict]): A list of dictionaries representing the therapy records.

--- a/utils/dereference.py
+++ b/utils/dereference.py
@@ -102,9 +102,26 @@ class BaseTable:
 
 
 class Agents(BaseTable):
+    """
+    Dereferences the Agents table. It inherits common functionality from the BaseTable class and dereferences
+    fields that reference other tables. This table does not currently reference any other tables.
+
+    Attributes:
+        records (list[dict]): A list of dictionaries representing the agent records.
+    """
+
     pass
 
 class Biomarkers(BaseTable):
+    """
+    Dereferences the Biomarkers table. It inherits common functionality from the BaseTable class and dereferences
+    fields that reference other tables. This table references the following tables:
+    - Genes (field: 'organization_id')
+
+    Attributes:
+        records (list[dict]): A list of dictionaries representing the document records.
+    """
+
     def dereference_genes(self, genes):
         self.records = self.dereference_list(
             referenced_key='genes',
@@ -113,6 +130,15 @@ class Biomarkers(BaseTable):
         )
 
 class Contributions(BaseTable):
+    """
+    Dereferences the Contributions table. It inherits common functionality from the BaseTable class and dereferences
+    fields that reference other tables. This table references the following tables:
+    - Agents (field: 'agent_id')
+
+    Attributes:
+        records (list[dict]): A list of dictionaries representing the contribution records.
+    """
+
     def dereference_agents(self, agents):
         self.records = self.dereference_integer(
             referenced_key='agent_id',
@@ -121,10 +147,37 @@ class Contributions(BaseTable):
         )
 
 class Diseases(BaseTable):
+    """
+    Dereferences the Diseases table. It inherits common functionality from the BaseTable class and dereferences
+    fields that reference other tables. This table does not currently reference any other tables.
+
+    Attributes:
+        records (list[dict]): A list of dictionaries representing the disease records.
+    """
+
     pass
 
 class Documents(BaseTable):
+    """
+    Dereferences the Documents table. It inherits common functionality from the BaseTable class and dereferences
+    fields that reference other tables. This table references the following tables:
+    - Organizations (field: 'organization_id')
+
+    Attributes:
+        records (list[dict]): A list of dictionaries representing the document records.
+    """
+
     def dereference_organizations(self, organizations):
+        """
+        Dereferences the organization field in the Documents table and replaces 'organization_id' field with 'organization'.
+
+        Args:
+            organizations (list[dict]): A list of dictionaries representing the organization records.
+
+        Raises:
+            KeyError: If the referenced key, 'organization_id', is not found within a document record.
+        """
+
         self.records = self.dereference_integer(
             referenced_key='organization_id',
             referenced_records=organizations,
@@ -132,9 +185,26 @@ class Documents(BaseTable):
         )
 
 class Genes(BaseTable):
+    """
+    Dereferences the Genes table. It inherits common functionality from the BaseTable class and dereferences
+    fields that reference other tables. This table does not currently reference any other tables.
+
+    Attributes:
+        records (list[dict]): A list of dictionaries representing the gene records.
+    """
+
     pass
 
 class Indications(BaseTable):
+    """
+    Dereferences the Indications table. It inherits common functionality from the BaseTable class and dereferences
+    fields that reference other tables. This table references the following tables:
+    - Documents (field: 'document_id')
+
+    Attributes:
+        records (list[dict]): A list of dictionaries representing the indication records.
+    """
+
     def dereference_documents(self, documents):
         self.records = self.dereference_integer(
             referenced_key='document_id',
@@ -143,9 +213,28 @@ class Indications(BaseTable):
         )
 
 class Organizations(BaseTable):
+    """
+    Dereferences the Organizations table. It inherits common functionality from the BaseTable class and dereferences
+    fields that reference other tables. This table does not currently reference any other tables.
+
+    Attributes:
+        records (list[dict]): A list of dictionaries representing the organization records.
+    """
+
     pass
 
 class Propositions(BaseTable):
+    """
+    Dereferences the Propositions table. It inherits common functionality from the BaseTable class and dereferences
+    fields that reference other tables. This table references the following tables:
+    - Biomarkers (field: 'biomarkers')
+    - Diseases (field: 'conditionQualifier_id')
+    - Therapies (field: 'therapies')
+
+    Attributes:
+        records (list[dict]): A list of dictionaries representing the proposition records.
+    """
+
     def dereference_biomarkers(self, biomarkers):
         self.records = self.dereference_list(
             referenced_key='biomarkers',
@@ -169,6 +258,18 @@ class Propositions(BaseTable):
         )
 
 class Statements(BaseTable):
+    """
+    Dereferences the Statements table. It inherits common functionality from the BaseTable class and dereferences
+    fields that reference other tables. This table references the following tables:
+    - Contributions (field: 'contributions')
+    - Documents (field: 'reportedIn')
+    - Propositions (field: 'proposition_id')
+    - Indications (field: 'indications')
+
+    Attributes:
+        records (list[dict]): A list of dictionaries representing the statement records.
+    """
+
     def dereference_contributions(self, contributions):
         self.records = self.dereference_list(
             referenced_key='contributions',
@@ -198,6 +299,14 @@ class Statements(BaseTable):
         )
 
 class Therapies(BaseTable):
+    """
+    Dereferences the Therapies table. It inherits common functionality from the BaseTable class and dereferences
+    fields that reference other tables. This table does not currently reference any other tables.
+
+    Attributes:
+        records (list[dict]): A list of dictionaries representing the therapy records.
+    """
+
     pass
 
 def main(input_paths):
@@ -237,8 +346,6 @@ def main(input_paths):
     propositions = Propositions(records=propositions)
     statements = Statements(records=statements)
     therapies = Therapies(records=therapies)
-
-    print(genes)
 
     # biomarkers; references genes.json
     biomarkers.dereference_genes(genes=genes.records)

--- a/utils/dereference.py
+++ b/utils/dereference.py
@@ -539,8 +539,6 @@ class Statements(BaseTable):
         # instead of using the function from the Indications class, we will just manually
         # dereference documents for indications
 
-        # indications.dereference(documents=documents, organizations=organizations)
-
         for record in indications.records:
             self.dereference_single(
                 record=record,
@@ -552,6 +550,8 @@ class Statements(BaseTable):
                 old_key='document_id',
                 new_key='document'
             )
+
+        # indications.dereference(documents=documents, organizations=organizations)
 
         for record in self.records:
             self.dereference_single(

--- a/utils/dereference.py
+++ b/utils/dereference.py
@@ -77,25 +77,22 @@ class BaseTable:
             record[referenced_key] = _values
 
     @staticmethod
-    def replace_key(record: dict, referenced_key: str, new_key_name: str) -> dict:
+    def replace_key(record: dict, old_key: str, new_key: str) -> None:
         """
         Dereferences a key for each record in records, where the key's value references a single record.
 
         Args:
             record (dict): the dictionary that contains a key to replace.
-            referenced_key (str): name of the key in `record` to replace.
-            new_key_name (str): this name will replace the `referenced_key` key in `record`.
+            old_key (str): the name of the key in `record` to replace.
+            new_key (str): the new key name that will replace `old_key` in `record`.
 
         Raises:
-            KeyError: If the referenced_key is not found in the record.
+            KeyError: If the `old_key` is not found in the record.
         """
-        new_record = {}
-        for key, value in record.items():
-            if key == referenced_key:
-                new_record[new_key_name] = record[referenced_key]
-            else:
-                new_record[key] = value
-        return new_record
+        if old_key not in record:
+            raise KeyError(f"Key '{old_key}' not found in {record}")
+
+        record[new_key] = record.pop(old_key)
 
     @staticmethod
     def remove_key(record: dict, key: str) -> None:
@@ -111,7 +108,6 @@ class BaseTable:
         """
         if key not in record:
             raise KeyError(f"Key '{key}' not found in {record}")
-
         record.pop(key)
 
 class Agents(BaseTable):
@@ -135,11 +131,11 @@ class Biomarkers(BaseTable):
         records (list[dict]): A list of dictionaries representing the biomarker records.
     """
 
-    def dereference(self, genes: Genes) -> None:
+    def dereference(self, genes: 'Genes') -> None:
         """Dereference all keys for this table."""
         self.dereference_genes(genes=genes)
 
-    def dereference_genes(self, genes: Genes) -> None:
+    def dereference_genes(self, genes: 'Genes') -> None:
         """
         Dereferences the `genes` key in each biomarker record.
 
@@ -167,11 +163,11 @@ class Contributions(BaseTable):
     Attributes:
         records (list[dict]): A list of dictionaries representing the contribution records.
     """
-    def dereference(self, agents: Agents) -> None:
+    def dereference(self, agents: 'Agents') -> None:
         """Dereference all keys for this table."""
         self.dereference_agents(agents=agents)
 
-    def dereference_agents(self, agents: Agents) -> None:
+    def dereference_agents(self, agents: 'Agents') -> None:
         """
         Dereferences the `agent_id` key in each contribution record.
 
@@ -193,8 +189,8 @@ class Contributions(BaseTable):
             )
             self.replace_key(
                 record=record,
-                referenced_key='agent_id',
-                new_key_name='agent'
+                old_key='agent_id',
+                new_key='agent'
             )
 
 class Diseases(BaseTable):
@@ -218,11 +214,11 @@ class Documents(BaseTable):
         records (list[dict]): A list of dictionaries representing the document records.
     """
 
-    def dereference(self, organizations: BaseTable) -> None:
+    def dereference(self, organizations: 'Organizations') -> None:
         """Dereference all keys for this table."""
         self.dereference_organizations(organizations=organizations)
 
-    def dereference_organizations(self, organizations: Organizations) -> None:
+    def dereference_organizations(self, organizations: 'Organizations') -> None:
         """
         Dereferences the `organization_id` key in each document record.
 
@@ -244,8 +240,8 @@ class Documents(BaseTable):
             )
             self.replace_key(
                 record=record,
-                referenced_key='organization_id',
-                new_key_name='organization'
+                old_key='organization_id',
+                new_key='organization'
             )
 
 class Genes(BaseTable):
@@ -269,11 +265,11 @@ class Indications(BaseTable):
         records (list[dict]): A list of dictionaries representing the indication records.
     """
 
-    def dereference(self, documents: Documents, organizations: Organizations) -> None:
+    def dereference(self, documents: 'Documents', organizations: 'Organizations') -> None:
         """Dereference all keys for this table."""
         self.dereference_documents(documents=documents, organizations=organizations)
 
-    def dereference_documents(self, documents: Documents, organizations: Organizations) -> None:
+    def dereference_documents(self, documents: 'Documents', organizations: 'Organizations') -> None:
         """
         Dereferences the `document_id` key in each indication record.
 
@@ -287,6 +283,7 @@ class Indications(BaseTable):
         Args:
             documents (Documents): An instance of the Documents class representing the documents table.
             organizations (Organizations): An instance of the Organizations class representing the organizations table.
+            dereference_organizations (bool): If `dereference_organizations` is `True`, this function will dereference organizations.
 
         Raises:
             KeyError: If the referenced_key, `document_id`, is not found in a record.
@@ -301,8 +298,8 @@ class Indications(BaseTable):
             )
             self.replace_key(
                 record=record,
-                referenced_key='document_id',
-                new_key_name='document'
+                old_key='document_id',
+                new_key='document'
             )
 
 class Organizations(BaseTable):
@@ -328,13 +325,13 @@ class Propositions(BaseTable):
         records (list[dict]): A list of dictionaries representing the proposition records.
     """
 
-    def dereference(self, biomarkers: Biomarkers, diseases: Diseases, genes: Genes, therapies: Therapies, therapy_groups: TherapyGroups) -> None:
+    def dereference(self, biomarkers: 'Biomarkers', diseases: 'Diseases', genes: 'Genes', therapies: 'Therapies', therapy_groups: 'TherapyGroups') -> None:
         """Dereferences all keys for this table."""
         self.dereference_biomarkers(biomarkers=biomarkers, genes=genes)
         self.dereference_diseases(diseases=diseases)
         self.dereference_therapeutics(therapies=therapies, therapy_groups=therapy_groups)
 
-    def dereference_biomarkers(self, biomarkers: Biomarkers, genes: Genes) -> None:
+    def dereference_biomarkers(self, biomarkers: 'Biomarkers', genes: 'Genes') -> None:
         """
         Dereferences the `biomarkers` key in each proposition record.
 
@@ -362,7 +359,7 @@ class Propositions(BaseTable):
                 key_always_present=True
             )
 
-    def dereference_diseases(self, diseases: Diseases) -> None:
+    def dereference_diseases(self, diseases: 'Diseases') -> None:
         """
         Dereferences the `conditionQualifier_id` key in each proposition record.
 
@@ -384,11 +381,11 @@ class Propositions(BaseTable):
             )
             self.replace_key(
                 record=record,
-                referenced_key='conditionQualifier_id',
-                new_key_name='conditionQualifier'
+                old_key='conditionQualifier_id',
+                new_key='conditionQualifier'
             )
 
-    def dereference_therapeutics(self, therapies: Therapies, therapy_groups: TherapyGroups) -> None:
+    def dereference_therapeutics(self, therapies: 'Therapies', therapy_groups: 'TherapyGroups') -> None:
         """
         Dereferences the `therapy_id` key or `therapy_group_id` key in each proposition record.
 
@@ -408,7 +405,7 @@ class Propositions(BaseTable):
         therapy_groups.dereference(therapies=therapies)
 
         for record in self.records:
-            if record['therapy_id']:
+            if isinstance(record['therapy_id'], int):
                 self.dereference_single(
                     record=record,
                     referenced_key='therapy_id',
@@ -416,31 +413,30 @@ class Propositions(BaseTable):
                 )
                 self.replace_key(
                     record=record,
-                    referenced_key='therapy_id',
-                    new_key_name='objectTherapeutic'
+                    old_key='therapy_id',
+                    new_key='objectTherapeutic'
                 )
-            elif record['therapy_group_id']:
-                self.dereference_list(
+                self.remove_key(
+                    record=record,
+                    key='therapy_group_id'
+                )
+            elif isinstance(record['therapy_group_id'], int):
+                self.dereference_single(
                     record=record,
                     referenced_key='therapy_group_id',
                     referenced_records=therapy_groups.records
                 )
                 self.replace_key(
                     record=record,
-                    referenced_key='therapy_group_id',
-                    new_key_name='objectTherapeutic'
+                    old_key='therapy_group_id',
+                    new_key='objectTherapeutic'
+                )
+                self.remove_key(
+                    record=record,
+                    key='therapy_id'
                 )
             else:
                 raise KeyError(f"Neither 'therapy_id' nor 'therapy_group_id' are keys found in {record}")
-
-            self.remove_key(
-                record=record,
-                key='therapy_id'
-            )
-            self.remove_key(
-                record=record,
-                key='therapy_group_id'
-            )
 
 class Statements(BaseTable):
     """
@@ -455,15 +451,14 @@ class Statements(BaseTable):
         records (list[dict]): A list of dictionaries representing the statement records.
     """
 
-    def dereference(self, agents: Agents, biomarkers: Biomarkers, contributions: Contributions, diseases: Diseases, documents: Documents, genes: Genes, indications: Indications, organizations: Organizations, propositions: Propositions, therapies: Therapies, therapy_groups: TherapyGroups) -> None:
+    def dereference(self, agents: 'Agents', biomarkers: 'Biomarkers', contributions: 'Contributions', diseases: 'Diseases', documents: 'Documents', genes: 'Genes', indications: 'Indications', organizations: 'Organizations', propositions: 'Propositions', therapies: 'Therapies', therapy_groups: 'TherapyGroups') -> None:
         """Dereferences all keys for this table."""
         self.dereference_contributions(contributions=contributions, agents=agents)
         self.dereference_documents(documents=documents, organizations=organizations)
-        # Will documents already be dereferenced...?
         self.dereference_indications(indications=indications, documents=documents, organizations=organizations)
         self.dereference_propositions(propositions=propositions, biomarkers=biomarkers, diseases=diseases, genes=genes, therapies=therapies, therapy_groups=therapy_groups)
 
-    def dereference_contributions(self, contributions: Contributions, agents: Agents) -> None:
+    def dereference_contributions(self, contributions: 'Contributions', agents: 'Agents') -> None:
         """
         Dereferences the `contributions` key in each statement record.
 
@@ -491,7 +486,7 @@ class Statements(BaseTable):
                 key_always_present=True
             )
 
-    def dereference_documents(self, documents: Documents, organizations: Organizations) -> None:
+    def dereference_documents(self, documents: 'Documents', organizations: 'Organizations') -> None:
         """
         Dereferences the `reportedIn` key in each statement record.
 
@@ -519,7 +514,7 @@ class Statements(BaseTable):
                 key_always_present=True
             )
 
-    def dereference_indications(self, indications: Indications, documents: Documents, organizations: Organizations) -> None:
+    def dereference_indications(self, indications: 'Indications', documents: 'Documents', organizations: 'Organizations') -> None:
         """
         Dereferences the `indication_id` key in each statement record.
 
@@ -549,11 +544,11 @@ class Statements(BaseTable):
             )
             self.replace_key(
                 record=record,
-                referenced_key='indication_id',
-                new_key_name='indication'
+                old_key='indication_id',
+                new_key='indication'
             )
 
-    def dereference_propositions(self, propositions: Propositions, biomarkers: Biomarkers, diseases: Diseases, genes: Genes, therapies: Therapies, therapy_groups: TherapyGroups) -> None:
+    def dereference_propositions(self, propositions: 'Propositions', biomarkers: 'Biomarkers', diseases: 'Diseases', genes: 'Genes', therapies: 'Therapies', therapy_groups: 'TherapyGroups') -> None:
         """
         Dereferences the `proposition_id` key in each statement record.
 
@@ -591,8 +586,8 @@ class Statements(BaseTable):
             )
             self.replace_key(
                 record=record,
-                referenced_key='proposition_id',
-                new_key_name='proposition'
+                old_key='proposition_id',
+                new_key='proposition'
             )
 
 class Therapies(BaseTable):
@@ -616,11 +611,11 @@ class TherapyGroups(BaseTable):
         records (list[dict]): A list of dictionaries representing the therapy records.
     """
 
-    def dereference(self, therapies: list[dict]):
+    def dereference(self, therapies: 'Therapies'):
         """Dereference all keys for this table."""
         self.dereference_therapies(therapies=therapies)
 
-    def dereference_therapies(self, therapies: list[dict]) -> None:
+    def dereference_therapies(self, therapies: 'Therapies') -> None:
         """
         Dereferences the `therapies_id` key in each therapy group record.
 
@@ -638,7 +633,7 @@ class TherapyGroups(BaseTable):
             self.dereference_list(
                 record=record,
                 referenced_key='therapies',
-                referenced_records=therapies,
+                referenced_records=therapies.records,
                 key_always_present=True
             )
 
@@ -685,39 +680,7 @@ def main(input_paths):
     therapies = Therapies(records=therapies)
     therapy_groups = TherapyGroups(records=therapy_groups)
 
-    # Step 3: dereference relevant tables
-    # biomarkers; references genes.json
-    #biomarkers.dereference(genes=genes)
-
-    # contributions; references agents.json
-    #contributions.dereference_agents(agents=agents.records)
-
-    # documents; references organizations.json
-    #documents.dereference_organizations(organizations=organizations.records)
-
-    # indications; references documents.json
-    #indications.dereference_documents(documents=documents.records)
-
-    # therapy groups; references therapies
-    #therapy_groups.dereference_therapies(therapies=therapies.records)
-
-    # propositions; references biomarkers.json, diseases.json, and therapies.json
-    #propositions.dereference(
-    #    biomarkers=biomarkers,
-    #    diseases=diseases,
-    #    genes=genes,
-    #    therapies=therapies,
-    #    therapy_groups=therapy_groups
-    #)
-    #propositions.dereference_biomarkers(biomarkers=biomarkers.records)
-    #propositions.dereference_diseases(diseases=diseases.records)
-    #propositions.dereference_therapeutics(therapies=therapies.records, therapy_groups=therapy_groups.records)
-
-    # statements; references contributions.json, documents.json, propositions.json, and indications.json
-    #statements.dereference_contributions(contributions=contributions.records)
-    #statements.dereference_documents(documents=documents.records)
-    #statements.dereference_propositions(propositions=propositions.records)
-    #statements.dereference_indications(indications=indications.records)
+    # Step 3: Dereference the database and generate statements
     statements.dereference(
         agents=agents,
         biomarkers=biomarkers,

--- a/utils/dereference.py
+++ b/utils/dereference.py
@@ -1,7 +1,4 @@
 import argparse
-from reprlib import recursive_repr
-
-from numpy.f2py.symbolic import as_ge
 
 import json_utils # Local import
 

--- a/utils/dereference.py
+++ b/utils/dereference.py
@@ -272,7 +272,7 @@ class Propositions(BaseTable):
         records (list[dict]): A list of dictionaries representing the proposition records.
     """
 
-    def dereference(self, biomarkers: list[dict], diseases: list[dict], genes: list[dict], therapies: list[dict]) -> None:
+    def dereference(self, biomarkers: list[dict], diseases: list[dict], therapies: list[dict]) -> None:
         """Dereferences all keys for this table."""
         self.dereference_biomarkers(biomarkers=biomarkers)
         self.dereference_diseases(diseases=diseases)
@@ -352,7 +352,7 @@ class Statements(BaseTable):
         records (list[dict]): A list of dictionaries representing the statement records.
     """
 
-    def dereference(self, agents: list[dict], biomarkers: list[dict], contributions: list[dict], diseases: list[dict], documents: list[dict], genes: list[dict], indications: list[dict], propositions: list[dict], therapies: list[dict]):
+    def dereference(self, contributions: list[dict], documents: list[dict], indications: list[dict], propositions: list[dict]):
         """Dereferences all keys for this table."""
         self.dereference_contributions(contributions=contributions)
         self.dereference_documents(documents=documents)

--- a/utils/dereference.py
+++ b/utils/dereference.py
@@ -534,7 +534,24 @@ class Statements(BaseTable):
         Raises:
             KeyError: If the referenced_key, `indication_id`, is not found in a record.
         """
-        indications.dereference(documents=documents, organizations=organizations)
+
+        # Documents will have already been dereferenced for organizations
+        # instead of using the function from the Indications class, we will just manually
+        # dereference documents for indications
+
+        # indications.dereference(documents=documents, organizations=organizations)
+
+        for record in indications.records:
+            self.dereference_single(
+                record=record,
+                referenced_key='document_id',
+                referenced_records=documents.records
+            )
+            self.replace_key(
+                record=record,
+                old_key='document_id',
+                new_key='document'
+            )
 
         for record in self.records:
             self.dereference_single(

--- a/utils/json_utils.py
+++ b/utils/json_utils.py
@@ -2,18 +2,18 @@ import json
 import typing
 
 
-def fetch_records_by_key_value(records: list[dict], value: typing.Any, key: str = "id", warn: bool = True) -> dict | None:
+def fetch_records_by_key_value(records: list[dict], value: typing.Any, key: str = "id", warn: bool = True) -> typing.Optional[dict]:
     """
-    Retrieves records where a specific field matches a given value.
+    Retrieves records where a specific key matches a given value.
 
     Args:
         records (list[dict]): A list of dictionaries to search.
         value (any): The value to match.
-        key (str): The field to check (default: "id").
+        key (str): The key to check (default: "id").
         warn (bool): Whether to warn and exit if the number of results is not 1 (default: True).
 
     Returns:
-        dict | None: A list of matching records, or None if no matches are found.
+        dict or None: A list of matching records, or None if no matches are found.
 
     Raises:
         ValueError: If the number of results is not exactly 1 and warnings are enabled.

--- a/utils/json_utils.py
+++ b/utils/json_utils.py
@@ -2,7 +2,7 @@ import json
 import typing
 
 
-def fetch_records_by_key_value(records: list[dict], value: typing.Any, key: str = "id", warn: bool = True) -> list[dict]:
+def fetch_records_by_key_value(records: list[dict], value: typing.Any, key: str = "id", warn: bool = True) -> dict | None:
     """
     Retrieves records where a specific field matches a given value.
 
@@ -13,7 +13,7 @@ def fetch_records_by_key_value(records: list[dict], value: typing.Any, key: str 
         warn (bool): Whether to warn and exit if the number of results is not 1 (default: True).
 
     Returns:
-        list[dict]: A list of matching records.
+        dict | None: A list of matching records, or None if no matches are found.
 
     Raises:
         ValueError: If the number of results is not exactly 1 and warnings are enabled.
@@ -23,7 +23,7 @@ def fetch_records_by_key_value(records: list[dict], value: typing.Any, key: str 
     if warn and len(results) != 1:
         ValueError(f"Warning: Expected 1 result for {key} == {value}, found {len(results)}.")
 
-    return results
+    return next(iter(results), None)
 
 
 def rename_key(dictionary: dict, old_key: str, new_key: str) -> None:


### PR DESCRIPTION
## Overview
The [in development](https://github.com/vanallenlab/moalmanac-db/blob/main/docs/referenced-schema-draft-about.md) version of the database was updated to represent therapies as [recommended by va-spec](https://va-ga4gh.readthedocs.io/en/latest/core-information-model/entities/domain-entities/therapeutics/index.html#therapeutic). 

## Feature updates
**Description**:
Therapies within [Therapeutic Response Propositions](https://va-ga4gh.readthedocs.io/en/latest/va-standard-profiles/base-profiles/proposition-profiles.html#variant-therapeutic-response-proposition) are now represented as suggested by va-spec. Specifically, only one `objectTherapeutic` object is associated with each proposition by representing therapies as either a [Drug](https://va-ga4gh.readthedocs.io/en/latest/core-information-model/entities/domain-entities/therapeutics/drug.html) or [Therapy Group](https://va-ga4gh.readthedocs.io/en/latest/core-information-model/entities/domain-entities/therapeutics/therapy-group.html). 

**Objective**:
To align therapy representation with VA-Spec.

**Implementation details**:
Outline the key details or steps involved in implementing this update.
- A new table `therapy_groups.json` was created from `propositions.json` that contains all referenced set of therapies. 
- The `therapies` key within each record of `propositions.json` was split up into two: `therapy_id` and `therapy_group_id`. If the length of `therapies` was one, `therapy_id` was populated with that value and `therapy_group_id` was set to null. Likewise, if the length of `therapies` was greater than one, `therapy_group_id` was populated with the corresponding id from `therapy_groups.json` and `therapy_id` was set to null.
- `utils/dereference.py` was updated to dereference the database in this way and refactored to chain dereferencing of referenced tables.
- Corresponding documentation was updated.

## Checklist
- [ ] All files changed have been reviewed.
- [x] All relevant documentation has been updated.
- [ ] All unit tests have passed.
