### PR TITLE
Reference codings and mappings

### DIFF
--- a/referenced/codings.json
+++ b/referenced/codings.json
@@ -1,0 +1,4220 @@
+[
+  {
+    "id": "oncotree:ALL",
+    "code": "ALL",
+    "name": "Acute Lymphoid Leukemia",
+    "system": "https://oncotree.mskcc.org",
+    "systemVersion": "oncotree_2021_11_02",
+    "iris": [
+      "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=ALL"
+    ]
+  },
+  {
+    "id": "oncotree:AML",
+    "code": "AML",
+    "name": "Acute Myeloid Leukemia",
+    "system": "https://oncotree.mskcc.org",
+    "systemVersion": "oncotree_2021_11_02",
+    "iris": [
+      "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=AML"
+    ]
+  },
+  {
+    "id": "oncotree:GEJ",
+    "code": "GEJ",
+    "name": "Adenocarcinoma of the Gastroesophageal Junction",
+    "system": "https://oncotree.mskcc.org",
+    "systemVersion": "oncotree_2021_11_02",
+    "iris": [
+      "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=GEJ"
+    ]
+  },
+  {
+    "id": "oncotree:ALCL",
+    "code": "ALCL",
+    "name": "Anaplastic Large Cell Lymphoma",
+    "system": "https://oncotree.mskcc.org",
+    "systemVersion": "oncotree_2021_11_02",
+    "iris": [
+      "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=ALCL"
+    ]
+  },
+  {
+    "id": "oncotree:THAP",
+    "code": "THAP",
+    "name": "Anaplastic Thyroid Cancer",
+    "system": "https://oncotree.mskcc.org",
+    "systemVersion": "oncotree_2021_11_02",
+    "iris": [
+      "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=THAP"
+    ]
+  },
+  {
+    "id": "oncotree:",
+    "code": "",
+    "name": "",
+    "system": "https://oncotree.mskcc.org",
+    "systemVersion": "oncotree_2021_11_02",
+    "iris": [
+      "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search="
+    ]
+  },
+  {
+    "id": "oncotree:ASTR",
+    "code": "ASTR",
+    "name": "Astrocytoma",
+    "system": "https://oncotree.mskcc.org",
+    "systemVersion": "oncotree_2021_11_02",
+    "iris": [
+      "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=ASTR"
+    ]
+  },
+  {
+    "id": "oncotree:BALL",
+    "code": "BALL",
+    "name": "B-Cell Acute Lymphoid Leukemia",
+    "system": "https://oncotree.mskcc.org",
+    "systemVersion": "oncotree_2021_11_02",
+    "iris": [
+      "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=BALL"
+    ]
+  },
+  {
+    "id": "oncotree:BLCA",
+    "code": "BLCA",
+    "name": "Bladder Urothelial Carcinoma",
+    "system": "https://oncotree.mskcc.org",
+    "systemVersion": "oncotree_2021_11_02",
+    "iris": [
+      "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=BLCA"
+    ]
+  },
+  {
+    "id": "oncotree:BRCA",
+    "code": "BRCA",
+    "name": "Invasive Breast Carcinoma",
+    "system": "https://oncotree.mskcc.org",
+    "systemVersion": "oncotree_2021_11_02",
+    "iris": [
+      "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=BRCA"
+    ]
+  },
+  {
+    "id": "oncotree:APLPMLRARA",
+    "code": "APLPMLRARA",
+    "name": "APL with PML-RARA",
+    "system": "https://oncotree.mskcc.org",
+    "systemVersion": "oncotree_2021_11_02",
+    "iris": [
+      "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=APLPMLRARA"
+    ]
+  },
+  {
+    "id": "oncotree:CHOL",
+    "code": "CHOL",
+    "name": "Cholangiocarcinoma",
+    "system": "https://oncotree.mskcc.org",
+    "systemVersion": "oncotree_2021_11_02",
+    "iris": [
+      "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=CHOL"
+    ]
+  },
+  {
+    "id": "oncotree:CELNOS",
+    "code": "CELNOS",
+    "name": "Chronic Eosinophilic Leukemia, NOS",
+    "system": "https://oncotree.mskcc.org",
+    "systemVersion": "oncotree_2021_11_02",
+    "iris": [
+      "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=CELNOS"
+    ]
+  },
+  {
+    "id": "oncotree:CML",
+    "code": "CML",
+    "name": "Chronic Myelogenous Leukemia",
+    "system": "https://oncotree.mskcc.org",
+    "systemVersion": "oncotree_2021_11_02",
+    "iris": [
+      "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=CML"
+    ]
+  },
+  {
+    "id": "oncotree:CMML",
+    "code": "CMML",
+    "name": "Chronic Myelomonocytic Leukemia",
+    "system": "https://oncotree.mskcc.org",
+    "systemVersion": "oncotree_2021_11_02",
+    "iris": [
+      "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=CMML"
+    ]
+  },
+  {
+    "id": "oncotree:COADREAD",
+    "code": "COADREAD",
+    "name": "Colorectal Adenocarcinoma",
+    "system": "https://oncotree.mskcc.org",
+    "systemVersion": "oncotree_2021_11_02",
+    "iris": [
+      "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=COADREAD"
+    ]
+  },
+  {
+    "id": "oncotree:DDLS",
+    "code": "DDLS",
+    "name": "Dedifferentiated Lipsarcoma",
+    "system": "https://oncotree.mskcc.org",
+    "systemVersion": "oncotree_2021_11_02",
+    "iris": [
+      "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=DDLS"
+    ]
+  },
+  {
+    "id": "oncotree:DFSP",
+    "code": "DFSP",
+    "name": "Dermatofibrosarcoma Protuberans",
+    "system": "https://oncotree.mskcc.org",
+    "systemVersion": "oncotree_2021_11_02",
+    "iris": [
+      "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=DFSP"
+    ]
+  },
+  {
+    "id": "oncotree:UCEC",
+    "code": "UCEC",
+    "name": "Endometrial Carcinoma",
+    "system": "https://oncotree.mskcc.org",
+    "systemVersion": "oncotree_2021_11_02",
+    "iris": [
+      "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=UCEC"
+    ]
+  },
+  {
+    "id": "oncotree:ES",
+    "code": "ES",
+    "name": "Ewing Sarcoma",
+    "system": "https://oncotree.mskcc.org",
+    "systemVersion": "oncotree_2021_11_02",
+    "iris": [
+      "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=ES"
+    ]
+  },
+  {
+    "id": "oncotree:FL",
+    "code": "FL",
+    "name": "Follicular Lymphoma",
+    "system": "https://oncotree.mskcc.org",
+    "systemVersion": "oncotree_2021_11_02",
+    "iris": [
+      "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=FL"
+    ]
+  },
+  {
+    "id": "oncotree:GRC",
+    "code": "GRC",
+    "name": "Gastric Remnant Adenocarcinoma",
+    "system": "https://oncotree.mskcc.org",
+    "systemVersion": "oncotree_2021_11_02",
+    "iris": [
+      "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=GRC"
+    ]
+  },
+  {
+    "id": "oncotree:GIST",
+    "code": "GIST",
+    "name": "Gastrointestinal Stromal Tumor",
+    "system": "https://oncotree.mskcc.org",
+    "systemVersion": "oncotree_2021_11_02",
+    "iris": [
+      "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=GIST"
+    ]
+  },
+  {
+    "id": "oncotree:GNOS",
+    "code": "GNOS",
+    "name": "Glioma",
+    "system": "https://oncotree.mskcc.org",
+    "systemVersion": "oncotree_2021_11_02",
+    "iris": [
+      "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=GNOS"
+    ]
+  },
+  {
+    "id": "oncotree:HNMUCM",
+    "code": "HNMUCM",
+    "name": "Head and Neck Mucosal Melanoma",
+    "system": "https://oncotree.mskcc.org",
+    "systemVersion": "oncotree_2021_11_02",
+    "iris": [
+      "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=HNMUCM"
+    ]
+  },
+  {
+    "id": "oncotree:HNSC",
+    "code": "HNSC",
+    "name": "Head and Neck Squamous Cell Carcinoma",
+    "system": "https://oncotree.mskcc.org",
+    "systemVersion": "oncotree_2021_11_02",
+    "iris": [
+      "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=HNSC"
+    ]
+  },
+  {
+    "id": "oncotree:HGNEC",
+    "code": "HGNEC",
+    "name": "High-Grade Neuroendocrine Carcinoma of the Colon and Rectum",
+    "system": "https://oncotree.mskcc.org",
+    "systemVersion": "oncotree_2021_11_02",
+    "iris": [
+      "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=HGNEC"
+    ]
+  },
+  {
+    "id": "oncotree:HGSFT",
+    "code": "HGSFT",
+    "name": "High-Grade Serous Fallopian Tube Cancer",
+    "system": "https://oncotree.mskcc.org",
+    "systemVersion": "oncotree_2021_11_02",
+    "iris": [
+      "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=HGSFT"
+    ]
+  },
+  {
+    "id": "oncotree:IMT",
+    "code": "IMT",
+    "name": "Inflammatory Myofibroblastic Tumor",
+    "system": "https://oncotree.mskcc.org",
+    "systemVersion": "oncotree_2021_11_02",
+    "iris": [
+      "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=IMT"
+    ]
+  },
+  {
+    "id": "oncotree:IHCH",
+    "code": "IHCH",
+    "name": "Intrahepatic Cholangiocarcinoma",
+    "system": "https://oncotree.mskcc.org",
+    "systemVersion": "oncotree_2021_11_02",
+    "iris": [
+      "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=IHCH"
+    ]
+  },
+  {
+    "id": "oncotree:LCH",
+    "code": "LCH",
+    "name": "Langerhans Cell Histiocytosis",
+    "system": "https://oncotree.mskcc.org",
+    "systemVersion": "oncotree_2021_11_02",
+    "iris": [
+      "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=LCH"
+    ]
+  },
+  {
+    "id": "oncotree:LMS",
+    "code": "LMS",
+    "name": "Leiomyosarcoma",
+    "system": "https://oncotree.mskcc.org",
+    "systemVersion": "oncotree_2021_11_02",
+    "iris": [
+      "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=LMS"
+    ]
+  },
+  {
+    "id": "oncotree:LEUK",
+    "code": "LEUK",
+    "name": "Leukemia",
+    "system": "https://oncotree.mskcc.org",
+    "systemVersion": "oncotree_2021_11_02",
+    "iris": [
+      "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=LEUK"
+    ]
+  },
+  {
+    "id": "oncotree:LIPO",
+    "code": "LIPO",
+    "name": "Liposarcoma",
+    "system": "https://oncotree.mskcc.org",
+    "systemVersion": "oncotree_2021_11_02",
+    "iris": [
+      "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=LIPO"
+    ]
+  },
+  {
+    "id": "oncotree:LGGNOS",
+    "code": "LGGNOS",
+    "name": "Low-Grade Glioma, NOS",
+    "system": "https://oncotree.mskcc.org",
+    "systemVersion": "oncotree_2021_11_02",
+    "iris": [
+      "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=LGGNOS"
+    ]
+  },
+  {
+    "id": "oncotree:LUSC",
+    "code": "LUSC",
+    "name": "Lung Squamous Cell Carcinoma",
+    "system": "https://oncotree.mskcc.org",
+    "systemVersion": "oncotree_2021_11_02",
+    "iris": [
+      "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=LUSC"
+    ]
+  },
+  {
+    "id": "oncotree:SMMCL",
+    "code": "SMMCL",
+    "name": "Mast Cell Leukemia",
+    "system": "https://oncotree.mskcc.org",
+    "systemVersion": "oncotree_2021_11_02",
+    "iris": [
+      "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=SMMCL"
+    ]
+  },
+  {
+    "id": "oncotree:THME",
+    "code": "THME",
+    "name": "Medullary Thyroid Cancer",
+    "system": "https://oncotree.mskcc.org",
+    "systemVersion": "oncotree_2021_11_02",
+    "iris": [
+      "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=THME"
+    ]
+  },
+  {
+    "id": "oncotree:MBL",
+    "code": "MBL",
+    "name": "Medulloblastoma",
+    "system": "https://oncotree.mskcc.org",
+    "systemVersion": "oncotree_2021_11_02",
+    "iris": [
+      "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=MBL"
+    ]
+  },
+  {
+    "id": "oncotree:MEL",
+    "code": "MEL",
+    "name": "Melanoma",
+    "system": "https://oncotree.mskcc.org",
+    "systemVersion": "oncotree_2021_11_02",
+    "iris": [
+      "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=MEL"
+    ]
+  },
+  {
+    "id": "oncotree:MM",
+    "code": "MM",
+    "name": "Multiple Myeloma",
+    "system": "https://oncotree.mskcc.org",
+    "systemVersion": "oncotree_2021_11_02",
+    "iris": [
+      "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=MM"
+    ]
+  },
+  {
+    "id": "oncotree:ASM",
+    "code": "ASM",
+    "name": "Aggressive Systemic Mastocytosis",
+    "system": "https://oncotree.mskcc.org",
+    "systemVersion": "oncotree_2021_11_02",
+    "iris": [
+      "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=ASM"
+    ]
+  },
+  {
+    "id": "oncotree:MDS",
+    "code": "MDS",
+    "name": "Myelodysplastic Syndromes",
+    "system": "https://oncotree.mskcc.org",
+    "systemVersion": "oncotree_2021_11_02",
+    "iris": [
+      "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=MDS"
+    ]
+  },
+  {
+    "id": "oncotree:MLN",
+    "code": "MLN",
+    "name": "Myeloid/Lymphoid Neoplasms",
+    "system": "https://oncotree.mskcc.org",
+    "systemVersion": "oncotree_2021_11_02",
+    "iris": [
+      "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=MLN"
+    ]
+  },
+  {
+    "id": "oncotree:MPN",
+    "code": "MPN",
+    "name": "Myeloproliferative Neoplasm",
+    "system": "https://oncotree.mskcc.org",
+    "systemVersion": "oncotree_2021_11_02",
+    "iris": [
+      "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=MPN"
+    ]
+  },
+  {
+    "id": "oncotree:ECD",
+    "code": "ECD",
+    "name": "Non-Langerhans Cell Histiocytosis/Erdheim-Chester Disease",
+    "system": "https://oncotree.mskcc.org",
+    "systemVersion": "oncotree_2021_11_02",
+    "iris": [
+      "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=ECD"
+    ]
+  },
+  {
+    "id": "oncotree:NSCLC",
+    "code": "NSCLC",
+    "name": "Non-Small Cell Lung Cancer",
+    "system": "https://oncotree.mskcc.org",
+    "systemVersion": "oncotree_2021_11_02",
+    "iris": [
+      "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=NSCLC"
+    ]
+  },
+  {
+    "id": "oncotree:ODG",
+    "code": "ODG",
+    "name": "Oligodendroglioma",
+    "system": "https://oncotree.mskcc.org",
+    "systemVersion": "oncotree_2021_11_02",
+    "iris": [
+      "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=ODG"
+    ]
+  },
+  {
+    "id": "oncotree:OS",
+    "code": "OS",
+    "name": "Osteosarcoma",
+    "system": "https://oncotree.mskcc.org",
+    "systemVersion": "oncotree_2021_11_02",
+    "iris": [
+      "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=OS"
+    ]
+  },
+  {
+    "id": "oncotree:OOVC",
+    "code": "OOVC",
+    "name": "Ovarian Cancer, Other",
+    "system": "https://oncotree.mskcc.org",
+    "systemVersion": "oncotree_2021_11_02",
+    "iris": [
+      "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=OOVC"
+    ]
+  },
+  {
+    "id": "oncotree:OVT",
+    "code": "OVT",
+    "name": "Ovarian Epithelial Tumor",
+    "system": "https://oncotree.mskcc.org",
+    "systemVersion": "oncotree_2021_11_02",
+    "iris": [
+      "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=OVT"
+    ]
+  },
+  {
+    "id": "oncotree:PAAD",
+    "code": "PAAD",
+    "name": "Pancreatic Adenocarcinoma",
+    "system": "https://oncotree.mskcc.org",
+    "systemVersion": "oncotree_2021_11_02",
+    "iris": [
+      "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=PAAD"
+    ]
+  },
+  {
+    "id": "oncotree:PEMESO",
+    "code": "PEMESO",
+    "name": "Peritoneal Mesothelioma",
+    "system": "https://oncotree.mskcc.org",
+    "systemVersion": "oncotree_2021_11_02",
+    "iris": [
+      "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=PEMESO"
+    ]
+  },
+  {
+    "id": "oncotree:PSEC",
+    "code": "PSEC",
+    "name": "Peritoneal Serous Carcinoma",
+    "system": "https://oncotree.mskcc.org",
+    "systemVersion": "oncotree_2021_11_02",
+    "iris": [
+      "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=PSEC"
+    ]
+  },
+  {
+    "id": "oncotree:PRAD",
+    "code": "PRAD",
+    "name": "Prostate Adenocarcinoma",
+    "system": "https://oncotree.mskcc.org",
+    "systemVersion": "oncotree_2021_11_02",
+    "iris": [
+      "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=PRAD"
+    ]
+  },
+  {
+    "id": "oncotree:PRNE",
+    "code": "PRNE",
+    "name": "Prostate Neuroendocrine Cancer",
+    "system": "https://oncotree.mskcc.org",
+    "systemVersion": "oncotree_2021_11_02",
+    "iris": [
+      "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=PRNE"
+    ]
+  },
+  {
+    "id": "oncotree:READ",
+    "code": "READ",
+    "name": "Rectal Adenocarcinoma",
+    "system": "https://oncotree.mskcc.org",
+    "systemVersion": "oncotree_2021_11_02",
+    "iris": [
+      "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=READ"
+    ]
+  },
+  {
+    "id": "oncotree:RCC",
+    "code": "RCC",
+    "name": "Renal Cell Carcinoma",
+    "system": "https://oncotree.mskcc.org",
+    "systemVersion": "oncotree_2021_11_02",
+    "iris": [
+      "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=RCC"
+    ]
+  },
+  {
+    "id": "oncotree:CCRCC",
+    "code": "CCRCC",
+    "name": "Renal Clear Cell Carcinoma",
+    "system": "https://oncotree.mskcc.org",
+    "systemVersion": "oncotree_2021_11_02",
+    "iris": [
+      "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=CCRCC"
+    ]
+  },
+  {
+    "id": "oncotree:SOC",
+    "code": "SOC",
+    "name": "Serous Ovarian Cancer",
+    "system": "https://oncotree.mskcc.org",
+    "systemVersion": "oncotree_2021_11_02",
+    "iris": [
+      "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=SOC"
+    ]
+  },
+  {
+    "id": "oncotree:SCLC",
+    "code": "SCLC",
+    "name": "Small Cell Lung Cancer",
+    "system": "https://oncotree.mskcc.org",
+    "systemVersion": "oncotree_2021_11_02",
+    "iris": [
+      "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=SCLC"
+    ]
+  },
+  {
+    "id": "oncotree:SCCNOS",
+    "code": "SCCNOS",
+    "name": "Squamous Cell Carcinoma, NOS",
+    "system": "https://oncotree.mskcc.org",
+    "systemVersion": "oncotree_2021_11_02",
+    "iris": [
+      "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=SCCNOS"
+    ]
+  },
+  {
+    "id": "oncotree:STAD",
+    "code": "STAD",
+    "name": "Stomach Adenocarcinoma",
+    "system": "https://oncotree.mskcc.org",
+    "systemVersion": "oncotree_2021_11_02",
+    "iris": [
+      "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=STAD"
+    ]
+  },
+  {
+    "id": "oncotree:TALL",
+    "code": "TALL",
+    "name": "T-Cell Acute Lymphoid Leukemia",
+    "system": "https://oncotree.mskcc.org",
+    "systemVersion": "oncotree_2021_11_02",
+    "iris": [
+      "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=TALL"
+    ]
+  },
+  {
+    "id": "oncotree:TGCT",
+    "code": "TGCT",
+    "name": "Testicular Germ Cell Tumors",
+    "system": "https://oncotree.mskcc.org",
+    "systemVersion": "oncotree_2021_11_02",
+    "iris": [
+      "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=TGCT"
+    ]
+  },
+  {
+    "id": "oncotree:THYC",
+    "code": "THYC",
+    "name": "Thymic Carcinoma",
+    "system": "https://oncotree.mskcc.org",
+    "systemVersion": "oncotree_2021_11_02",
+    "iris": [
+      "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=THYC"
+    ]
+  },
+  {
+    "id": "oncotree:UCU",
+    "code": "UCU",
+    "name": "Urethral Urothelial Carcinoma",
+    "system": "https://oncotree.mskcc.org",
+    "systemVersion": "oncotree_2021_11_02",
+    "iris": [
+      "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=UCU"
+    ]
+  },
+  {
+    "id": "oncotree:ULM",
+    "code": "ULM",
+    "name": "Uterine Leiomyoma",
+    "system": "https://oncotree.mskcc.org",
+    "systemVersion": "oncotree_2021_11_02",
+    "iris": [
+      "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=ULM"
+    ]
+  },
+  {
+    "id": "oncotree:ULMS",
+    "code": "ULMS",
+    "name": "Uterine Leiomyosarcoma",
+    "system": "https://oncotree.mskcc.org",
+    "systemVersion": "oncotree_2021_11_02",
+    "iris": [
+      "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=ULMS"
+    ]
+  },
+  {
+    "id": "oncotree:WDLS",
+    "code": "WDLS",
+    "name": "Well-Differentiated Liposarcoma",
+    "system": "https://oncotree.mskcc.org",
+    "systemVersion": "oncotree_2021_11_02",
+    "iris": [
+      "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=WDLS"
+    ]
+  },
+  {
+    "id": "oncotree:CMLBCRABL1",
+    "code": "CMLBCRABL1",
+    "name": "Chronic Myeloid Leukemia, BCR-ABL1+",
+    "system": "https://oncotree.mskcc.org",
+    "systemVersion": "oncotree_2021_11_02",
+    "iris": [
+      "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=CMLBCRABL1"
+    ]
+  },
+  {
+    "id": "oncotree:CEAD",
+    "code": "CEAD",
+    "name": "Cervical Adenocarcinoma",
+    "system": "https://oncotree.mskcc.org",
+    "systemVersion": "oncotree_2021_11_02",
+    "iris": [
+      "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=CEAD"
+    ]
+  },
+  {
+    "id": "oncotree:CESC",
+    "code": "CESC",
+    "name": "Cervical Squamous Cell Carcinoma",
+    "system": "https://oncotree.mskcc.org",
+    "systemVersion": "oncotree_2021_11_02",
+    "iris": [
+      "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=CESC"
+    ]
+  },
+  {
+    "id": "oncotree:ESCA",
+    "code": "ESCA",
+    "name": "Esophageal Adenocarcinoma",
+    "system": "https://oncotree.mskcc.org",
+    "systemVersion": "oncotree_2021_11_02",
+    "iris": [
+      "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=ESCA"
+    ]
+  },
+  {
+    "id": "oncotree:THPA",
+    "code": "THPA",
+    "name": "Papillary Thyroid Cancer",
+    "system": "https://oncotree.mskcc.org",
+    "systemVersion": "oncotree_2021_11_02",
+    "iris": [
+      "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=THPA"
+    ]
+  },
+  {
+    "id": "oncotree:NHL",
+    "code": "NHL",
+    "name": "Non-Hodgkin Lymphoma",
+    "system": "https://oncotree.mskcc.org",
+    "systemVersion": "oncotree_2021_11_02",
+    "iris": [
+      "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=NHL"
+    ]
+  },
+  {
+    "id": "oncotree:DLBCLNOS",
+    "code": "DLBCLNOS",
+    "name": "Diffuse Large B-Cell Lymphoma",
+    "system": "https://oncotree.mskcc.org",
+    "systemVersion": "oncotree_2021_11_02",
+    "iris": [
+      "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=DLBCLNOS"
+    ]
+  },
+  {
+    "id": "oncotree:BL",
+    "code": "BL",
+    "name": "Burkitt Lymphoma",
+    "system": "https://oncotree.mskcc.org",
+    "systemVersion": "oncotree_2021_11_02",
+    "iris": [
+      "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=BL"
+    ]
+  },
+  {
+    "id": "oncotree:MBN",
+    "code": "MBN",
+    "name": "Mature B-Cell Neoplasms",
+    "system": "https://oncotree.mskcc.org",
+    "systemVersion": "oncotree_2021_11_02",
+    "iris": [
+      "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=MBN"
+    ]
+  },
+  {
+    "id": "oncotree:HL",
+    "code": "HL",
+    "name": "Hodgkin Lymphoma",
+    "system": "https://oncotree.mskcc.org",
+    "systemVersion": "oncotree_2021_11_02",
+    "iris": [
+      "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=HL"
+    ]
+  },
+  {
+    "id": "oncotree:EGC",
+    "code": "EGC",
+    "name": "Esophagogastric Adenocarcinoma",
+    "system": "https://oncotree.mskcc.org",
+    "systemVersion": "oncotree_2021_11_02",
+    "iris": [
+      "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=EGC"
+    ]
+  },
+  {
+    "id": "oncotree:ESCC",
+    "code": "ESCC",
+    "name": "Esophageal Squamous Cell Carcinoma",
+    "system": "https://oncotree.mskcc.org",
+    "systemVersion": "oncotree_2021_11_02",
+    "iris": [
+      "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=ESCC"
+    ]
+  },
+  {
+    "id": "oncotree:HGGNOS",
+    "code": "HGGNOS",
+    "name": "High-Grade Glioma, NOS",
+    "system": "https://oncotree.mskcc.org",
+    "systemVersion": "oncotree_2021_11_02",
+    "iris": [
+      "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=HGGNOS"
+    ]
+  },
+  {
+    "id": "oncotree:IPN",
+    "code": "IPN",
+    "name": "Intraductal Papillary Neoplasm of the Bile Duct",
+    "system": "https://oncotree.mskcc.org",
+    "systemVersion": "oncotree_2021_11_02",
+    "iris": [
+      "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=IPN"
+    ]
+  },
+  {
+    "id": "oncotree:ICPN",
+    "code": "ICPN",
+    "name": "Intracholecystic Papillary Neoplasm",
+    "system": "https://oncotree.mskcc.org",
+    "systemVersion": "oncotree_2021_11_02",
+    "iris": [
+      "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=ICPN"
+    ]
+  },
+  {
+    "id": "oncotree:ALAL",
+    "code": "ALAL",
+    "name": "Acute Leukemias of Ambiguous Lineage",
+    "system": "https://oncotree.mskcc.org",
+    "systemVersion": "oncotree_2021_11_02",
+    "iris": [
+      "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=ALAL"
+    ]
+  },
+  {
+    "id": "oncotree:RAML",
+    "code": "RAML",
+    "name": "Renal Angiomyolipoma",
+    "system": "https://oncotree.mskcc.org",
+    "systemVersion": "oncotree_2021_11_02",
+    "iris": [
+      "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=RAML"
+    ]
+  },
+  {
+    "id": "hgnc:76",
+    "code": "HGNC:76",
+    "system": "https://genenames.org",
+    "iris": [
+      "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/HGNC:76"
+    ]
+  },
+  {
+    "id": "ensembl:ensg00000097007",
+    "code": "ENSG00000097007",
+    "system": "https://www.ensembl.org",
+    "iris": [
+      "https://www.ensembl.org/id/ENSG00000097007"
+    ]
+  },
+  {
+    "id": "ncbi:25",
+    "code": "25",
+    "system": "https://www.ncbi.nlm.nih.gov/gene",
+    "iris": [
+      "https://www.ncbi.nlm.nih.gov/gene/25"
+    ]
+  },
+  {
+    "id": "refseq:NM_005157.6",
+    "code": "NM_005157.6",
+    "system": "https://www.ncbi.nlm.nih.gov/nuccore",
+    "iris": [
+      "https://www.ncbi.nlm.nih.gov/nuccore/NM_005157.6"
+    ]
+  },
+  {
+    "id": "hgnc:391",
+    "code": "HGNC:391",
+    "system": "https://genenames.org",
+    "iris": [
+      "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/HGNC:391"
+    ]
+  },
+  {
+    "id": "ensembl:ensg00000142208",
+    "code": "ENSG00000142208",
+    "system": "https://www.ensembl.org",
+    "iris": [
+      "https://www.ensembl.org/id/ENSG00000142208"
+    ]
+  },
+  {
+    "id": "ncbi:207",
+    "code": "207",
+    "system": "https://www.ncbi.nlm.nih.gov/gene",
+    "iris": [
+      "https://www.ncbi.nlm.nih.gov/gene/207"
+    ]
+  },
+  {
+    "id": "refseq:NM_001382430.1",
+    "code": "NM_001382430.1",
+    "system": "https://www.ncbi.nlm.nih.gov/nuccore",
+    "iris": [
+      "https://www.ncbi.nlm.nih.gov/nuccore/NM_001382430.1"
+    ]
+  },
+  {
+    "id": "hgnc:427",
+    "code": "HGNC:427",
+    "system": "https://genenames.org",
+    "iris": [
+      "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/HGNC:427"
+    ]
+  },
+  {
+    "id": "ensembl:ensg00000171094",
+    "code": "ENSG00000171094",
+    "system": "https://www.ensembl.org",
+    "iris": [
+      "https://www.ensembl.org/id/ENSG00000171094"
+    ]
+  },
+  {
+    "id": "ncbi:238",
+    "code": "238",
+    "system": "https://www.ncbi.nlm.nih.gov/gene",
+    "iris": [
+      "https://www.ncbi.nlm.nih.gov/gene/238"
+    ]
+  },
+  {
+    "id": "refseq:NM_004304.5",
+    "code": "NM_004304.5",
+    "system": "https://www.ncbi.nlm.nih.gov/nuccore",
+    "iris": [
+      "https://www.ncbi.nlm.nih.gov/nuccore/NM_004304.5"
+    ]
+  },
+  {
+    "id": "hgnc:795",
+    "code": "HGNC:795",
+    "system": "https://genenames.org",
+    "iris": [
+      "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/HGNC:795"
+    ]
+  },
+  {
+    "id": "ensembl:ensg00000149311",
+    "code": "ENSG00000149311",
+    "system": "https://www.ensembl.org",
+    "iris": [
+      "https://www.ensembl.org/id/ENSG00000149311"
+    ]
+  },
+  {
+    "id": "ncbi:472",
+    "code": "472",
+    "system": "https://www.ncbi.nlm.nih.gov/gene",
+    "iris": [
+      "https://www.ncbi.nlm.nih.gov/gene/472"
+    ]
+  },
+  {
+    "id": "refseq:NM_000051.4",
+    "code": "NM_000051.4",
+    "system": "https://www.ncbi.nlm.nih.gov/nuccore",
+    "iris": [
+      "https://www.ncbi.nlm.nih.gov/nuccore/NM_000051.4"
+    ]
+  },
+  {
+    "id": "hgnc:21649",
+    "code": "HGNC:21649",
+    "system": "https://genenames.org",
+    "iris": [
+      "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/HGNC:21649"
+    ]
+  },
+  {
+    "id": "ensembl:ensg00000006453",
+    "code": "ENSG00000006453",
+    "system": "https://www.ensembl.org",
+    "iris": [
+      "https://www.ensembl.org/id/ENSG00000006453"
+    ]
+  },
+  {
+    "id": "ncbi:55971",
+    "code": "55971",
+    "system": "https://www.ncbi.nlm.nih.gov/gene",
+    "iris": [
+      "https://www.ncbi.nlm.nih.gov/gene/55971"
+    ]
+  },
+  {
+    "id": "refseq:NM_018842.5",
+    "code": "NM_018842.5",
+    "system": "https://www.ncbi.nlm.nih.gov/nuccore",
+    "iris": [
+      "https://www.ncbi.nlm.nih.gov/nuccore/NM_018842.5"
+    ]
+  },
+  {
+    "id": "hgnc:952",
+    "code": "HGNC:952",
+    "system": "https://genenames.org",
+    "iris": [
+      "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/HGNC:952"
+    ]
+  },
+  {
+    "id": "ensembl:ensg00000138376",
+    "code": "ENSG00000138376",
+    "system": "https://www.ensembl.org",
+    "iris": [
+      "https://www.ensembl.org/id/ENSG00000138376"
+    ]
+  },
+  {
+    "id": "ncbi:580",
+    "code": "580",
+    "system": "https://www.ncbi.nlm.nih.gov/gene",
+    "iris": [
+      "https://www.ncbi.nlm.nih.gov/gene/580"
+    ]
+  },
+  {
+    "id": "refseq:NM_000465.4",
+    "code": "NM_000465.4",
+    "system": "https://www.ncbi.nlm.nih.gov/nuccore",
+    "iris": [
+      "https://www.ncbi.nlm.nih.gov/nuccore/NM_000465.4"
+    ]
+  },
+  {
+    "id": "hgnc:1014",
+    "code": "HGNC:1014",
+    "system": "https://genenames.org",
+    "iris": [
+      "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/HGNC:1014"
+    ]
+  },
+  {
+    "id": "ensembl:ensg00000186716",
+    "code": "ENSG00000186716",
+    "system": "https://www.ensembl.org",
+    "iris": [
+      "https://www.ensembl.org/id/ENSG00000186716"
+    ]
+  },
+  {
+    "id": "ncbi:613",
+    "code": "613",
+    "system": "https://www.ncbi.nlm.nih.gov/gene",
+    "iris": [
+      "https://www.ncbi.nlm.nih.gov/gene/613"
+    ]
+  },
+  {
+    "id": "refseq:NM_004327.4",
+    "code": "NM_004327.4",
+    "system": "https://www.ncbi.nlm.nih.gov/nuccore",
+    "iris": [
+      "https://www.ncbi.nlm.nih.gov/nuccore/NM_004327.4"
+    ]
+  },
+  {
+    "id": "hgnc:19351",
+    "code": "HGNC:19351",
+    "system": "https://genenames.org",
+    "iris": [
+      "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/HGNC:19351"
+    ]
+  },
+  {
+    "id": "ensembl:ensg00000122870",
+    "code": "ENSG00000122870",
+    "system": "https://www.ensembl.org",
+    "iris": [
+      "https://www.ensembl.org/id/ENSG00000122870"
+    ]
+  },
+  {
+    "id": "ncbi:80114",
+    "code": "80114",
+    "system": "https://www.ncbi.nlm.nih.gov/gene",
+    "iris": [
+      "https://www.ncbi.nlm.nih.gov/gene/80114"
+    ]
+  },
+  {
+    "id": "refseq:NM_001080512.3",
+    "code": "NM_001080512.3",
+    "system": "https://www.ncbi.nlm.nih.gov/nuccore",
+    "iris": [
+      "https://www.ncbi.nlm.nih.gov/nuccore/NM_001080512.3"
+    ]
+  },
+  {
+    "id": "hgnc:1097",
+    "code": "HGNC:1097",
+    "system": "https://genenames.org",
+    "iris": [
+      "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/HGNC:1097"
+    ]
+  },
+  {
+    "id": "ensembl:ensg00000157764",
+    "code": "ENSG00000157764",
+    "system": "https://www.ensembl.org",
+    "iris": [
+      "https://www.ensembl.org/id/ENSG00000157764"
+    ]
+  },
+  {
+    "id": "ncbi:673",
+    "code": "673",
+    "system": "https://www.ncbi.nlm.nih.gov/gene",
+    "iris": [
+      "https://www.ncbi.nlm.nih.gov/gene/673"
+    ]
+  },
+  {
+    "id": "refseq:NM_004333.6",
+    "code": "NM_004333.6",
+    "system": "https://www.ncbi.nlm.nih.gov/nuccore",
+    "iris": [
+      "https://www.ncbi.nlm.nih.gov/nuccore/NM_004333.6"
+    ]
+  },
+  {
+    "id": "hgnc:1100",
+    "code": "HGNC:1100",
+    "system": "https://genenames.org",
+    "iris": [
+      "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/HGNC:1100"
+    ]
+  },
+  {
+    "id": "ensembl:ensg00000012048",
+    "code": "ENSG00000012048",
+    "system": "https://www.ensembl.org",
+    "iris": [
+      "https://www.ensembl.org/id/ENSG00000012048"
+    ]
+  },
+  {
+    "id": "ncbi:672",
+    "code": "672",
+    "system": "https://www.ncbi.nlm.nih.gov/gene",
+    "iris": [
+      "https://www.ncbi.nlm.nih.gov/gene/672"
+    ]
+  },
+  {
+    "id": "refseq:NM_007294.4",
+    "code": "NM_007294.4",
+    "system": "https://www.ncbi.nlm.nih.gov/nuccore",
+    "iris": [
+      "https://www.ncbi.nlm.nih.gov/nuccore/NM_007294.4"
+    ]
+  },
+  {
+    "id": "hgnc:1101",
+    "code": "HGNC:1101",
+    "system": "https://genenames.org",
+    "iris": [
+      "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/HGNC:1101"
+    ]
+  },
+  {
+    "id": "ensembl:ensg00000139618",
+    "code": "ENSG00000139618",
+    "system": "https://www.ensembl.org",
+    "iris": [
+      "https://www.ensembl.org/id/ENSG00000139618"
+    ]
+  },
+  {
+    "id": "ncbi:675",
+    "code": "675",
+    "system": "https://www.ncbi.nlm.nih.gov/gene",
+    "iris": [
+      "https://www.ncbi.nlm.nih.gov/gene/675"
+    ]
+  },
+  {
+    "id": "refseq:NM_000059.4",
+    "code": "NM_000059.4",
+    "system": "https://www.ncbi.nlm.nih.gov/nuccore",
+    "iris": [
+      "https://www.ncbi.nlm.nih.gov/nuccore/NM_000059.4"
+    ]
+  },
+  {
+    "id": "hgnc:20473",
+    "code": "HGNC:20473",
+    "system": "https://genenames.org",
+    "iris": [
+      "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/HGNC:20473"
+    ]
+  },
+  {
+    "id": "ensembl:ensg00000136492",
+    "code": "ENSG00000136492",
+    "system": "https://www.ensembl.org",
+    "iris": [
+      "https://www.ensembl.org/id/ENSG00000136492"
+    ]
+  },
+  {
+    "id": "ncbi:83990",
+    "code": "83990",
+    "system": "https://www.ncbi.nlm.nih.gov/gene",
+    "iris": [
+      "https://www.ncbi.nlm.nih.gov/gene/83990"
+    ]
+  },
+  {
+    "id": "refseq:NM_032043.3",
+    "code": "NM_032043.3",
+    "system": "https://www.ncbi.nlm.nih.gov/nuccore",
+    "iris": [
+      "https://www.ncbi.nlm.nih.gov/nuccore/NM_032043.3"
+    ]
+  },
+  {
+    "id": "hgnc:1508",
+    "code": "HGNC:1508",
+    "system": "https://genenames.org",
+    "iris": [
+      "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/HGNC:1508"
+    ]
+  },
+  {
+    "id": "ensembl:ensg00000165806",
+    "code": "ENSG00000165806",
+    "system": "https://www.ensembl.org",
+    "iris": [
+      "https://www.ensembl.org/id/ENSG00000165806"
+    ]
+  },
+  {
+    "id": "ncbi:840",
+    "code": "840",
+    "system": "https://www.ncbi.nlm.nih.gov/gene",
+    "iris": [
+      "https://www.ncbi.nlm.nih.gov/gene/840"
+    ]
+  },
+  {
+    "id": "refseq:NM_001227.5",
+    "code": "NM_001227.5",
+    "system": "https://www.ncbi.nlm.nih.gov/nuccore",
+    "iris": [
+      "https://www.ncbi.nlm.nih.gov/nuccore/NM_001227.5"
+    ]
+  },
+  {
+    "id": "hgnc:17635",
+    "code": "HGNC:17635",
+    "system": "https://genenames.org",
+    "iris": [
+      "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/HGNC:17635"
+    ]
+  },
+  {
+    "id": "ensembl:ensg00000120217",
+    "code": "ENSG00000120217",
+    "system": "https://www.ensembl.org",
+    "iris": [
+      "https://www.ensembl.org/id/ENSG00000120217"
+    ]
+  },
+  {
+    "id": "ncbi:29126",
+    "code": "29126",
+    "system": "https://www.ncbi.nlm.nih.gov/gene",
+    "iris": [
+      "https://www.ncbi.nlm.nih.gov/gene/29126"
+    ]
+  },
+  {
+    "id": "refseq:NM_014143.4",
+    "code": "NM_014143.4",
+    "system": "https://www.ncbi.nlm.nih.gov/nuccore",
+    "iris": [
+      "https://www.ncbi.nlm.nih.gov/nuccore/NM_014143.4"
+    ]
+  },
+  {
+    "id": "hgnc:24224",
+    "code": "HGNC:24224",
+    "system": "https://genenames.org",
+    "iris": [
+      "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/HGNC:24224"
+    ]
+  },
+  {
+    "id": "ensembl:ensg00000167258",
+    "code": "ENSG00000167258",
+    "system": "https://www.ensembl.org",
+    "iris": [
+      "https://www.ensembl.org/id/ENSG00000167258"
+    ]
+  },
+  {
+    "id": "ncbi:51755",
+    "code": "51755",
+    "system": "https://www.ncbi.nlm.nih.gov/gene",
+    "iris": [
+      "https://www.ncbi.nlm.nih.gov/gene/51755"
+    ]
+  },
+  {
+    "id": "refseq:NM_016507.4",
+    "code": "NM_016507.4",
+    "system": "https://www.ncbi.nlm.nih.gov/nuccore",
+    "iris": [
+      "https://www.ncbi.nlm.nih.gov/nuccore/NM_016507.4"
+    ]
+  },
+  {
+    "id": "hgnc:1925",
+    "code": "HGNC:1925",
+    "system": "https://genenames.org",
+    "iris": [
+      "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/HGNC:1925"
+    ]
+  },
+  {
+    "id": "ensembl:ensg00000149554",
+    "code": "ENSG00000149554",
+    "system": "https://www.ensembl.org",
+    "iris": [
+      "https://www.ensembl.org/id/ENSG00000149554"
+    ]
+  },
+  {
+    "id": "ncbi:1111",
+    "code": "1111",
+    "system": "https://www.ncbi.nlm.nih.gov/gene",
+    "iris": [
+      "https://www.ncbi.nlm.nih.gov/gene/1111"
+    ]
+  },
+  {
+    "id": "refseq:NM_001114122.3",
+    "code": "NM_001114122.3",
+    "system": "https://www.ncbi.nlm.nih.gov/nuccore",
+    "iris": [
+      "https://www.ncbi.nlm.nih.gov/nuccore/NM_001114122.3"
+    ]
+  },
+  {
+    "id": "hgnc:16627",
+    "code": "HGNC:16627",
+    "system": "https://genenames.org",
+    "iris": [
+      "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/HGNC:16627"
+    ]
+  },
+  {
+    "id": "ensembl:ensg00000183765",
+    "code": "ENSG00000183765",
+    "system": "https://www.ensembl.org",
+    "iris": [
+      "https://www.ensembl.org/id/ENSG00000183765"
+    ]
+  },
+  {
+    "id": "ncbi:11200",
+    "code": "11200",
+    "system": "https://www.ncbi.nlm.nih.gov/gene",
+    "iris": [
+      "https://www.ncbi.nlm.nih.gov/gene/11200"
+    ]
+  },
+  {
+    "id": "refseq:NM_007194.4",
+    "code": "NM_007194.4",
+    "system": "https://www.ncbi.nlm.nih.gov/nuccore",
+    "iris": [
+      "https://www.ncbi.nlm.nih.gov/nuccore/NM_007194.4"
+    ]
+  },
+  {
+    "id": "hgnc:3236",
+    "code": "HGNC:3236",
+    "system": "https://genenames.org",
+    "iris": [
+      "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/HGNC:3236"
+    ]
+  },
+  {
+    "id": "ensembl:ensg00000146648",
+    "code": "ENSG00000146648",
+    "system": "https://www.ensembl.org",
+    "iris": [
+      "https://www.ensembl.org/id/ENSG00000146648"
+    ]
+  },
+  {
+    "id": "ncbi:1956",
+    "code": "1956",
+    "system": "https://www.ncbi.nlm.nih.gov/gene",
+    "iris": [
+      "https://www.ncbi.nlm.nih.gov/gene/1956"
+    ]
+  },
+  {
+    "id": "refseq:NM_005228.5",
+    "code": "NM_005228.5",
+    "system": "https://www.ncbi.nlm.nih.gov/nuccore",
+    "iris": [
+      "https://www.ncbi.nlm.nih.gov/nuccore/NM_005228.5"
+    ]
+  },
+  {
+    "id": "hgnc:3430",
+    "code": "HGNC:3430",
+    "system": "https://genenames.org",
+    "iris": [
+      "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/HGNC:3430"
+    ]
+  },
+  {
+    "id": "ensembl:ensg00000141736",
+    "code": "ENSG00000141736",
+    "system": "https://www.ensembl.org",
+    "iris": [
+      "https://www.ensembl.org/id/ENSG00000141736"
+    ]
+  },
+  {
+    "id": "ncbi:2064",
+    "code": "2064",
+    "system": "https://www.ncbi.nlm.nih.gov/gene",
+    "iris": [
+      "https://www.ncbi.nlm.nih.gov/gene/2064"
+    ]
+  },
+  {
+    "id": "refseq:NM_004448.4",
+    "code": "NM_004448.4",
+    "system": "https://www.ncbi.nlm.nih.gov/nuccore",
+    "iris": [
+      "https://www.ncbi.nlm.nih.gov/nuccore/NM_004448.4"
+    ]
+  },
+  {
+    "id": "hgnc:3467",
+    "code": "HGNC:3467",
+    "system": "https://genenames.org",
+    "iris": [
+      "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/HGNC:3467"
+    ]
+  },
+  {
+    "id": "ensembl:ensg00000091831",
+    "code": "ENSG00000091831",
+    "system": "https://www.ensembl.org",
+    "iris": [
+      "https://www.ensembl.org/id/ENSG00000091831"
+    ]
+  },
+  {
+    "id": "ncbi:2099",
+    "code": "2099",
+    "system": "https://www.ncbi.nlm.nih.gov/gene",
+    "iris": [
+      "https://www.ncbi.nlm.nih.gov/gene/2099"
+    ]
+  },
+  {
+    "id": "refseq:NM_000125.4",
+    "code": "NM_000125.4",
+    "system": "https://www.ncbi.nlm.nih.gov/nuccore",
+    "iris": [
+      "https://www.ncbi.nlm.nih.gov/nuccore/NM_000125.4"
+    ]
+  },
+  {
+    "id": "hgnc:3527",
+    "code": "HGNC:3527",
+    "system": "https://genenames.org",
+    "iris": [
+      "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/HGNC:3527"
+    ]
+  },
+  {
+    "id": "ensembl:ensg00000106462",
+    "code": "ENSG00000106462",
+    "system": "https://www.ensembl.org",
+    "iris": [
+      "https://www.ensembl.org/id/ENSG00000106462"
+    ]
+  },
+  {
+    "id": "ncbi:2146",
+    "code": "2146",
+    "system": "https://www.ncbi.nlm.nih.gov/gene",
+    "iris": [
+      "https://www.ncbi.nlm.nih.gov/gene/2146"
+    ]
+  },
+  {
+    "id": "refseq:NM_004456.5",
+    "code": "NM_004456.5",
+    "system": "https://www.ncbi.nlm.nih.gov/nuccore",
+    "iris": [
+      "https://www.ncbi.nlm.nih.gov/nuccore/NM_004456.5"
+    ]
+  },
+  {
+    "id": "hgnc:20748",
+    "code": "HGNC:20748",
+    "system": "https://genenames.org",
+    "iris": [
+      "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/HGNC:20748"
+    ]
+  },
+  {
+    "id": "ensembl:ensg00000115392",
+    "code": "ENSG00000115392",
+    "system": "https://www.ensembl.org",
+    "iris": [
+      "https://www.ensembl.org/id/ENSG00000115392"
+    ]
+  },
+  {
+    "id": "ncbi:55120",
+    "code": "55120",
+    "system": "https://www.ncbi.nlm.nih.gov/gene",
+    "iris": [
+      "https://www.ncbi.nlm.nih.gov/gene/55120"
+    ]
+  },
+  {
+    "id": "refseq:NM_018062.4",
+    "code": "NM_018062.4",
+    "system": "https://www.ncbi.nlm.nih.gov/nuccore",
+    "iris": [
+      "https://www.ncbi.nlm.nih.gov/nuccore/NM_018062.4"
+    ]
+  },
+  {
+    "id": "hgnc:3688",
+    "code": "HGNC:3688",
+    "system": "https://genenames.org",
+    "iris": [
+      "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/HGNC:3688"
+    ]
+  },
+  {
+    "id": "ensembl:ensg00000077782",
+    "code": "ENSG00000077782",
+    "system": "https://www.ensembl.org",
+    "iris": [
+      "https://www.ensembl.org/id/ENSG00000077782"
+    ]
+  },
+  {
+    "id": "ncbi:2260",
+    "code": "2260",
+    "system": "https://www.ncbi.nlm.nih.gov/gene",
+    "iris": [
+      "https://www.ncbi.nlm.nih.gov/gene/2260"
+    ]
+  },
+  {
+    "id": "refseq:NM_023110.3",
+    "code": "NM_023110.3",
+    "system": "https://www.ncbi.nlm.nih.gov/nuccore",
+    "iris": [
+      "https://www.ncbi.nlm.nih.gov/nuccore/NM_023110.3"
+    ]
+  },
+  {
+    "id": "hgnc:3689",
+    "code": "HGNC:3689",
+    "system": "https://genenames.org",
+    "iris": [
+      "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/HGNC:3689"
+    ]
+  },
+  {
+    "id": "ensembl:ensg00000066468",
+    "code": "ENSG00000066468",
+    "system": "https://www.ensembl.org",
+    "iris": [
+      "https://www.ensembl.org/id/ENSG00000066468"
+    ]
+  },
+  {
+    "id": "ncbi:2263",
+    "code": "2263",
+    "system": "https://www.ncbi.nlm.nih.gov/gene",
+    "iris": [
+      "https://www.ncbi.nlm.nih.gov/gene/2263"
+    ]
+  },
+  {
+    "id": "refseq:NM_000141.5",
+    "code": "NM_000141.5",
+    "system": "https://www.ncbi.nlm.nih.gov/nuccore",
+    "iris": [
+      "https://www.ncbi.nlm.nih.gov/nuccore/NM_000141.5"
+    ]
+  },
+  {
+    "id": "hgnc:3690",
+    "code": "HGNC:3690",
+    "system": "https://genenames.org",
+    "iris": [
+      "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/HGNC:3690"
+    ]
+  },
+  {
+    "id": "ensembl:ensg00000068078",
+    "code": "ENSG00000068078",
+    "system": "https://www.ensembl.org",
+    "iris": [
+      "https://www.ensembl.org/id/ENSG00000068078"
+    ]
+  },
+  {
+    "id": "ncbi:2261",
+    "code": "2261",
+    "system": "https://www.ncbi.nlm.nih.gov/gene",
+    "iris": [
+      "https://www.ncbi.nlm.nih.gov/gene/2261"
+    ]
+  },
+  {
+    "id": "refseq:NM_000142.5",
+    "code": "NM_000142.5",
+    "system": "https://www.ncbi.nlm.nih.gov/nuccore",
+    "iris": [
+      "https://www.ncbi.nlm.nih.gov/nuccore/NM_000142.5"
+    ]
+  },
+  {
+    "id": "hgnc:19124",
+    "code": "HGNC:19124",
+    "system": "https://genenames.org",
+    "iris": [
+      "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/HGNC:19124"
+    ]
+  },
+  {
+    "id": "ensembl:ensg00000145216",
+    "code": "ENSG00000145216",
+    "system": "https://www.ensembl.org",
+    "iris": [
+      "https://www.ensembl.org/id/ENSG00000145216"
+    ]
+  },
+  {
+    "id": "ncbi:81608",
+    "code": "81608",
+    "system": "https://www.ncbi.nlm.nih.gov/gene",
+    "iris": [
+      "https://www.ncbi.nlm.nih.gov/gene/81608"
+    ]
+  },
+  {
+    "id": "refseq:NM_030917.4",
+    "code": "NM_030917.4",
+    "system": "https://www.ncbi.nlm.nih.gov/nuccore",
+    "iris": [
+      "https://www.ncbi.nlm.nih.gov/nuccore/NM_030917.4"
+    ]
+  },
+  {
+    "id": "hgnc:3765",
+    "code": "HGNC:3765",
+    "system": "https://genenames.org",
+    "iris": [
+      "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/HGNC:3765"
+    ]
+  },
+  {
+    "id": "ensembl:ensg00000122025",
+    "code": "ENSG00000122025",
+    "system": "https://www.ensembl.org",
+    "iris": [
+      "https://www.ensembl.org/id/ENSG00000122025"
+    ]
+  },
+  {
+    "id": "ncbi:2322",
+    "code": "2322",
+    "system": "https://www.ncbi.nlm.nih.gov/gene",
+    "iris": [
+      "https://www.ncbi.nlm.nih.gov/gene/2322"
+    ]
+  },
+  {
+    "id": "refseq:NM_004119.3",
+    "code": "NM_004119.3",
+    "system": "https://www.ncbi.nlm.nih.gov/nuccore",
+    "iris": [
+      "https://www.ncbi.nlm.nih.gov/nuccore/NM_004119.3"
+    ]
+  },
+  {
+    "id": "hgnc:5173",
+    "code": "HGNC:5173",
+    "system": "https://genenames.org",
+    "iris": [
+      "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/HGNC:5173"
+    ]
+  },
+  {
+    "id": "ensembl:ensg00000174775",
+    "code": "ENSG00000174775",
+    "system": "https://www.ensembl.org",
+    "iris": [
+      "https://www.ensembl.org/id/ENSG00000174775"
+    ]
+  },
+  {
+    "id": "ncbi:3265",
+    "code": "3265",
+    "system": "https://www.ncbi.nlm.nih.gov/gene",
+    "iris": [
+      "https://www.ncbi.nlm.nih.gov/gene/3265"
+    ]
+  },
+  {
+    "id": "refseq:NM_005343.4",
+    "code": "NM_005343.4",
+    "system": "https://www.ncbi.nlm.nih.gov/nuccore",
+    "iris": [
+      "https://www.ncbi.nlm.nih.gov/nuccore/NM_005343.4"
+    ]
+  },
+  {
+    "id": "hgnc:5382",
+    "code": "HGNC:5382",
+    "system": "https://genenames.org",
+    "iris": [
+      "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/HGNC:5382"
+    ]
+  },
+  {
+    "id": "ensembl:ensg00000138413",
+    "code": "ENSG00000138413",
+    "system": "https://www.ensembl.org",
+    "iris": [
+      "https://www.ensembl.org/id/ENSG00000138413"
+    ]
+  },
+  {
+    "id": "ncbi:3417",
+    "code": "3417",
+    "system": "https://www.ncbi.nlm.nih.gov/gene",
+    "iris": [
+      "https://www.ncbi.nlm.nih.gov/gene/3417"
+    ]
+  },
+  {
+    "id": "refseq:NM_005896.4",
+    "code": "NM_005896.4",
+    "system": "https://www.ncbi.nlm.nih.gov/nuccore",
+    "iris": [
+      "https://www.ncbi.nlm.nih.gov/nuccore/NM_005896.4"
+    ]
+  },
+  {
+    "id": "hgnc:5383",
+    "code": "HGNC:5383",
+    "system": "https://genenames.org",
+    "iris": [
+      "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/HGNC:5383"
+    ]
+  },
+  {
+    "id": "ensembl:ensg00000182054",
+    "code": "ENSG00000182054",
+    "system": "https://www.ensembl.org",
+    "iris": [
+      "https://www.ensembl.org/id/ENSG00000182054"
+    ]
+  },
+  {
+    "id": "ncbi:3418",
+    "code": "3418",
+    "system": "https://www.ncbi.nlm.nih.gov/gene",
+    "iris": [
+      "https://www.ncbi.nlm.nih.gov/gene/3418"
+    ]
+  },
+  {
+    "id": "refseq:NM_002168.4",
+    "code": "NM_002168.4",
+    "system": "https://www.ncbi.nlm.nih.gov/nuccore",
+    "iris": [
+      "https://www.ncbi.nlm.nih.gov/nuccore/NM_002168.4"
+    ]
+  },
+  {
+    "id": "hgnc:6342",
+    "code": "HGNC:6342",
+    "system": "https://genenames.org",
+    "iris": [
+      "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/HGNC:6342"
+    ]
+  },
+  {
+    "id": "ensembl:ensg00000157404",
+    "code": "ENSG00000157404",
+    "system": "https://www.ensembl.org",
+    "iris": [
+      "https://www.ensembl.org/id/ENSG00000157404"
+    ]
+  },
+  {
+    "id": "ncbi:3815",
+    "code": "3815",
+    "system": "https://www.ncbi.nlm.nih.gov/gene",
+    "iris": [
+      "https://www.ncbi.nlm.nih.gov/gene/3815"
+    ]
+  },
+  {
+    "id": "refseq:NM_000222.3",
+    "code": "NM_000222.3",
+    "system": "https://www.ncbi.nlm.nih.gov/nuccore",
+    "iris": [
+      "https://www.ncbi.nlm.nih.gov/nuccore/NM_000222.3"
+    ]
+  },
+  {
+    "id": "hgnc:6407",
+    "code": "HGNC:6407",
+    "system": "https://genenames.org",
+    "iris": [
+      "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/HGNC:6407"
+    ]
+  },
+  {
+    "id": "ensembl:ensg00000133703",
+    "code": "ENSG00000133703",
+    "system": "https://www.ensembl.org",
+    "iris": [
+      "https://www.ensembl.org/id/ENSG00000133703"
+    ]
+  },
+  {
+    "id": "ncbi:3845",
+    "code": "3845",
+    "system": "https://www.ncbi.nlm.nih.gov/gene",
+    "iris": [
+      "https://www.ncbi.nlm.nih.gov/gene/3845"
+    ]
+  },
+  {
+    "id": "refseq:NM_004985.5",
+    "code": "NM_004985.5",
+    "system": "https://www.ncbi.nlm.nih.gov/nuccore",
+    "iris": [
+      "https://www.ncbi.nlm.nih.gov/nuccore/NM_004985.5"
+    ]
+  },
+  {
+    "id": "hgnc:7029",
+    "code": "HGNC:7029",
+    "system": "https://genenames.org",
+    "iris": [
+      "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/HGNC:7029"
+    ]
+  },
+  {
+    "id": "ensembl:ensg00000105976",
+    "code": "ENSG00000105976",
+    "system": "https://www.ensembl.org",
+    "iris": [
+      "https://www.ensembl.org/id/ENSG00000105976"
+    ]
+  },
+  {
+    "id": "ncbi:4233",
+    "code": "4233",
+    "system": "https://www.ncbi.nlm.nih.gov/gene",
+    "iris": [
+      "https://www.ncbi.nlm.nih.gov/gene/4233"
+    ]
+  },
+  {
+    "id": "refseq:NM_000245.4",
+    "code": "NM_000245.4",
+    "system": "https://www.ncbi.nlm.nih.gov/nuccore",
+    "iris": [
+      "https://www.ncbi.nlm.nih.gov/nuccore/NM_000245.4"
+    ]
+  },
+  {
+    "id": "hgnc:7989",
+    "code": "HGNC:7989",
+    "system": "https://genenames.org",
+    "iris": [
+      "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/HGNC:7989"
+    ]
+  },
+  {
+    "id": "ensembl:ensg00000213281",
+    "code": "ENSG00000213281",
+    "system": "https://www.ensembl.org",
+    "iris": [
+      "https://www.ensembl.org/id/ENSG00000213281"
+    ]
+  },
+  {
+    "id": "ncbi:4893",
+    "code": "4893",
+    "system": "https://www.ncbi.nlm.nih.gov/gene",
+    "iris": [
+      "https://www.ncbi.nlm.nih.gov/gene/4893"
+    ]
+  },
+  {
+    "id": "refseq:NM_002524.5",
+    "code": "NM_002524.5",
+    "system": "https://www.ncbi.nlm.nih.gov/nuccore",
+    "iris": [
+      "https://www.ncbi.nlm.nih.gov/nuccore/NM_002524.5"
+    ]
+  },
+  {
+    "id": "hgnc:7997",
+    "code": "HGNC:7997",
+    "system": "https://genenames.org",
+    "iris": [
+      "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/HGNC:7997"
+    ]
+  },
+  {
+    "id": "ensembl:ensg00000157168",
+    "code": "ENSG00000157168",
+    "system": "https://www.ensembl.org",
+    "iris": [
+      "https://www.ensembl.org/id/ENSG00000157168"
+    ]
+  },
+  {
+    "id": "ncbi:3084",
+    "code": "3084",
+    "system": "https://www.ncbi.nlm.nih.gov/gene",
+    "iris": [
+      "https://www.ncbi.nlm.nih.gov/gene/3084"
+    ]
+  },
+  {
+    "id": "refseq:NM_013964.5",
+    "code": "NM_013964.5",
+    "system": "https://www.ncbi.nlm.nih.gov/nuccore",
+    "iris": [
+      "https://www.ncbi.nlm.nih.gov/nuccore/NM_013964.5"
+    ]
+  },
+  {
+    "id": "hgnc:8031",
+    "code": "HGNC:8031",
+    "system": "https://genenames.org",
+    "iris": [
+      "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/HGNC:8031"
+    ]
+  },
+  {
+    "id": "ensembl:ensg00000198400",
+    "code": "ENSG00000198400",
+    "system": "https://www.ensembl.org",
+    "iris": [
+      "https://www.ensembl.org/id/ENSG00000198400"
+    ]
+  },
+  {
+    "id": "ncbi:4914",
+    "code": "4914",
+    "system": "https://www.ncbi.nlm.nih.gov/gene",
+    "iris": [
+      "https://www.ncbi.nlm.nih.gov/gene/4914"
+    ]
+  },
+  {
+    "id": "refseq:NM_002529.4",
+    "code": "NM_002529.4",
+    "system": "https://www.ncbi.nlm.nih.gov/nuccore",
+    "iris": [
+      "https://www.ncbi.nlm.nih.gov/nuccore/NM_002529.4"
+    ]
+  },
+  {
+    "id": "hgnc:8032",
+    "code": "HGNC:8032",
+    "system": "https://genenames.org",
+    "iris": [
+      "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/HGNC:8032"
+    ]
+  },
+  {
+    "id": "ensembl:ensg00000148053",
+    "code": "ENSG00000148053",
+    "system": "https://www.ensembl.org",
+    "iris": [
+      "https://www.ensembl.org/id/ENSG00000148053"
+    ]
+  },
+  {
+    "id": "ncbi:4915",
+    "code": "4915",
+    "system": "https://www.ncbi.nlm.nih.gov/gene",
+    "iris": [
+      "https://www.ncbi.nlm.nih.gov/gene/4915"
+    ]
+  },
+  {
+    "id": "refseq:NM_006180.6",
+    "code": "NM_006180.6",
+    "system": "https://www.ncbi.nlm.nih.gov/nuccore",
+    "iris": [
+      "https://www.ncbi.nlm.nih.gov/nuccore/NM_006180.6"
+    ]
+  },
+  {
+    "id": "hgnc:8033",
+    "code": "HGNC:8033",
+    "system": "https://genenames.org",
+    "iris": [
+      "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/HGNC:8033"
+    ]
+  },
+  {
+    "id": "ensembl:ensg00000140538",
+    "code": "ENSG00000140538",
+    "system": "https://www.ensembl.org",
+    "iris": [
+      "https://www.ensembl.org/id/ENSG00000140538"
+    ]
+  },
+  {
+    "id": "ncbi:4916",
+    "code": "4916",
+    "system": "https://www.ncbi.nlm.nih.gov/gene",
+    "iris": [
+      "https://www.ncbi.nlm.nih.gov/gene/4916"
+    ]
+  },
+  {
+    "id": "refseq:NM_001012338.3",
+    "code": "NM_001012338.3",
+    "system": "https://www.ncbi.nlm.nih.gov/nuccore",
+    "iris": [
+      "https://www.ncbi.nlm.nih.gov/nuccore/NM_001012338.3"
+    ]
+  },
+  {
+    "id": "hgnc:26144",
+    "code": "HGNC:26144",
+    "system": "https://genenames.org",
+    "iris": [
+      "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/HGNC:26144"
+    ]
+  },
+  {
+    "id": "ensembl:ensg00000083093",
+    "code": "ENSG00000083093",
+    "system": "https://www.ensembl.org",
+    "iris": [
+      "https://www.ensembl.org/id/ENSG00000083093"
+    ]
+  },
+  {
+    "id": "ncbi:79728",
+    "code": "79728",
+    "system": "https://www.ncbi.nlm.nih.gov/gene",
+    "iris": [
+      "https://www.ncbi.nlm.nih.gov/gene/79728"
+    ]
+  },
+  {
+    "id": "refseq:NM_024675.4",
+    "code": "NM_024675.4",
+    "system": "https://www.ncbi.nlm.nih.gov/nuccore",
+    "iris": [
+      "https://www.ncbi.nlm.nih.gov/nuccore/NM_024675.4"
+    ]
+  },
+  {
+    "id": "hgnc:8803",
+    "code": "HGNC:8803",
+    "system": "https://genenames.org",
+    "iris": [
+      "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/HGNC:8803"
+    ]
+  },
+  {
+    "id": "ensembl:ensg00000134853",
+    "code": "ENSG00000134853",
+    "system": "https://www.ensembl.org",
+    "iris": [
+      "https://www.ensembl.org/id/ENSG00000134853"
+    ]
+  },
+  {
+    "id": "ncbi:5156",
+    "code": "5156",
+    "system": "https://www.ncbi.nlm.nih.gov/gene",
+    "iris": [
+      "https://www.ncbi.nlm.nih.gov/gene/5156"
+    ]
+  },
+  {
+    "id": "refseq:NM_006206.6",
+    "code": "NM_006206.6",
+    "system": "https://www.ncbi.nlm.nih.gov/nuccore",
+    "iris": [
+      "https://www.ncbi.nlm.nih.gov/nuccore/NM_006206.6"
+    ]
+  },
+  {
+    "id": "hgnc:8804",
+    "code": "HGNC:8804",
+    "system": "https://genenames.org",
+    "iris": [
+      "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/HGNC:8804"
+    ]
+  },
+  {
+    "id": "ensembl:ensg00000113721",
+    "code": "ENSG00000113721",
+    "system": "https://www.ensembl.org",
+    "iris": [
+      "https://www.ensembl.org/id/ENSG00000113721"
+    ]
+  },
+  {
+    "id": "ncbi:5159",
+    "code": "5159",
+    "system": "https://www.ncbi.nlm.nih.gov/gene",
+    "iris": [
+      "https://www.ncbi.nlm.nih.gov/gene/5159"
+    ]
+  },
+  {
+    "id": "refseq:NM_002609.4",
+    "code": "NM_002609.4",
+    "system": "https://www.ncbi.nlm.nih.gov/nuccore",
+    "iris": [
+      "https://www.ncbi.nlm.nih.gov/nuccore/NM_002609.4"
+    ]
+  },
+  {
+    "id": "hgnc:8975",
+    "code": "HGNC:8975",
+    "system": "https://genenames.org",
+    "iris": [
+      "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/HGNC:8975"
+    ]
+  },
+  {
+    "id": "ensembl:ensg00000121879",
+    "code": "ENSG00000121879",
+    "system": "https://www.ensembl.org",
+    "iris": [
+      "https://www.ensembl.org/id/ENSG00000121879"
+    ]
+  },
+  {
+    "id": "ncbi:5290",
+    "code": "5290",
+    "system": "https://www.ncbi.nlm.nih.gov/gene",
+    "iris": [
+      "https://www.ncbi.nlm.nih.gov/gene/5290"
+    ]
+  },
+  {
+    "id": "refseq:NM_006218.4",
+    "code": "NM_006218.4",
+    "system": "https://www.ncbi.nlm.nih.gov/nuccore",
+    "iris": [
+      "https://www.ncbi.nlm.nih.gov/nuccore/NM_006218.4"
+    ]
+  },
+  {
+    "id": "hgnc:9113",
+    "code": "HGNC:9113",
+    "system": "https://genenames.org",
+    "iris": [
+      "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/HGNC:9113"
+    ]
+  },
+  {
+    "id": "ensembl:ensg00000140464",
+    "code": "ENSG00000140464",
+    "system": "https://www.ensembl.org",
+    "iris": [
+      "https://www.ensembl.org/id/ENSG00000140464"
+    ]
+  },
+  {
+    "id": "ncbi:5371",
+    "code": "5371",
+    "system": "https://www.ncbi.nlm.nih.gov/gene",
+    "iris": [
+      "https://www.ncbi.nlm.nih.gov/gene/5371"
+    ]
+  },
+  {
+    "id": "refseq:NM_033238.3",
+    "code": "NM_033238.3",
+    "system": "https://www.ncbi.nlm.nih.gov/nuccore",
+    "iris": [
+      "https://www.ncbi.nlm.nih.gov/nuccore/NM_033238.3"
+    ]
+  },
+  {
+    "id": "hgnc:9588",
+    "code": "HGNC:9588",
+    "system": "https://genenames.org",
+    "iris": [
+      "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/HGNC:9588"
+    ]
+  },
+  {
+    "id": "ensembl:ensg00000171862",
+    "code": "ENSG00000171862",
+    "system": "https://www.ensembl.org",
+    "iris": [
+      "https://www.ensembl.org/id/ENSG00000171862"
+    ]
+  },
+  {
+    "id": "ncbi:5728",
+    "code": "5728",
+    "system": "https://www.ncbi.nlm.nih.gov/gene",
+    "iris": [
+      "https://www.ncbi.nlm.nih.gov/gene/5728"
+    ]
+  },
+  {
+    "id": "refseq:NM_000314.8",
+    "code": "NM_000314.8",
+    "system": "https://www.ncbi.nlm.nih.gov/nuccore",
+    "iris": [
+      "https://www.ncbi.nlm.nih.gov/nuccore/NM_000314.8"
+    ]
+  },
+  {
+    "id": "hgnc:9822",
+    "code": "HGNC:9822",
+    "system": "https://genenames.org",
+    "iris": [
+      "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/HGNC:9822"
+    ]
+  },
+  {
+    "id": "ensembl:ensg00000182185",
+    "code": "ENSG00000182185",
+    "system": "https://www.ensembl.org",
+    "iris": [
+      "https://www.ensembl.org/id/ENSG00000182185"
+    ]
+  },
+  {
+    "id": "ncbi:5890",
+    "code": "5890",
+    "system": "https://www.ncbi.nlm.nih.gov/gene",
+    "iris": [
+      "https://www.ncbi.nlm.nih.gov/gene/5890"
+    ]
+  },
+  {
+    "id": "refseq:NM_133510.4",
+    "code": "NM_133510.4",
+    "system": "https://www.ncbi.nlm.nih.gov/nuccore",
+    "iris": [
+      "https://www.ncbi.nlm.nih.gov/nuccore/NM_133510.4"
+    ]
+  },
+  {
+    "id": "hgnc:9820",
+    "code": "HGNC:9820",
+    "system": "https://genenames.org",
+    "iris": [
+      "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/HGNC:9820"
+    ]
+  },
+  {
+    "id": "ensembl:ensg00000108384",
+    "code": "ENSG00000108384",
+    "system": "https://www.ensembl.org",
+    "iris": [
+      "https://www.ensembl.org/id/ENSG00000108384"
+    ]
+  },
+  {
+    "id": "ncbi:5889",
+    "code": "5889",
+    "system": "https://www.ncbi.nlm.nih.gov/gene",
+    "iris": [
+      "https://www.ncbi.nlm.nih.gov/gene/5889"
+    ]
+  },
+  {
+    "id": "refseq:NM_058216.3",
+    "code": "NM_058216.3",
+    "system": "https://www.ncbi.nlm.nih.gov/nuccore",
+    "iris": [
+      "https://www.ncbi.nlm.nih.gov/nuccore/NM_058216.3"
+    ]
+  },
+  {
+    "id": "hgnc:9823",
+    "code": "HGNC:9823",
+    "system": "https://genenames.org",
+    "iris": [
+      "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/HGNC:9823"
+    ]
+  },
+  {
+    "id": "ensembl:ensg00000185379",
+    "code": "ENSG00000185379",
+    "system": "https://www.ensembl.org",
+    "iris": [
+      "https://www.ensembl.org/id/ENSG00000185379"
+    ]
+  },
+  {
+    "id": "ncbi:5892",
+    "code": "5892",
+    "system": "https://www.ncbi.nlm.nih.gov/gene",
+    "iris": [
+      "https://www.ncbi.nlm.nih.gov/gene/5892"
+    ]
+  },
+  {
+    "id": "refseq:NM_002878.4",
+    "code": "NM_002878.4",
+    "system": "https://www.ncbi.nlm.nih.gov/nuccore",
+    "iris": [
+      "https://www.ncbi.nlm.nih.gov/nuccore/NM_002878.4"
+    ]
+  },
+  {
+    "id": "hgnc:9826",
+    "code": "HGNC:9826",
+    "system": "https://genenames.org",
+    "iris": [
+      "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/HGNC:9826"
+    ]
+  },
+  {
+    "id": "ensembl:ensg00000085999",
+    "code": "ENSG00000085999",
+    "system": "https://www.ensembl.org",
+    "iris": [
+      "https://www.ensembl.org/id/ENSG00000085999"
+    ]
+  },
+  {
+    "id": "ncbi:8438",
+    "code": "8438",
+    "system": "https://www.ncbi.nlm.nih.gov/gene",
+    "iris": [
+      "https://www.ncbi.nlm.nih.gov/gene/8438"
+    ]
+  },
+  {
+    "id": "refseq:NM_003579.4",
+    "code": "NM_003579.4",
+    "system": "https://www.ncbi.nlm.nih.gov/nuccore",
+    "iris": [
+      "https://www.ncbi.nlm.nih.gov/nuccore/NM_003579.4"
+    ]
+  },
+  {
+    "id": "hgnc:9864",
+    "code": "HGNC:9864",
+    "system": "https://genenames.org",
+    "iris": [
+      "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/HGNC:9864"
+    ]
+  },
+  {
+    "id": "ensembl:ensg00000131759",
+    "code": "ENSG00000131759",
+    "system": "https://www.ensembl.org",
+    "iris": [
+      "https://www.ensembl.org/id/ENSG00000131759"
+    ]
+  },
+  {
+    "id": "ncbi:5914",
+    "code": "5914",
+    "system": "https://www.ncbi.nlm.nih.gov/gene",
+    "iris": [
+      "https://www.ncbi.nlm.nih.gov/gene/5914"
+    ]
+  },
+  {
+    "id": "refseq:NM_000964.4",
+    "code": "NM_000964.4",
+    "system": "https://www.ncbi.nlm.nih.gov/nuccore",
+    "iris": [
+      "https://www.ncbi.nlm.nih.gov/nuccore/NM_000964.4"
+    ]
+  },
+  {
+    "id": "hgnc:9967",
+    "code": "HGNC:9967",
+    "system": "https://genenames.org",
+    "iris": [
+      "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/HGNC:9967"
+    ]
+  },
+  {
+    "id": "ensembl:ensg00000165731",
+    "code": "ENSG00000165731",
+    "system": "https://www.ensembl.org",
+    "iris": [
+      "https://www.ensembl.org/id/ENSG00000165731"
+    ]
+  },
+  {
+    "id": "ncbi:5979",
+    "code": "5979",
+    "system": "https://www.ncbi.nlm.nih.gov/gene",
+    "iris": [
+      "https://www.ncbi.nlm.nih.gov/gene/5979"
+    ]
+  },
+  {
+    "id": "refseq:NM_020975.6",
+    "code": "NM_020975.6",
+    "system": "https://www.ncbi.nlm.nih.gov/nuccore",
+    "iris": [
+      "https://www.ncbi.nlm.nih.gov/nuccore/NM_020975.6"
+    ]
+  },
+  {
+    "id": "hgnc:10261",
+    "code": "HGNC:10261",
+    "system": "https://genenames.org",
+    "iris": [
+      "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/HGNC:10261"
+    ]
+  },
+  {
+    "id": "ensembl:ensg00000047936",
+    "code": "ENSG00000047936",
+    "system": "https://www.ensembl.org",
+    "iris": [
+      "https://www.ensembl.org/id/ENSG00000047936"
+    ]
+  },
+  {
+    "id": "ncbi:6098",
+    "code": "6098",
+    "system": "https://www.ncbi.nlm.nih.gov/gene",
+    "iris": [
+      "https://www.ncbi.nlm.nih.gov/gene/6098"
+    ]
+  },
+  {
+    "id": "refseq:NM_001378902.1",
+    "code": "NM_001378902.1",
+    "system": "https://www.ncbi.nlm.nih.gov/nuccore",
+    "iris": [
+      "https://www.ncbi.nlm.nih.gov/nuccore/NM_001378902.1"
+    ]
+  },
+  {
+    "id": "hgnc:11524",
+    "code": "HGNC:11524",
+    "system": "https://genenames.org",
+    "iris": [
+      "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/HGNC:11524"
+    ]
+  },
+  {
+    "id": "ensembl:ensg00000013810",
+    "code": "ENSG00000013810",
+    "system": "https://www.ensembl.org",
+    "iris": [
+      "https://www.ensembl.org/id/ENSG00000013810"
+    ]
+  },
+  {
+    "id": "ncbi:10460",
+    "code": "10460",
+    "system": "https://www.ncbi.nlm.nih.gov/gene",
+    "iris": [
+      "https://www.ncbi.nlm.nih.gov/gene/10460"
+    ]
+  },
+  {
+    "id": "refseq:NM_006342.3",
+    "code": "NM_006342.3",
+    "system": "https://www.ncbi.nlm.nih.gov/nuccore",
+    "iris": [
+      "https://www.ncbi.nlm.nih.gov/nuccore/NM_006342.3"
+    ]
+  },
+  {
+    "id": "hgnc:11998",
+    "code": "HGNC:11998",
+    "system": "https://genenames.org",
+    "iris": [
+      "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/HGNC:11998"
+    ]
+  },
+  {
+    "id": "ensembl:ensg00000141510",
+    "code": "ENSG00000141510",
+    "system": "https://www.ensembl.org",
+    "iris": [
+      "https://www.ensembl.org/id/ENSG00000141510"
+    ]
+  },
+  {
+    "id": "ncbi:7157",
+    "code": "7157",
+    "system": "https://www.ncbi.nlm.nih.gov/gene",
+    "iris": [
+      "https://www.ncbi.nlm.nih.gov/gene/7157"
+    ]
+  },
+  {
+    "id": "refseq:NM_000546.6",
+    "code": "NM_000546.6",
+    "system": "https://www.ncbi.nlm.nih.gov/nuccore",
+    "iris": [
+      "https://www.ncbi.nlm.nih.gov/nuccore/NM_000546.6"
+    ]
+  },
+  {
+    "id": "hgnc:7131",
+    "code": "HGNC:7131",
+    "system": "https://genenames.org",
+    "iris": [
+      "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/HGNC:7131"
+    ]
+  },
+  {
+    "id": "ensembl:ensg00000118058",
+    "code": "ENSG00000118058",
+    "system": "https://www.ensembl.org",
+    "iris": [
+      "https://www.ensembl.org/id/ENSG00000118058"
+    ]
+  },
+  {
+    "id": "ncbi:4297",
+    "code": "4297",
+    "system": "https://www.ncbi.nlm.nih.gov/gene",
+    "iris": [
+      "https://www.ncbi.nlm.nih.gov/gene/4297"
+    ]
+  },
+  {
+    "id": "hgnc:12362",
+    "code": "HGNC:12362",
+    "system": "https://genenames.org",
+    "iris": [
+      "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/HGNC:12362"
+    ]
+  },
+  {
+    "id": "ensembl:ENSG00000165699",
+    "code": "ENSG00000165699",
+    "system": "https://www.ensembl.org",
+    "iris": [
+      "https://www.ensembl.org/id/ENSG00000165699"
+    ]
+  },
+  {
+    "id": "ncbi:7248",
+    "code": "7248",
+    "system": "https://www.ncbi.nlm.nih.gov/gene",
+    "iris": [
+      "https://www.ncbi.nlm.nih.gov/gene/7248"
+    ]
+  },
+  {
+    "id": "hgnc:12363",
+    "code": "HGNC:12363",
+    "system": "https://genenames.org",
+    "iris": [
+      "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/HGNC:12363"
+    ]
+  },
+  {
+    "id": "ensembl:ENSG00000103197",
+    "code": "ENSG00000103197",
+    "system": "https://www.ensembl.org",
+    "iris": [
+      "https://www.ensembl.org/id/ENSG00000103197"
+    ]
+  },
+  {
+    "id": "ncbi:7249",
+    "code": "7249",
+    "system": "https://www.ncbi.nlm.nih.gov/gene",
+    "iris": [
+      "https://www.ncbi.nlm.nih.gov/gene/7249"
+    ]
+  },
+  {
+    "id": "hgnc:882",
+    "code": "HGNC:882",
+    "system": "https://genenames.org",
+    "iris": [
+      "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/HGNC:882"
+    ]
+  },
+  {
+    "id": "ensembl:ENSG00000175054",
+    "code": "ENSG00000175054",
+    "system": "https://www.ensembl.org",
+    "iris": [
+      "https://www.ensembl.org/id/ENSG00000175054"
+    ]
+  },
+  {
+    "id": "ncbi:545",
+    "code": "545",
+    "system": "https://www.ncbi.nlm.nih.gov/gene",
+    "iris": [
+      "https://www.ncbi.nlm.nih.gov/gene/545"
+    ]
+  },
+  {
+    "id": "hgnc:3582",
+    "code": "HGNC:3582",
+    "system": "https://genenames.org",
+    "iris": [
+      "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/HGNC:3582"
+    ]
+  },
+  {
+    "id": "ensembl:ENSG00000187741",
+    "code": "ENSG00000187741",
+    "system": "https://www.ensembl.org",
+    "iris": [
+      "https://www.ensembl.org/id/ENSG00000187741"
+    ]
+  },
+  {
+    "id": "ncbi:2175",
+    "code": "2175",
+    "system": "https://www.ncbi.nlm.nih.gov/gene",
+    "iris": [
+      "https://www.ncbi.nlm.nih.gov/gene/2175"
+    ]
+  },
+  {
+    "id": "hgnc:7127",
+    "code": "HGNC:7127",
+    "system": "https://genenames.org",
+    "iris": [
+      "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/HGNC:7127"
+    ]
+  },
+  {
+    "id": "ensembl:ENSG00000076242",
+    "code": "ENSG00000076242",
+    "system": "https://www.ensembl.org",
+    "iris": [
+      "https://www.ensembl.org/id/ENSG00000076242"
+    ]
+  },
+  {
+    "id": "ncbi:4292",
+    "code": "4292",
+    "system": "https://www.ncbi.nlm.nih.gov/gene",
+    "iris": [
+      "https://www.ncbi.nlm.nih.gov/gene/4292"
+    ]
+  },
+  {
+    "id": "hgnc:7230",
+    "code": "HGNC:7230",
+    "system": "https://genenames.org",
+    "iris": [
+      "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/HGNC:7230"
+    ]
+  },
+  {
+    "id": "ensembl:ENSG00000020922",
+    "code": "ENSG00000020922",
+    "system": "https://www.ensembl.org",
+    "iris": [
+      "https://www.ensembl.org/id/ENSG00000020922"
+    ]
+  },
+  {
+    "id": "ncbi:4361",
+    "code": "4361",
+    "system": "https://www.ncbi.nlm.nih.gov/gene",
+    "iris": [
+      "https://www.ncbi.nlm.nih.gov/gene/4361"
+    ]
+  },
+  {
+    "id": "hgnc:7652",
+    "code": "HGNC:7652",
+    "system": "https://genenames.org",
+    "iris": [
+      "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/HGNC:7652"
+    ]
+  },
+  {
+    "id": "ensembl:ENSG00000104320",
+    "code": "ENSG00000104320",
+    "system": "https://www.ensembl.org",
+    "iris": [
+      "https://www.ensembl.org/id/ENSG00000104320"
+    ]
+  },
+  {
+    "id": "ncbi:4683",
+    "code": "4683",
+    "system": "https://www.ncbi.nlm.nih.gov/gene",
+    "iris": [
+      "https://www.ncbi.nlm.nih.gov/gene/4683"
+    ]
+  },
+  {
+    "id": "ncit:C25425",
+    "code": "C25425",
+    "name": "Approval",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C25425"
+    ]
+  },
+  {
+    "id": "ncit:C66944",
+    "code": "C66944",
+    "name": "Brentuximab Vedotin",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C66944"
+    ]
+  },
+  {
+    "id": "ncit:C411",
+    "code": "C411",
+    "name": "Dacarbazine",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C411"
+    ]
+  },
+  {
+    "id": "ncit:C456",
+    "code": "C456",
+    "name": "Doxorubicin",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C456"
+    ]
+  },
+  {
+    "id": "ncit:",
+    "code": "C930",
+    "name": "Vinblastine",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C930"
+    ]
+  },
+  {
+    "id": "ncit:C48387",
+    "code": "C48387",
+    "name": "Everolimus",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C48387"
+    ]
+  },
+  {
+    "id": "ncit:C1097",
+    "code": "C1097",
+    "name": "Exemestane",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C1097"
+    ]
+  },
+  {
+    "id": "ncit:C80059",
+    "code": "C80059",
+    "name": "Niraparib",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C80059"
+    ]
+  },
+  {
+    "id": "ncit:C68845",
+    "code": "C68845",
+    "name": "Abiraterone Acetate",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C68845"
+    ]
+  },
+  {
+    "id": "ncit:C769",
+    "code": "C769",
+    "name": "Prednisolone",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C769"
+    ]
+  },
+  {
+    "id": "ncit:C101790",
+    "code": "C101790",
+    "name": "Alectinib",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C101790"
+    ]
+  },
+  {
+    "id": "ncit:C98831",
+    "code": "C98831",
+    "name": "Brigatinib",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C98831"
+    ]
+  },
+  {
+    "id": "ncit:C2039",
+    "code": "C2039",
+    "name": "Bevacizumab",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C2039"
+    ]
+  },
+  {
+    "id": "ncit:C65530",
+    "code": "C65530",
+    "name": "Erlotinib",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C65530"
+    ]
+  },
+  {
+    "id": "ncit:C123827",
+    "code": "C123827",
+    "name": "Avapritinib",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C123827"
+    ]
+  },
+  {
+    "id": "ncit:C71542",
+    "code": "C71542",
+    "name": "Inotuzumab Ozogamicin",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C71542"
+    ]
+  },
+  {
+    "id": "ncit:C62528",
+    "code": "C62528",
+    "name": "Blinatumomab",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C62528"
+    ]
+  },
+  {
+    "id": "ncit:C60809",
+    "code": "C60809",
+    "name": "Bosutinib",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C60809"
+    ]
+  },
+  {
+    "id": "ncit:C84865",
+    "code": "C84865",
+    "name": "Binimetinib",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C84865"
+    ]
+  },
+  {
+    "id": "ncit:C98283",
+    "code": "C98283",
+    "name": "Encorafenib",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C98283"
+    ]
+  },
+  {
+    "id": "ncit:C1723",
+    "code": "C1723",
+    "name": "Cetuximab",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C1723"
+    ]
+  },
+  {
+    "id": "ncit:C2737",
+    "code": "C2737",
+    "name": "Vandetanib",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C2737"
+    ]
+  },
+  {
+    "id": "ncit:C68923",
+    "code": "C68923",
+    "name": "Cobimetinib",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C68923"
+    ]
+  },
+  {
+    "id": "ncit:C64768",
+    "code": "C64768",
+    "name": "Vemurafenib",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C64768"
+    ]
+  },
+  {
+    "id": "ncit:C70792",
+    "code": "C70792",
+    "name": "Ramucirumab",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C70792"
+    ]
+  },
+  {
+    "id": "ncit:C1526",
+    "code": "C1526",
+    "name": "Docetaxel",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C1526"
+    ]
+  },
+  {
+    "id": "ncit:C1647",
+    "code": "C1647",
+    "name": "Trastuzumab",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C1647"
+    ]
+  },
+  {
+    "id": "ncit:C128799",
+    "code": "C128799",
+    "name": "Trastuzumab Deruxtecan",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C128799"
+    ]
+  },
+  {
+    "id": "ncit:C62040",
+    "code": "C62040",
+    "name": "Irinotecan",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C62040"
+    ]
+  },
+  {
+    "id": "ncit:C1181",
+    "code": "C1181",
+    "name": "Oxaliplatin",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C1181"
+    ]
+  },
+  {
+    "id": "ncit:C505",
+    "code": "C505",
+    "name": "Fluorouracil",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C505"
+    ]
+  },
+  {
+    "id": "ncit:C1379",
+    "code": "C1379",
+    "name": "Fulvestrant",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C1379"
+    ]
+  },
+  {
+    "id": "ncit:C49176",
+    "code": "C49176",
+    "name": "Palbociclib",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C49176"
+    ]
+  },
+  {
+    "id": "ncit:C132295",
+    "code": "C132295",
+    "name": "Pralsetinib",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C132295"
+    ]
+  },
+  {
+    "id": "ncit:C1855",
+    "code": "C1855",
+    "name": "Gefitinib",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C1855"
+    ]
+  },
+  {
+    "id": "ncit:C66940",
+    "code": "C66940",
+    "name": "Afatinib",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C66940"
+    ]
+  },
+  {
+    "id": "ncit:C1411",
+    "code": "C1411",
+    "name": "Paclitaxel",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C1411"
+    ]
+  },
+  {
+    "id": "ncit:C1607",
+    "code": "C1607",
+    "name": "Anastrozole",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C1607"
+    ]
+  },
+  {
+    "id": "ncit:C1282",
+    "code": "C1282",
+    "name": "Carboplatin",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C1282"
+    ]
+  },
+  {
+    "id": "ncit:C1794",
+    "code": "C1794",
+    "name": "Capecitabine",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C1794"
+    ]
+  },
+  {
+    "id": "ncit:C376",
+    "code": "C376",
+    "name": "Cisplatin",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C376"
+    ]
+  },
+  {
+    "id": "ncit:C1527",
+    "code": "C1527",
+    "name": "Letrozole",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C1527"
+    ]
+  },
+  {
+    "id": "ncit:C62035",
+    "code": "C62035",
+    "name": "Imatinib",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C62035"
+    ]
+  },
+  {
+    "id": "ncit:",
+    "code": "",
+    "name": "",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/"
+    ]
+  },
+  {
+    "id": "ncit:C95777",
+    "code": "C95777",
+    "name": "Ponatinib",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C95777"
+    ]
+  },
+  {
+    "id": "ncit:C103194",
+    "code": "C103194",
+    "name": "Durvalumab",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C103194"
+    ]
+  },
+  {
+    "id": "ncit:C49085",
+    "code": "C49085",
+    "name": "Tremelimumab",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C49085"
+    ]
+  },
+  {
+    "id": "ncit:C71721",
+    "code": "C71721",
+    "name": "Olaparib",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C71721"
+    ]
+  },
+  {
+    "id": "ncit:C126799",
+    "code": "C126799",
+    "name": "Dostarlimab",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C126799"
+    ]
+  },
+  {
+    "id": "ncit:C106432",
+    "code": "C106432",
+    "name": "Pembrolizumab",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C106432"
+    ]
+  },
+  {
+    "id": "ncit:C61614",
+    "code": "C61614",
+    "name": "Pemetrexed",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C61614"
+    ]
+  },
+  {
+    "id": "ncit:C66876",
+    "code": "C66876",
+    "name": "Gemcitabine",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C66876"
+    ]
+  },
+  {
+    "id": "ncit:C2688",
+    "code": "C2688",
+    "name": "Nab-paclitaxel",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C2688"
+    ]
+  },
+  {
+    "id": "ncit:C82492",
+    "code": "C82492",
+    "name": "Trastuzumab Emtansine",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C82492"
+    ]
+  },
+  {
+    "id": "ncit:C95701",
+    "code": "C95701",
+    "name": "Ribociclib",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C95701"
+    ]
+  },
+  {
+    "id": "ncit:C157493",
+    "code": "C157493",
+    "name": "Adagrasib",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C157493"
+    ]
+  },
+  {
+    "id": "ncit:C121540",
+    "code": "C121540",
+    "name": "Cemiplimab",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C121540"
+    ]
+  },
+  {
+    "id": "ncit:C113655",
+    "code": "C113655",
+    "name": "Lorlatinib",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C113655"
+    ]
+  },
+  {
+    "id": "ncit:C154287",
+    "code": "C154287",
+    "name": "Sotorasib",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C154287"
+    ]
+  },
+  {
+    "id": "ncit:C114283",
+    "code": "C114283",
+    "name": "Futibatinib",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C114283"
+    ]
+  },
+  {
+    "id": "ncit:C405",
+    "code": "C405",
+    "name": "Cyclophosphamide",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C405"
+    ]
+  },
+  {
+    "id": "ncit:C1702",
+    "code": "C1702",
+    "name": "Rituximab",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C1702"
+    ]
+  },
+  {
+    "id": "ncit:C933",
+    "code": "C933",
+    "name": "Vincristine",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C933"
+    ]
+  },
+  {
+    "id": "ncit:C2322",
+    "code": "C2322",
+    "name": "Corticosteroid",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C2322"
+    ]
+  },
+  {
+    "id": "ncit:C408",
+    "code": "C408",
+    "name": "Cytarabine",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C408"
+    ]
+  },
+  {
+    "id": "ncit:C491",
+    "code": "C491",
+    "name": "Etoposide",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C491"
+    ]
+  },
+  {
+    "id": "ncit:C642",
+    "code": "C642",
+    "name": "Methotrexate",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C642"
+    ]
+  },
+  {
+    "id": "ncit:C77908",
+    "code": "C77908",
+    "name": "Trametinib",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C77908"
+    ]
+  },
+  {
+    "id": "ncit:C82386",
+    "code": "C82386",
+    "name": "Dabrafenib",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C82386"
+    ]
+  },
+  {
+    "id": "ncit:C62091",
+    "code": "C62091",
+    "name": "Daunorubicin",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C62091"
+    ]
+  },
+  {
+    "id": "ncit:C1806",
+    "code": "C1806",
+    "name": "Gemtuzumab Ozogamicin",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C1806"
+    ]
+  },
+  {
+    "id": "ncit:C49094",
+    "code": "C49094",
+    "name": "Neratinib",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C49094"
+    ]
+  },
+  {
+    "id": "ncit:C2654",
+    "code": "C2654",
+    "name": "Ipilimumab",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C2654"
+    ]
+  },
+  {
+    "id": "ncit:C68814",
+    "code": "C68814",
+    "name": "Nivolumab",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C68814"
+    ]
+  },
+  {
+    "id": "ncit:C111999",
+    "code": "C111999",
+    "name": "Relatlimab",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C111999"
+    ]
+  },
+  {
+    "id": "ncit:C120211",
+    "code": "C120211",
+    "name": "Elacestrant",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C120211"
+    ]
+  },
+  {
+    "id": "ncit:C38692",
+    "code": "C38692",
+    "name": "Pertuzumab",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C38692"
+    ]
+  },
+  {
+    "id": "ncit:C62028",
+    "code": "C62028",
+    "name": "Epirubicin",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C62028"
+    ]
+  },
+  {
+    "id": "ncit:C94214",
+    "code": "C94214",
+    "name": "Alpelisib",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C94214"
+    ]
+  },
+  {
+    "id": "ncit:C134987",
+    "code": "C134987",
+    "name": "Selpercatinib",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C134987"
+    ]
+  },
+  {
+    "id": "ncit:C2668",
+    "code": "C2668",
+    "name": "Lenalidomide",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C2668"
+    ]
+  },
+  {
+    "id": "ncit:C114984",
+    "code": "C114984",
+    "name": "Entrectinib",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C114984"
+    ]
+  },
+  {
+    "id": "ncit:C1872",
+    "code": "C1872",
+    "name": "Midostaurin",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C1872"
+    ]
+  },
+  {
+    "id": "ncit:C114494",
+    "code": "C114494",
+    "name": "Asciminib",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C114494"
+    ]
+  },
+  {
+    "id": "ncit:C38713",
+    "code": "C38713",
+    "name": "Dasatinib",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C38713"
+    ]
+  },
+  {
+    "id": "ncit:C90564",
+    "code": "C90564",
+    "name": "Capmatinib",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C90564"
+    ]
+  },
+  {
+    "id": "ncit:C116377",
+    "code": "C116377",
+    "name": "Osimertinib",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C116377"
+    ]
+  },
+  {
+    "id": "ncit:C95733",
+    "code": "C95733",
+    "name": "Talazoparib",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C95733"
+    ]
+  },
+  {
+    "id": "ncit:C48375",
+    "code": "C48375",
+    "name": "Nilotinib",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C48375"
+    ]
+  },
+  {
+    "id": "ncit:C106250",
+    "code": "C106250",
+    "name": "Atezolizumab",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C106250"
+    ]
+  },
+  {
+    "id": "ncit:C88314",
+    "code": "C88314",
+    "name": "Tepotinib",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C88314"
+    ]
+  },
+  {
+    "id": "ncit:C288",
+    "code": "C288",
+    "name": "Azacitidine",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C288"
+    ]
+  },
+  {
+    "id": "ncit:C114383",
+    "code": "C114383",
+    "name": "Ivosidenib",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C114383"
+    ]
+  },
+  {
+    "id": "ncit:C1005",
+    "code": "C1005",
+    "name": "Arsenic Trioxide",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C1005"
+    ]
+  },
+  {
+    "id": "ncit:C102783",
+    "code": "C102783",
+    "name": "Sacituzumab Govitecan",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C102783"
+    ]
+  },
+  {
+    "id": "ncit:C77896",
+    "code": "C77896",
+    "name": "Tucatinib",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C77896"
+    ]
+  },
+  {
+    "id": "ncit:C26653",
+    "code": "C26653",
+    "name": "Lapatinib",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C26653"
+    ]
+  },
+  {
+    "id": "ncit:C1857",
+    "code": "C1857",
+    "name": "Panitumumab",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C1857"
+    ]
+  },
+  {
+    "id": "ncit:C103147",
+    "code": "C103147",
+    "name": "Venetoclax",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C103147"
+    ]
+  },
+  {
+    "id": "ncit:C97660",
+    "code": "C97660",
+    "name": "Abemaciclib",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C97660"
+    ]
+  },
+  {
+    "id": "ncit:C115977",
+    "code": "C115977",
+    "name": "Larotrectinib",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C115977"
+    ]
+  },
+  {
+    "id": "ncit:C53398",
+    "code": "C53398",
+    "name": "Dacomitinib",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C53398"
+    ]
+  },
+  {
+    "id": "ncit:C74061",
+    "code": "C74061",
+    "name": "Crizotinib",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C74061"
+    ]
+  },
+  {
+    "id": "ncit:C116722",
+    "code": "C116722",
+    "name": "Gilteritinib",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C116722"
+    ]
+  },
+  {
+    "id": "ncit:C78825",
+    "code": "C78825",
+    "name": "Idelalisib",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C78825"
+    ]
+  },
+  {
+    "id": "ncit:C115112",
+    "code": "C115112",
+    "name": "Ceritinib",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C115112"
+    ]
+  },
+  {
+    "id": "ncit:C121775",
+    "code": "C121775",
+    "name": "Tislelizumab",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C121775"
+    ]
+  },
+  {
+    "id": "ncit:C124993",
+    "code": "C124993",
+    "name": "Amivantamab",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C124993"
+    ]
+  },
+  {
+    "id": "ncit:C102564",
+    "code": "C102564",
+    "name": "Capivasertib",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C102564"
+    ]
+  },
+  {
+    "id": "ncit:C103273",
+    "code": "C103273",
+    "name": "Erdafitinib",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C103273"
+    ]
+  },
+  {
+    "id": "ncit:C85475",
+    "code": "C85475",
+    "name": "Zolbetuximab",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C85475"
+    ]
+  },
+  {
+    "id": "ncit:C141428",
+    "code": "C141428",
+    "name": "Zanubrutinib",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C141428"
+    ]
+  },
+  {
+    "id": "ncit:C113442",
+    "code": "C113442",
+    "name": "Acalabrutinib",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C113442"
+    ]
+  },
+  {
+    "id": "ncit:C81934",
+    "code": "C81934",
+    "name": "Ibrutinib",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C81934"
+    ]
+  },
+  {
+    "id": "ncit:C564",
+    "code": "C564",
+    "name": "Ifosfamide",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C564"
+    ]
+  },
+  {
+    "id": "ncit:C1275",
+    "code": "C1275",
+    "name": "Vinorelbine",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C1275"
+    ]
+  },
+  {
+    "id": "ncit:C62078",
+    "code": "C62078",
+    "name": "Tamoxifen",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C62078"
+    ]
+  },
+  {
+    "id": "ncit:C66952",
+    "code": "C66952",
+    "name": "Ofatumumab",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C66952"
+    ]
+  },
+  {
+    "id": "ncit:C73261",
+    "code": "C73261",
+    "name": "Bendamustine",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C73261"
+    ]
+  },
+  {
+    "id": "ncit:C770",
+    "code": "C770",
+    "name": "Prednisone",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C770"
+    ]
+  },
+  {
+    "id": "ncit:C362",
+    "code": "C362",
+    "name": "Chlorambucil",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C362"
+    ]
+  },
+  {
+    "id": "ncit:C62050",
+    "code": "C62050",
+    "name": "Mitoxantrone",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C62050"
+    ]
+  },
+  {
+    "id": "ncit:C20494",
+    "code": "C20494",
+    "name": "Interferon Alpha",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C20494"
+    ]
+  },
+  {
+    "id": "ncit:C111573",
+    "code": "C111573",
+    "name": "Enasidenib",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C111573"
+    ]
+  },
+  {
+    "id": "ncit:C88302",
+    "code": "C88302",
+    "name": "Infigratinib",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C88302"
+    ]
+  },
+  {
+    "id": "ncit:C91733",
+    "code": "C91733",
+    "name": "Margetuximab",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C91733"
+    ]
+  },
+  {
+    "id": "ncit:C96748",
+    "code": "C96748",
+    "name": "Eribulin",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C96748"
+    ]
+  },
+  {
+    "id": "ncit:C126752",
+    "code": "C126752",
+    "name": "Mobocertinib",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C126752"
+    ]
+  },
+  {
+    "id": "ncit:C129687",
+    "code": "C129687",
+    "name": "Olutasidenib",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C129687"
+    ]
+  },
+  {
+    "id": "ncit:C95124",
+    "code": "C95124",
+    "name": "Lenvatinib",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C95124"
+    ]
+  },
+  {
+    "id": "ncit:C121553",
+    "code": "C121553",
+    "name": "Pemigatinib",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C121553"
+    ]
+  },
+  {
+    "id": "ncit:C133821",
+    "code": "C133821",
+    "name": "Repotrectinib",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C133821"
+    ]
+  },
+  {
+    "id": "ncit:C1094",
+    "code": "C1094",
+    "name": "Fludarabine",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C1094"
+    ]
+  },
+  {
+    "id": "ncit:C137800",
+    "code": "C137800",
+    "name": "Rucaparib",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C137800"
+    ]
+  },
+  {
+    "id": "ncit:C107506",
+    "code": "C107506",
+    "name": "Tazemetostat",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C107506"
+    ]
+  },
+  {
+    "id": "ncit:C71744",
+    "code": "C71744",
+    "name": "Enzalutamide",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C71744"
+    ]
+  },
+  {
+    "id": "ncit:C148147",
+    "code": "C148147",
+    "name": "Lazertinib",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C148147"
+    ]
+  },
+  {
+    "id": "ncit:C102566",
+    "code": "C102566",
+    "name": "Mirvetuximab Soravtansine",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C102566"
+    ]
+  },
+  {
+    "id": "ncit:C106254",
+    "code": "C106254",
+    "name": "Tovorafenib",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C106254"
+    ]
+  },
+  {
+    "id": "ncit:C152914",
+    "code": "C152914",
+    "name": "Vorasidenib",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C152914"
+    ]
+  },
+  {
+    "id": "ncit:C1374",
+    "code": "C1374",
+    "name": "Goserelin",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C1374"
+    ]
+  },
+  {
+    "id": "ncit:C132166",
+    "code": "C132166",
+    "name": "Inavolisib",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C132166"
+    ]
+  },
+  {
+    "id": "ncit:C130010",
+    "code": "C130010",
+    "name": "Zanidatamab",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C130010"
+    ]
+  },
+  {
+    "id": "ncit:C152948",
+    "code": "C152948",
+    "name": "Zenocutuzumab",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C152948"
+    ]
+  },
+  {
+    "id": "ncit:C102754",
+    "code": "C102754",
+    "name": "Ensartinib",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C102754"
+    ]
+  },
+  {
+    "id": "ncit:C165776",
+    "code": "C165776",
+    "name": "Revumenib",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C165776"
+    ]
+  }
+]

--- a/referenced/codings.json
+++ b/referenced/codings.json
@@ -50,13 +50,13 @@
     ]
   },
   {
-    "id": "oncotree:",
-    "code": "",
-    "name": "",
+    "id": "oncotree:CLLSLL",
+    "code": "CLLSLL",
+    "name": "Chronic Lymphocytic Leukemia/Small Lymphocytic Lymphoma",
     "system": "https://oncotree.mskcc.org",
     "systemVersion": "oncotree_2021_11_02",
     "iris": [
-      "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search="
+      "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=CLLSLL"
     ]
   },
   {
@@ -4215,6 +4215,36 @@
     "systemVersion": "25.01d",
     "iris": [
       "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C165776"
+    ]
+  },
+  {
+    "id": "ncit:C132146",
+    "code": "C132146",
+    "name": "Malignant Solid Neoplasm",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C132146"
+    ]
+  },
+  {
+    "id": "ncit:C3467",
+    "code": "C3467",
+    "name": "Primary Cutaneous T-Cell Non-Hodgkin Lymphoma",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C3467"
+    ]
+  },
+  {
+    "id": "ncit:C3163",
+    "code": "C3163",
+    "name": "Chronic Lymphocytic Leukemia",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C3163"
     ]
   }
 ]

--- a/referenced/codings.json
+++ b/referenced/codings.json
@@ -2798,7 +2798,7 @@
     ]
   },
   {
-    "id": "ncit:",
+    "id": "ncit:C930",
     "code": "C930",
     "name": "Vinblastine",
     "system": "https://evsexplore.semantics.cancer.gov",

--- a/referenced/diseases.json
+++ b/referenced/diseases.json
@@ -4,9 +4,7 @@
     "conceptType": "Disease",
     "name": "Acute Lymphoid Leukemia",
     "primaryCoding": "oncotree:ALL",
-    "mappings": [
-      0
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "solid_tumor",
@@ -20,9 +18,7 @@
     "conceptType": "Disease",
     "name": "Acute Myeloid Leukemia",
     "primaryCoding": "oncotree:AML",
-    "mappings": [
-      1
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "solid_tumor",
@@ -36,9 +32,7 @@
     "conceptType": "Disease",
     "name": "Adenocarcinoma of the Gastroesophageal Junction",
     "primaryCoding": "oncotree:GEJ",
-    "mappings": [
-      2
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "solid_tumor",
@@ -52,9 +46,7 @@
     "conceptType": "Disease",
     "name": "Anaplastic Large Cell Lymphoma",
     "primaryCoding": "oncotree:ALCL",
-    "mappings": [
-      3
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "solid_tumor",
@@ -68,9 +60,7 @@
     "conceptType": "Disease",
     "name": "Anaplastic Thyroid Cancer",
     "primaryCoding": "oncotree:THAP",
-    "mappings": [
-      4
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "solid_tumor",
@@ -98,9 +88,7 @@
     "conceptType": "Disease",
     "name": "Astrocytoma",
     "primaryCoding": "oncotree:ASTR",
-    "mappings": [
-      6
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "solid_tumor",
@@ -114,9 +102,7 @@
     "conceptType": "Disease",
     "name": "B-Cell Acute Lymphoid Leukemia",
     "primaryCoding": "oncotree:BALL",
-    "mappings": [
-      7
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "solid_tumor",
@@ -130,9 +116,7 @@
     "conceptType": "Disease",
     "name": "Bladder Urothelial Carcinoma",
     "primaryCoding": "oncotree:BLCA",
-    "mappings": [
-      8
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "solid_tumor",
@@ -146,9 +130,7 @@
     "conceptType": "Disease",
     "name": "Invasive Breast Carcinoma",
     "primaryCoding": "oncotree:BRCA",
-    "mappings": [
-      9
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "solid_tumor",
@@ -162,9 +144,7 @@
     "conceptType": "Disease",
     "name": "APL with PML-RARA",
     "primaryCoding": "oncotree:APLPMLRARA",
-    "mappings": [
-      10
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "solid_tumor",
@@ -178,9 +158,7 @@
     "conceptType": "Disease",
     "name": "Cholangiocarcinoma",
     "primaryCoding": "oncotree:CHOL",
-    "mappings": [
-      11
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "solid_tumor",
@@ -194,9 +172,7 @@
     "conceptType": "Disease",
     "name": "Chronic Eosinophilic Leukemia, NOS",
     "primaryCoding": "oncotree:CELNOS",
-    "mappings": [
-      12
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "solid_tumor",
@@ -210,9 +186,7 @@
     "conceptType": "Disease",
     "name": "Chronic Myelogenous Leukemia",
     "primaryCoding": "oncotree:CML",
-    "mappings": [
-      13
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "solid_tumor",
@@ -226,9 +200,7 @@
     "conceptType": "Disease",
     "name": "Chronic Myelomonocytic Leukemia",
     "primaryCoding": "oncotree:CMML",
-    "mappings": [
-      14
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "solid_tumor",
@@ -242,9 +214,7 @@
     "conceptType": "Disease",
     "name": "Colorectal Adenocarcinoma",
     "primaryCoding": "oncotree:COADREAD",
-    "mappings": [
-      15
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "solid_tumor",
@@ -258,9 +228,7 @@
     "conceptType": "Disease",
     "name": "Dedifferentiated Lipsarcoma",
     "primaryCoding": "oncotree:DDLS",
-    "mappings": [
-      16
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "solid_tumor",
@@ -274,9 +242,7 @@
     "conceptType": "Disease",
     "name": "Dermatofibrosarcoma Protuberans",
     "primaryCoding": "oncotree:DFSP",
-    "mappings": [
-      17
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "solid_tumor",
@@ -290,9 +256,7 @@
     "conceptType": "Disease",
     "name": "Endometrial Carcinoma",
     "primaryCoding": "oncotree:UCEC",
-    "mappings": [
-      18
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "solid_tumor",
@@ -306,9 +270,7 @@
     "conceptType": "Disease",
     "name": "Ewing Sarcoma",
     "primaryCoding": "oncotree:ES",
-    "mappings": [
-      19
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "solid_tumor",
@@ -322,9 +284,7 @@
     "conceptType": "Disease",
     "name": "Follicular Lymphoma",
     "primaryCoding": "oncotree:FL",
-    "mappings": [
-      20
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "solid_tumor",
@@ -338,9 +298,7 @@
     "conceptType": "Disease",
     "name": "Gastric Remnant Adenocarcinoma",
     "primaryCoding": "oncotree:GRC",
-    "mappings": [
-      21
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "solid_tumor",
@@ -354,9 +312,7 @@
     "conceptType": "Disease",
     "name": "Gastrointestinal Stromal Tumor",
     "primaryCoding": "oncotree:GIST",
-    "mappings": [
-      22
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "solid_tumor",
@@ -370,9 +326,7 @@
     "conceptType": "Disease",
     "name": "Glioma",
     "primaryCoding": "oncotree:GNOS",
-    "mappings": [
-      23
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "solid_tumor",
@@ -386,9 +340,7 @@
     "conceptType": "Disease",
     "name": "Head and Neck Mucosal Melanoma",
     "primaryCoding": "oncotree:HNMUCM",
-    "mappings": [
-      24
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "solid_tumor",
@@ -402,9 +354,7 @@
     "conceptType": "Disease",
     "name": "Head and Neck Squamous Cell Carcinoma",
     "primaryCoding": "oncotree:HNSC",
-    "mappings": [
-      25
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "solid_tumor",
@@ -418,9 +368,7 @@
     "conceptType": "Disease",
     "name": "High-Grade Neuroendocrine Carcinoma of the Colon and Rectum",
     "primaryCoding": "oncotree:HGNEC",
-    "mappings": [
-      26
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "solid_tumor",
@@ -434,9 +382,7 @@
     "conceptType": "Disease",
     "name": "High-Grade Serous Fallopian Tube Cancer",
     "primaryCoding": "oncotree:HGSFT",
-    "mappings": [
-      27
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "solid_tumor",
@@ -450,9 +396,7 @@
     "conceptType": "Disease",
     "name": "Inflammatory Myofibroblastic Tumor",
     "primaryCoding": "oncotree:IMT",
-    "mappings": [
-      28
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "solid_tumor",
@@ -466,9 +410,7 @@
     "conceptType": "Disease",
     "name": "Intrahepatic Cholangiocarcinoma",
     "primaryCoding": "oncotree:IHCH",
-    "mappings": [
-      29
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "solid_tumor",
@@ -496,9 +438,7 @@
     "conceptType": "Disease",
     "name": "Langerhans Cell Histiocytosis",
     "primaryCoding": "oncotree:LCH",
-    "mappings": [
-      31
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "solid_tumor",
@@ -512,9 +452,7 @@
     "conceptType": "Disease",
     "name": "Leiomyosarcoma",
     "primaryCoding": "oncotree:LMS",
-    "mappings": [
-      32
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "solid_tumor",
@@ -528,9 +466,7 @@
     "conceptType": "Disease",
     "name": "Leukemia",
     "primaryCoding": "oncotree:LEUK",
-    "mappings": [
-      33
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "solid_tumor",
@@ -544,9 +480,7 @@
     "conceptType": "Disease",
     "name": "Liposarcoma",
     "primaryCoding": "oncotree:LIPO",
-    "mappings": [
-      34
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "solid_tumor",
@@ -560,9 +494,7 @@
     "conceptType": "Disease",
     "name": "Low-Grade Glioma, NOS",
     "primaryCoding": "oncotree:LGGNOS",
-    "mappings": [
-      35
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "solid_tumor",
@@ -576,9 +508,7 @@
     "conceptType": "Disease",
     "name": "Lung Squamous Cell Carcinoma",
     "primaryCoding": "oncotree:LUSC",
-    "mappings": [
-      36
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "solid_tumor",
@@ -592,9 +522,7 @@
     "conceptType": "Disease",
     "name": "Mast Cell Leukemia",
     "primaryCoding": "oncotree:SMMCL",
-    "mappings": [
-      37
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "solid_tumor",
@@ -608,9 +536,7 @@
     "conceptType": "Disease",
     "name": "Medullary Thyroid Cancer",
     "primaryCoding": "oncotree:THME",
-    "mappings": [
-      38
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "solid_tumor",
@@ -624,9 +550,7 @@
     "conceptType": "Disease",
     "name": "Medulloblastoma",
     "primaryCoding": "oncotree:MBL",
-    "mappings": [
-      39
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "solid_tumor",
@@ -640,9 +564,7 @@
     "conceptType": "Disease",
     "name": "Melanoma",
     "primaryCoding": "oncotree:MEL",
-    "mappings": [
-      40
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "solid_tumor",
@@ -656,9 +578,7 @@
     "conceptType": "Disease",
     "name": "Multiple Myeloma",
     "primaryCoding": "oncotree:MM",
-    "mappings": [
-      41
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "solid_tumor",
@@ -672,9 +592,7 @@
     "conceptType": "Disease",
     "name": "Aggressive Systemic Mastocytosis",
     "primaryCoding": "oncotree:ASM",
-    "mappings": [
-      42
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "solid_tumor",
@@ -688,9 +606,7 @@
     "conceptType": "Disease",
     "name": "Myelodysplastic Syndromes",
     "primaryCoding": "oncotree:MDS",
-    "mappings": [
-      43
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "solid_tumor",
@@ -704,9 +620,7 @@
     "conceptType": "Disease",
     "name": "Myeloid/Lymphoid Neoplasms",
     "primaryCoding": "oncotree:MLN",
-    "mappings": [
-      44
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "solid_tumor",
@@ -720,9 +634,7 @@
     "conceptType": "Disease",
     "name": "Myeloproliferative Neoplasm",
     "primaryCoding": "oncotree:MPN",
-    "mappings": [
-      45
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "solid_tumor",
@@ -736,9 +648,7 @@
     "conceptType": "Disease",
     "name": "Non-Langerhans Cell Histiocytosis/Erdheim-Chester Disease",
     "primaryCoding": "oncotree:ECD",
-    "mappings": [
-      46
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "solid_tumor",
@@ -752,9 +662,7 @@
     "conceptType": "Disease",
     "name": "Non-Small Cell Lung Cancer",
     "primaryCoding": "oncotree:NSCLC",
-    "mappings": [
-      47
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "solid_tumor",
@@ -768,9 +676,7 @@
     "conceptType": "Disease",
     "name": "Oligodendroglioma",
     "primaryCoding": "oncotree:ODG",
-    "mappings": [
-      48
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "solid_tumor",
@@ -784,9 +690,7 @@
     "conceptType": "Disease",
     "name": "Osteosarcoma",
     "primaryCoding": "oncotree:OS",
-    "mappings": [
-      49
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "solid_tumor",
@@ -800,9 +704,7 @@
     "conceptType": "Disease",
     "name": "Ovarian Cancer, Other",
     "primaryCoding": "oncotree:OOVC",
-    "mappings": [
-      50
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "solid_tumor",
@@ -816,9 +718,7 @@
     "conceptType": "Disease",
     "name": "Ovarian Epithelial Tumor",
     "primaryCoding": "oncotree:OVT",
-    "mappings": [
-      51
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "solid_tumor",
@@ -832,9 +732,7 @@
     "conceptType": "Disease",
     "name": "Pancreatic Adenocarcinoma",
     "primaryCoding": "oncotree:PAAD",
-    "mappings": [
-      52
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "solid_tumor",
@@ -848,9 +746,7 @@
     "conceptType": "Disease",
     "name": "Peritoneal Mesothelioma",
     "primaryCoding": "oncotree:PEMESO",
-    "mappings": [
-      53
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "solid_tumor",
@@ -864,9 +760,7 @@
     "conceptType": "Disease",
     "name": "Peritoneal Serous Carcinoma",
     "primaryCoding": "oncotree:PSEC",
-    "mappings": [
-      54
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "solid_tumor",
@@ -880,9 +774,7 @@
     "conceptType": "Disease",
     "name": "Prostate Adenocarcinoma",
     "primaryCoding": "oncotree:PRAD",
-    "mappings": [
-      55
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "solid_tumor",
@@ -896,9 +788,7 @@
     "conceptType": "Disease",
     "name": "Prostate Neuroendocrine Cancer",
     "primaryCoding": "oncotree:PRNE",
-    "mappings": [
-      56
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "solid_tumor",
@@ -912,9 +802,7 @@
     "conceptType": "Disease",
     "name": "Rectal Adenocarcinoma",
     "primaryCoding": "oncotree:READ",
-    "mappings": [
-      57
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "solid_tumor",
@@ -928,9 +816,7 @@
     "conceptType": "Disease",
     "name": "Renal Cell Carcinoma",
     "primaryCoding": "oncotree:RCC",
-    "mappings": [
-      58
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "solid_tumor",
@@ -944,9 +830,7 @@
     "conceptType": "Disease",
     "name": "Renal Clear Cell Carcinoma",
     "primaryCoding": "oncotree:CCRCC",
-    "mappings": [
-      59
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "solid_tumor",
@@ -960,9 +844,7 @@
     "conceptType": "Disease",
     "name": "Serous Ovarian Cancer",
     "primaryCoding": "oncotree:SOC",
-    "mappings": [
-      60
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "solid_tumor",
@@ -976,9 +858,7 @@
     "conceptType": "Disease",
     "name": "Small Cell Lung Cancer",
     "primaryCoding": "oncotree:SCLC",
-    "mappings": [
-      61
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "solid_tumor",
@@ -992,9 +872,7 @@
     "conceptType": "Disease",
     "name": "Squamous Cell Carcinoma, NOS",
     "primaryCoding": "oncotree:SCCNOS",
-    "mappings": [
-      62
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "solid_tumor",
@@ -1008,9 +886,7 @@
     "conceptType": "Disease",
     "name": "Stomach Adenocarcinoma",
     "primaryCoding": "oncotree:STAD",
-    "mappings": [
-      63
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "solid_tumor",
@@ -1024,9 +900,7 @@
     "conceptType": "Disease",
     "name": "T-Cell Acute Lymphoid Leukemia",
     "primaryCoding": "oncotree:TALL",
-    "mappings": [
-      64
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "solid_tumor",
@@ -1040,9 +914,7 @@
     "conceptType": "Disease",
     "name": "Testicular Germ Cell Tumors",
     "primaryCoding": "oncotree:TGCT",
-    "mappings": [
-      65
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "solid_tumor",
@@ -1056,9 +928,7 @@
     "conceptType": "Disease",
     "name": "Thymic Carcinoma",
     "primaryCoding": "oncotree:THYC",
-    "mappings": [
-      66
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "solid_tumor",
@@ -1072,9 +942,7 @@
     "conceptType": "Disease",
     "name": "Urethral Urothelial Carcinoma",
     "primaryCoding": "oncotree:UCU",
-    "mappings": [
-      67
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "solid_tumor",
@@ -1088,9 +956,7 @@
     "conceptType": "Disease",
     "name": "Uterine Leiomyoma",
     "primaryCoding": "oncotree:ULM",
-    "mappings": [
-      68
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "solid_tumor",
@@ -1104,9 +970,7 @@
     "conceptType": "Disease",
     "name": "Uterine Leiomyosarcoma",
     "primaryCoding": "oncotree:ULMS",
-    "mappings": [
-      69
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "solid_tumor",
@@ -1120,9 +984,7 @@
     "conceptType": "Disease",
     "name": "Well-Differentiated Liposarcoma",
     "primaryCoding": "oncotree:WDLS",
-    "mappings": [
-      70
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "solid_tumor",
@@ -1136,9 +998,7 @@
     "conceptType": "Disease",
     "name": "Chronic Myeloid Leukemia, BCR-ABL1+",
     "primaryCoding": "oncotree:CMLBCRABL1",
-    "mappings": [
-      71
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "solid_tumor",
@@ -1152,9 +1012,7 @@
     "conceptType": "Disease",
     "name": "Cervical Adenocarcinoma",
     "primaryCoding": "oncotree:CEAD",
-    "mappings": [
-      72
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "solid_tumor",
@@ -1168,9 +1026,7 @@
     "conceptType": "Disease",
     "name": "Cervical Squamous Cell Carcinoma",
     "primaryCoding": "oncotree:CESC",
-    "mappings": [
-      73
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "solid_tumor",
@@ -1184,9 +1040,7 @@
     "conceptType": "Disease",
     "name": "Esophageal Adenocarcinoma",
     "primaryCoding": "oncotree:ESCA",
-    "mappings": [
-      74
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "solid_tumor",
@@ -1200,9 +1054,7 @@
     "conceptType": "Disease",
     "name": "Papillary Thyroid Cancer",
     "primaryCoding": "oncotree:THPA",
-    "mappings": [
-      75
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "solid_tumor",
@@ -1216,9 +1068,7 @@
     "conceptType": "Disease",
     "name": "Non-Hodgkin Lymphoma",
     "primaryCoding": "oncotree:NHL",
-    "mappings": [
-      76
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "solid_tumor",
@@ -1232,9 +1082,7 @@
     "conceptType": "Disease",
     "name": "Diffuse Large B-Cell Lymphoma",
     "primaryCoding": "oncotree:DLBCLNOS",
-    "mappings": [
-      77
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "solid_tumor",
@@ -1248,9 +1096,7 @@
     "conceptType": "Disease",
     "name": "Burkitt Lymphoma",
     "primaryCoding": "oncotree:BL",
-    "mappings": [
-      78
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "solid_tumor",
@@ -1264,9 +1110,7 @@
     "conceptType": "Disease",
     "name": "Mature B-Cell Neoplasms",
     "primaryCoding": "oncotree:MBN",
-    "mappings": [
-      79
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "solid_tumor",
@@ -1280,9 +1124,7 @@
     "conceptType": "Disease",
     "name": "Hodgkin Lymphoma",
     "primaryCoding": "oncotree:HL",
-    "mappings": [
-      80
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "solid_tumor",
@@ -1296,9 +1138,7 @@
     "conceptType": "Disease",
     "name": "Esophagogastric Adenocarcinoma",
     "primaryCoding": "oncotree:EGC",
-    "mappings": [
-      81
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "solid_tumor",
@@ -1312,9 +1152,7 @@
     "conceptType": "Disease",
     "name": "Esophageal Squamous Cell Carcinoma",
     "primaryCoding": "oncotree:ESCC",
-    "mappings": [
-      82
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "solid_tumor",
@@ -1328,9 +1166,7 @@
     "conceptType": "Disease",
     "name": "High-Grade Glioma, NOS",
     "primaryCoding": "oncotree:HGGNOS",
-    "mappings": [
-      83
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "solid_tumor",
@@ -1345,7 +1181,7 @@
     "name": "Chronic Lymphocytic Leukemia",
     "primaryCoding": "ncit:C3163",
     "mappings": [
-      84
+      175
     ],
     "extensions": [
       {
@@ -1360,9 +1196,7 @@
     "conceptType": "Disease",
     "name": "Intraductal Papillary Neoplasm of the Bile Duct",
     "primaryCoding": "oncotree:IPN",
-    "mappings": [
-      85
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "solid_tumor",
@@ -1376,9 +1210,7 @@
     "conceptType": "Disease",
     "name": "Intracholecystic Papillary Neoplasm",
     "primaryCoding": "oncotree:ICPN",
-    "mappings": [
-      86
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "solid_tumor",
@@ -1392,9 +1224,7 @@
     "conceptType": "Disease",
     "name": "Acute Leukemias of Ambiguous Lineage",
     "primaryCoding": "oncotree:ALAL",
-    "mappings": [
-      87
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "solid_tumor",
@@ -1408,9 +1238,7 @@
     "conceptType": "Disease",
     "name": "Renal Angiomyolipoma",
     "primaryCoding": "oncotree:RAML",
-    "mappings": [
-      88
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "solid_tumor",

--- a/referenced/diseases.json
+++ b/referenced/diseases.json
@@ -83,7 +83,7 @@
     "id": 5,
     "conceptType": "Disease",
     "name": "Any solid tumor",
-    "primaryCoding": "oncotree:",
+    "primaryCoding": "ncit:C132146",
     "mappings": [],
     "extensions": [
       {
@@ -481,7 +481,7 @@
     "id": 30,
     "conceptType": "Disease",
     "name": "Cutaneous T-cell Lymphoma",
-    "primaryCoding": "oncotree:",
+    "primaryCoding": "ncit:C3467",
     "mappings": [],
     "extensions": [
       {
@@ -1343,8 +1343,10 @@
     "id": 84,
     "conceptType": "Disease",
     "name": "Chronic Lymphocytic Leukemia",
-    "primaryCoding": "oncotree:",
-    "mappings": [],
+    "primaryCoding": "ncit:C3163",
+    "mappings": [
+      84
+    ],
     "extensions": [
       {
         "name": "solid_tumor",

--- a/referenced/diseases.json
+++ b/referenced/diseases.json
@@ -3,7 +3,7 @@
     "id": 0,
     "conceptType": "Disease",
     "name": "Acute Lymphoid Leukemia",
-    "primaryCoding": "oncotree:ALL",
+    "primary_coding_id": "oncotree:ALL",
     "mappings": [],
     "extensions": [
       {
@@ -17,7 +17,7 @@
     "id": 1,
     "conceptType": "Disease",
     "name": "Acute Myeloid Leukemia",
-    "primaryCoding": "oncotree:AML",
+    "primary_coding_id": "oncotree:AML",
     "mappings": [],
     "extensions": [
       {
@@ -31,7 +31,7 @@
     "id": 2,
     "conceptType": "Disease",
     "name": "Adenocarcinoma of the Gastroesophageal Junction",
-    "primaryCoding": "oncotree:GEJ",
+    "primary_coding_id": "oncotree:GEJ",
     "mappings": [],
     "extensions": [
       {
@@ -45,7 +45,7 @@
     "id": 3,
     "conceptType": "Disease",
     "name": "Anaplastic Large Cell Lymphoma",
-    "primaryCoding": "oncotree:ALCL",
+    "primary_coding_id": "oncotree:ALCL",
     "mappings": [],
     "extensions": [
       {
@@ -59,7 +59,7 @@
     "id": 4,
     "conceptType": "Disease",
     "name": "Anaplastic Thyroid Cancer",
-    "primaryCoding": "oncotree:THAP",
+    "primary_coding_id": "oncotree:THAP",
     "mappings": [],
     "extensions": [
       {
@@ -73,7 +73,7 @@
     "id": 5,
     "conceptType": "Disease",
     "name": "Any solid tumor",
-    "primaryCoding": "ncit:C132146",
+    "primary_coding_id": "ncit:C132146",
     "mappings": [],
     "extensions": [
       {
@@ -87,7 +87,7 @@
     "id": 6,
     "conceptType": "Disease",
     "name": "Astrocytoma",
-    "primaryCoding": "oncotree:ASTR",
+    "primary_coding_id": "oncotree:ASTR",
     "mappings": [],
     "extensions": [
       {
@@ -101,7 +101,7 @@
     "id": 7,
     "conceptType": "Disease",
     "name": "B-Cell Acute Lymphoid Leukemia",
-    "primaryCoding": "oncotree:BALL",
+    "primary_coding_id": "oncotree:BALL",
     "mappings": [],
     "extensions": [
       {
@@ -115,7 +115,7 @@
     "id": 8,
     "conceptType": "Disease",
     "name": "Bladder Urothelial Carcinoma",
-    "primaryCoding": "oncotree:BLCA",
+    "primary_coding_id": "oncotree:BLCA",
     "mappings": [],
     "extensions": [
       {
@@ -129,7 +129,7 @@
     "id": 9,
     "conceptType": "Disease",
     "name": "Invasive Breast Carcinoma",
-    "primaryCoding": "oncotree:BRCA",
+    "primary_coding_id": "oncotree:BRCA",
     "mappings": [],
     "extensions": [
       {
@@ -143,7 +143,7 @@
     "id": 10,
     "conceptType": "Disease",
     "name": "APL with PML-RARA",
-    "primaryCoding": "oncotree:APLPMLRARA",
+    "primary_coding_id": "oncotree:APLPMLRARA",
     "mappings": [],
     "extensions": [
       {
@@ -157,7 +157,7 @@
     "id": 11,
     "conceptType": "Disease",
     "name": "Cholangiocarcinoma",
-    "primaryCoding": "oncotree:CHOL",
+    "primary_coding_id": "oncotree:CHOL",
     "mappings": [],
     "extensions": [
       {
@@ -171,7 +171,7 @@
     "id": 12,
     "conceptType": "Disease",
     "name": "Chronic Eosinophilic Leukemia, NOS",
-    "primaryCoding": "oncotree:CELNOS",
+    "primary_coding_id": "oncotree:CELNOS",
     "mappings": [],
     "extensions": [
       {
@@ -185,7 +185,7 @@
     "id": 13,
     "conceptType": "Disease",
     "name": "Chronic Myelogenous Leukemia",
-    "primaryCoding": "oncotree:CML",
+    "primary_coding_id": "oncotree:CML",
     "mappings": [],
     "extensions": [
       {
@@ -199,7 +199,7 @@
     "id": 14,
     "conceptType": "Disease",
     "name": "Chronic Myelomonocytic Leukemia",
-    "primaryCoding": "oncotree:CMML",
+    "primary_coding_id": "oncotree:CMML",
     "mappings": [],
     "extensions": [
       {
@@ -213,7 +213,7 @@
     "id": 15,
     "conceptType": "Disease",
     "name": "Colorectal Adenocarcinoma",
-    "primaryCoding": "oncotree:COADREAD",
+    "primary_coding_id": "oncotree:COADREAD",
     "mappings": [],
     "extensions": [
       {
@@ -227,7 +227,7 @@
     "id": 16,
     "conceptType": "Disease",
     "name": "Dedifferentiated Lipsarcoma",
-    "primaryCoding": "oncotree:DDLS",
+    "primary_coding_id": "oncotree:DDLS",
     "mappings": [],
     "extensions": [
       {
@@ -241,7 +241,7 @@
     "id": 17,
     "conceptType": "Disease",
     "name": "Dermatofibrosarcoma Protuberans",
-    "primaryCoding": "oncotree:DFSP",
+    "primary_coding_id": "oncotree:DFSP",
     "mappings": [],
     "extensions": [
       {
@@ -255,7 +255,7 @@
     "id": 18,
     "conceptType": "Disease",
     "name": "Endometrial Carcinoma",
-    "primaryCoding": "oncotree:UCEC",
+    "primary_coding_id": "oncotree:UCEC",
     "mappings": [],
     "extensions": [
       {
@@ -269,7 +269,7 @@
     "id": 19,
     "conceptType": "Disease",
     "name": "Ewing Sarcoma",
-    "primaryCoding": "oncotree:ES",
+    "primary_coding_id": "oncotree:ES",
     "mappings": [],
     "extensions": [
       {
@@ -283,7 +283,7 @@
     "id": 20,
     "conceptType": "Disease",
     "name": "Follicular Lymphoma",
-    "primaryCoding": "oncotree:FL",
+    "primary_coding_id": "oncotree:FL",
     "mappings": [],
     "extensions": [
       {
@@ -297,7 +297,7 @@
     "id": 21,
     "conceptType": "Disease",
     "name": "Gastric Remnant Adenocarcinoma",
-    "primaryCoding": "oncotree:GRC",
+    "primary_coding_id": "oncotree:GRC",
     "mappings": [],
     "extensions": [
       {
@@ -311,7 +311,7 @@
     "id": 22,
     "conceptType": "Disease",
     "name": "Gastrointestinal Stromal Tumor",
-    "primaryCoding": "oncotree:GIST",
+    "primary_coding_id": "oncotree:GIST",
     "mappings": [],
     "extensions": [
       {
@@ -325,7 +325,7 @@
     "id": 23,
     "conceptType": "Disease",
     "name": "Glioma",
-    "primaryCoding": "oncotree:GNOS",
+    "primary_coding_id": "oncotree:GNOS",
     "mappings": [],
     "extensions": [
       {
@@ -339,7 +339,7 @@
     "id": 24,
     "conceptType": "Disease",
     "name": "Head and Neck Mucosal Melanoma",
-    "primaryCoding": "oncotree:HNMUCM",
+    "primary_coding_id": "oncotree:HNMUCM",
     "mappings": [],
     "extensions": [
       {
@@ -353,7 +353,7 @@
     "id": 25,
     "conceptType": "Disease",
     "name": "Head and Neck Squamous Cell Carcinoma",
-    "primaryCoding": "oncotree:HNSC",
+    "primary_coding_id": "oncotree:HNSC",
     "mappings": [],
     "extensions": [
       {
@@ -367,7 +367,7 @@
     "id": 26,
     "conceptType": "Disease",
     "name": "High-Grade Neuroendocrine Carcinoma of the Colon and Rectum",
-    "primaryCoding": "oncotree:HGNEC",
+    "primary_coding_id": "oncotree:HGNEC",
     "mappings": [],
     "extensions": [
       {
@@ -381,7 +381,7 @@
     "id": 27,
     "conceptType": "Disease",
     "name": "High-Grade Serous Fallopian Tube Cancer",
-    "primaryCoding": "oncotree:HGSFT",
+    "primary_coding_id": "oncotree:HGSFT",
     "mappings": [],
     "extensions": [
       {
@@ -395,7 +395,7 @@
     "id": 28,
     "conceptType": "Disease",
     "name": "Inflammatory Myofibroblastic Tumor",
-    "primaryCoding": "oncotree:IMT",
+    "primary_coding_id": "oncotree:IMT",
     "mappings": [],
     "extensions": [
       {
@@ -409,7 +409,7 @@
     "id": 29,
     "conceptType": "Disease",
     "name": "Intrahepatic Cholangiocarcinoma",
-    "primaryCoding": "oncotree:IHCH",
+    "primary_coding_id": "oncotree:IHCH",
     "mappings": [],
     "extensions": [
       {
@@ -423,7 +423,7 @@
     "id": 30,
     "conceptType": "Disease",
     "name": "Cutaneous T-cell Lymphoma",
-    "primaryCoding": "ncit:C3467",
+    "primary_coding_id": "ncit:C3467",
     "mappings": [],
     "extensions": [
       {
@@ -437,7 +437,7 @@
     "id": 31,
     "conceptType": "Disease",
     "name": "Langerhans Cell Histiocytosis",
-    "primaryCoding": "oncotree:LCH",
+    "primary_coding_id": "oncotree:LCH",
     "mappings": [],
     "extensions": [
       {
@@ -451,7 +451,7 @@
     "id": 32,
     "conceptType": "Disease",
     "name": "Leiomyosarcoma",
-    "primaryCoding": "oncotree:LMS",
+    "primary_coding_id": "oncotree:LMS",
     "mappings": [],
     "extensions": [
       {
@@ -465,7 +465,7 @@
     "id": 33,
     "conceptType": "Disease",
     "name": "Leukemia",
-    "primaryCoding": "oncotree:LEUK",
+    "primary_coding_id": "oncotree:LEUK",
     "mappings": [],
     "extensions": [
       {
@@ -479,7 +479,7 @@
     "id": 34,
     "conceptType": "Disease",
     "name": "Liposarcoma",
-    "primaryCoding": "oncotree:LIPO",
+    "primary_coding_id": "oncotree:LIPO",
     "mappings": [],
     "extensions": [
       {
@@ -493,7 +493,7 @@
     "id": 35,
     "conceptType": "Disease",
     "name": "Low-Grade Glioma, NOS",
-    "primaryCoding": "oncotree:LGGNOS",
+    "primary_coding_id": "oncotree:LGGNOS",
     "mappings": [],
     "extensions": [
       {
@@ -507,7 +507,7 @@
     "id": 36,
     "conceptType": "Disease",
     "name": "Lung Squamous Cell Carcinoma",
-    "primaryCoding": "oncotree:LUSC",
+    "primary_coding_id": "oncotree:LUSC",
     "mappings": [],
     "extensions": [
       {
@@ -521,7 +521,7 @@
     "id": 37,
     "conceptType": "Disease",
     "name": "Mast Cell Leukemia",
-    "primaryCoding": "oncotree:SMMCL",
+    "primary_coding_id": "oncotree:SMMCL",
     "mappings": [],
     "extensions": [
       {
@@ -535,7 +535,7 @@
     "id": 38,
     "conceptType": "Disease",
     "name": "Medullary Thyroid Cancer",
-    "primaryCoding": "oncotree:THME",
+    "primary_coding_id": "oncotree:THME",
     "mappings": [],
     "extensions": [
       {
@@ -549,7 +549,7 @@
     "id": 39,
     "conceptType": "Disease",
     "name": "Medulloblastoma",
-    "primaryCoding": "oncotree:MBL",
+    "primary_coding_id": "oncotree:MBL",
     "mappings": [],
     "extensions": [
       {
@@ -563,7 +563,7 @@
     "id": 40,
     "conceptType": "Disease",
     "name": "Melanoma",
-    "primaryCoding": "oncotree:MEL",
+    "primary_coding_id": "oncotree:MEL",
     "mappings": [],
     "extensions": [
       {
@@ -577,7 +577,7 @@
     "id": 41,
     "conceptType": "Disease",
     "name": "Multiple Myeloma",
-    "primaryCoding": "oncotree:MM",
+    "primary_coding_id": "oncotree:MM",
     "mappings": [],
     "extensions": [
       {
@@ -591,7 +591,7 @@
     "id": 42,
     "conceptType": "Disease",
     "name": "Aggressive Systemic Mastocytosis",
-    "primaryCoding": "oncotree:ASM",
+    "primary_coding_id": "oncotree:ASM",
     "mappings": [],
     "extensions": [
       {
@@ -605,7 +605,7 @@
     "id": 43,
     "conceptType": "Disease",
     "name": "Myelodysplastic Syndromes",
-    "primaryCoding": "oncotree:MDS",
+    "primary_coding_id": "oncotree:MDS",
     "mappings": [],
     "extensions": [
       {
@@ -619,7 +619,7 @@
     "id": 44,
     "conceptType": "Disease",
     "name": "Myeloid/Lymphoid Neoplasms",
-    "primaryCoding": "oncotree:MLN",
+    "primary_coding_id": "oncotree:MLN",
     "mappings": [],
     "extensions": [
       {
@@ -633,7 +633,7 @@
     "id": 45,
     "conceptType": "Disease",
     "name": "Myeloproliferative Neoplasm",
-    "primaryCoding": "oncotree:MPN",
+    "primary_coding_id": "oncotree:MPN",
     "mappings": [],
     "extensions": [
       {
@@ -647,7 +647,7 @@
     "id": 46,
     "conceptType": "Disease",
     "name": "Non-Langerhans Cell Histiocytosis/Erdheim-Chester Disease",
-    "primaryCoding": "oncotree:ECD",
+    "primary_coding_id": "oncotree:ECD",
     "mappings": [],
     "extensions": [
       {
@@ -661,7 +661,7 @@
     "id": 47,
     "conceptType": "Disease",
     "name": "Non-Small Cell Lung Cancer",
-    "primaryCoding": "oncotree:NSCLC",
+    "primary_coding_id": "oncotree:NSCLC",
     "mappings": [],
     "extensions": [
       {
@@ -675,7 +675,7 @@
     "id": 48,
     "conceptType": "Disease",
     "name": "Oligodendroglioma",
-    "primaryCoding": "oncotree:ODG",
+    "primary_coding_id": "oncotree:ODG",
     "mappings": [],
     "extensions": [
       {
@@ -689,7 +689,7 @@
     "id": 49,
     "conceptType": "Disease",
     "name": "Osteosarcoma",
-    "primaryCoding": "oncotree:OS",
+    "primary_coding_id": "oncotree:OS",
     "mappings": [],
     "extensions": [
       {
@@ -703,7 +703,7 @@
     "id": 50,
     "conceptType": "Disease",
     "name": "Ovarian Cancer, Other",
-    "primaryCoding": "oncotree:OOVC",
+    "primary_coding_id": "oncotree:OOVC",
     "mappings": [],
     "extensions": [
       {
@@ -717,7 +717,7 @@
     "id": 51,
     "conceptType": "Disease",
     "name": "Ovarian Epithelial Tumor",
-    "primaryCoding": "oncotree:OVT",
+    "primary_coding_id": "oncotree:OVT",
     "mappings": [],
     "extensions": [
       {
@@ -731,7 +731,7 @@
     "id": 52,
     "conceptType": "Disease",
     "name": "Pancreatic Adenocarcinoma",
-    "primaryCoding": "oncotree:PAAD",
+    "primary_coding_id": "oncotree:PAAD",
     "mappings": [],
     "extensions": [
       {
@@ -745,7 +745,7 @@
     "id": 53,
     "conceptType": "Disease",
     "name": "Peritoneal Mesothelioma",
-    "primaryCoding": "oncotree:PEMESO",
+    "primary_coding_id": "oncotree:PEMESO",
     "mappings": [],
     "extensions": [
       {
@@ -759,7 +759,7 @@
     "id": 54,
     "conceptType": "Disease",
     "name": "Peritoneal Serous Carcinoma",
-    "primaryCoding": "oncotree:PSEC",
+    "primary_coding_id": "oncotree:PSEC",
     "mappings": [],
     "extensions": [
       {
@@ -773,7 +773,7 @@
     "id": 55,
     "conceptType": "Disease",
     "name": "Prostate Adenocarcinoma",
-    "primaryCoding": "oncotree:PRAD",
+    "primary_coding_id": "oncotree:PRAD",
     "mappings": [],
     "extensions": [
       {
@@ -787,7 +787,7 @@
     "id": 56,
     "conceptType": "Disease",
     "name": "Prostate Neuroendocrine Cancer",
-    "primaryCoding": "oncotree:PRNE",
+    "primary_coding_id": "oncotree:PRNE",
     "mappings": [],
     "extensions": [
       {
@@ -801,7 +801,7 @@
     "id": 57,
     "conceptType": "Disease",
     "name": "Rectal Adenocarcinoma",
-    "primaryCoding": "oncotree:READ",
+    "primary_coding_id": "oncotree:READ",
     "mappings": [],
     "extensions": [
       {
@@ -815,7 +815,7 @@
     "id": 58,
     "conceptType": "Disease",
     "name": "Renal Cell Carcinoma",
-    "primaryCoding": "oncotree:RCC",
+    "primary_coding_id": "oncotree:RCC",
     "mappings": [],
     "extensions": [
       {
@@ -829,7 +829,7 @@
     "id": 59,
     "conceptType": "Disease",
     "name": "Renal Clear Cell Carcinoma",
-    "primaryCoding": "oncotree:CCRCC",
+    "primary_coding_id": "oncotree:CCRCC",
     "mappings": [],
     "extensions": [
       {
@@ -843,7 +843,7 @@
     "id": 60,
     "conceptType": "Disease",
     "name": "Serous Ovarian Cancer",
-    "primaryCoding": "oncotree:SOC",
+    "primary_coding_id": "oncotree:SOC",
     "mappings": [],
     "extensions": [
       {
@@ -857,7 +857,7 @@
     "id": 61,
     "conceptType": "Disease",
     "name": "Small Cell Lung Cancer",
-    "primaryCoding": "oncotree:SCLC",
+    "primary_coding_id": "oncotree:SCLC",
     "mappings": [],
     "extensions": [
       {
@@ -871,7 +871,7 @@
     "id": 62,
     "conceptType": "Disease",
     "name": "Squamous Cell Carcinoma, NOS",
-    "primaryCoding": "oncotree:SCCNOS",
+    "primary_coding_id": "oncotree:SCCNOS",
     "mappings": [],
     "extensions": [
       {
@@ -885,7 +885,7 @@
     "id": 63,
     "conceptType": "Disease",
     "name": "Stomach Adenocarcinoma",
-    "primaryCoding": "oncotree:STAD",
+    "primary_coding_id": "oncotree:STAD",
     "mappings": [],
     "extensions": [
       {
@@ -899,7 +899,7 @@
     "id": 64,
     "conceptType": "Disease",
     "name": "T-Cell Acute Lymphoid Leukemia",
-    "primaryCoding": "oncotree:TALL",
+    "primary_coding_id": "oncotree:TALL",
     "mappings": [],
     "extensions": [
       {
@@ -913,7 +913,7 @@
     "id": 65,
     "conceptType": "Disease",
     "name": "Testicular Germ Cell Tumors",
-    "primaryCoding": "oncotree:TGCT",
+    "primary_coding_id": "oncotree:TGCT",
     "mappings": [],
     "extensions": [
       {
@@ -927,7 +927,7 @@
     "id": 66,
     "conceptType": "Disease",
     "name": "Thymic Carcinoma",
-    "primaryCoding": "oncotree:THYC",
+    "primary_coding_id": "oncotree:THYC",
     "mappings": [],
     "extensions": [
       {
@@ -941,7 +941,7 @@
     "id": 67,
     "conceptType": "Disease",
     "name": "Urethral Urothelial Carcinoma",
-    "primaryCoding": "oncotree:UCU",
+    "primary_coding_id": "oncotree:UCU",
     "mappings": [],
     "extensions": [
       {
@@ -955,7 +955,7 @@
     "id": 68,
     "conceptType": "Disease",
     "name": "Uterine Leiomyoma",
-    "primaryCoding": "oncotree:ULM",
+    "primary_coding_id": "oncotree:ULM",
     "mappings": [],
     "extensions": [
       {
@@ -969,7 +969,7 @@
     "id": 69,
     "conceptType": "Disease",
     "name": "Uterine Leiomyosarcoma",
-    "primaryCoding": "oncotree:ULMS",
+    "primary_coding_id": "oncotree:ULMS",
     "mappings": [],
     "extensions": [
       {
@@ -983,7 +983,7 @@
     "id": 70,
     "conceptType": "Disease",
     "name": "Well-Differentiated Liposarcoma",
-    "primaryCoding": "oncotree:WDLS",
+    "primary_coding_id": "oncotree:WDLS",
     "mappings": [],
     "extensions": [
       {
@@ -997,7 +997,7 @@
     "id": 71,
     "conceptType": "Disease",
     "name": "Chronic Myeloid Leukemia, BCR-ABL1+",
-    "primaryCoding": "oncotree:CMLBCRABL1",
+    "primary_coding_id": "oncotree:CMLBCRABL1",
     "mappings": [],
     "extensions": [
       {
@@ -1011,7 +1011,7 @@
     "id": 72,
     "conceptType": "Disease",
     "name": "Cervical Adenocarcinoma",
-    "primaryCoding": "oncotree:CEAD",
+    "primary_coding_id": "oncotree:CEAD",
     "mappings": [],
     "extensions": [
       {
@@ -1025,7 +1025,7 @@
     "id": 73,
     "conceptType": "Disease",
     "name": "Cervical Squamous Cell Carcinoma",
-    "primaryCoding": "oncotree:CESC",
+    "primary_coding_id": "oncotree:CESC",
     "mappings": [],
     "extensions": [
       {
@@ -1039,7 +1039,7 @@
     "id": 74,
     "conceptType": "Disease",
     "name": "Esophageal Adenocarcinoma",
-    "primaryCoding": "oncotree:ESCA",
+    "primary_coding_id": "oncotree:ESCA",
     "mappings": [],
     "extensions": [
       {
@@ -1053,7 +1053,7 @@
     "id": 75,
     "conceptType": "Disease",
     "name": "Papillary Thyroid Cancer",
-    "primaryCoding": "oncotree:THPA",
+    "primary_coding_id": "oncotree:THPA",
     "mappings": [],
     "extensions": [
       {
@@ -1067,7 +1067,7 @@
     "id": 76,
     "conceptType": "Disease",
     "name": "Non-Hodgkin Lymphoma",
-    "primaryCoding": "oncotree:NHL",
+    "primary_coding_id": "oncotree:NHL",
     "mappings": [],
     "extensions": [
       {
@@ -1081,7 +1081,7 @@
     "id": 77,
     "conceptType": "Disease",
     "name": "Diffuse Large B-Cell Lymphoma",
-    "primaryCoding": "oncotree:DLBCLNOS",
+    "primary_coding_id": "oncotree:DLBCLNOS",
     "mappings": [],
     "extensions": [
       {
@@ -1095,7 +1095,7 @@
     "id": 78,
     "conceptType": "Disease",
     "name": "Burkitt Lymphoma",
-    "primaryCoding": "oncotree:BL",
+    "primary_coding_id": "oncotree:BL",
     "mappings": [],
     "extensions": [
       {
@@ -1109,7 +1109,7 @@
     "id": 79,
     "conceptType": "Disease",
     "name": "Mature B-Cell Neoplasms",
-    "primaryCoding": "oncotree:MBN",
+    "primary_coding_id": "oncotree:MBN",
     "mappings": [],
     "extensions": [
       {
@@ -1123,7 +1123,7 @@
     "id": 80,
     "conceptType": "Disease",
     "name": "Hodgkin Lymphoma",
-    "primaryCoding": "oncotree:HL",
+    "primary_coding_id": "oncotree:HL",
     "mappings": [],
     "extensions": [
       {
@@ -1137,7 +1137,7 @@
     "id": 81,
     "conceptType": "Disease",
     "name": "Esophagogastric Adenocarcinoma",
-    "primaryCoding": "oncotree:EGC",
+    "primary_coding_id": "oncotree:EGC",
     "mappings": [],
     "extensions": [
       {
@@ -1151,7 +1151,7 @@
     "id": 82,
     "conceptType": "Disease",
     "name": "Esophageal Squamous Cell Carcinoma",
-    "primaryCoding": "oncotree:ESCC",
+    "primary_coding_id": "oncotree:ESCC",
     "mappings": [],
     "extensions": [
       {
@@ -1165,7 +1165,7 @@
     "id": 83,
     "conceptType": "Disease",
     "name": "High-Grade Glioma, NOS",
-    "primaryCoding": "oncotree:HGGNOS",
+    "primary_coding_id": "oncotree:HGGNOS",
     "mappings": [],
     "extensions": [
       {
@@ -1179,7 +1179,7 @@
     "id": 84,
     "conceptType": "Disease",
     "name": "Chronic Lymphocytic Leukemia",
-    "primaryCoding": "ncit:C3163",
+    "primary_coding_id": "ncit:C3163",
     "mappings": [
       175
     ],
@@ -1195,7 +1195,7 @@
     "id": 85,
     "conceptType": "Disease",
     "name": "Intraductal Papillary Neoplasm of the Bile Duct",
-    "primaryCoding": "oncotree:IPN",
+    "primary_coding_id": "oncotree:IPN",
     "mappings": [],
     "extensions": [
       {
@@ -1209,7 +1209,7 @@
     "id": 86,
     "conceptType": "Disease",
     "name": "Intracholecystic Papillary Neoplasm",
-    "primaryCoding": "oncotree:ICPN",
+    "primary_coding_id": "oncotree:ICPN",
     "mappings": [],
     "extensions": [
       {
@@ -1223,7 +1223,7 @@
     "id": 87,
     "conceptType": "Disease",
     "name": "Acute Leukemias of Ambiguous Lineage",
-    "primaryCoding": "oncotree:ALAL",
+    "primary_coding_id": "oncotree:ALAL",
     "mappings": [],
     "extensions": [
       {
@@ -1237,7 +1237,7 @@
     "id": 88,
     "conceptType": "Disease",
     "name": "Renal Angiomyolipoma",
-    "primaryCoding": "oncotree:RAML",
+    "primary_coding_id": "oncotree:RAML",
     "mappings": [],
     "extensions": [
       {

--- a/referenced/diseases.json
+++ b/referenced/diseases.json
@@ -3,18 +3,9 @@
     "id": 0,
     "conceptType": "Disease",
     "name": "Acute Lymphoid Leukemia",
-    "primaryCode": "oncotree:ALL",
+    "primaryCoding": "oncotree:ALL",
     "mappings": [
-      {
-        "coding": {
-          "id": "oncotree:ALL",
-          "code": "ALL",
-          "name": "Acute Lymphoid Leukemia",
-          "system": "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=",
-          "systemVersion": "oncotree_2021_11_02"
-        },
-        "relation": "exactMatch"
-      }
+      0
     ],
     "extensions": [
       {
@@ -28,18 +19,9 @@
     "id": 1,
     "conceptType": "Disease",
     "name": "Acute Myeloid Leukemia",
-    "primaryCode": "oncotree:AML",
+    "primaryCoding": "oncotree:AML",
     "mappings": [
-      {
-        "coding": {
-          "id": "oncotree:AML",
-          "code": "AML",
-          "name": "Acute Myeloid Leukemia",
-          "system": "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=",
-          "systemVersion": "oncotree_2021_11_02"
-        },
-        "relation": "exactMatch"
-      }
+      1
     ],
     "extensions": [
       {
@@ -53,18 +35,9 @@
     "id": 2,
     "conceptType": "Disease",
     "name": "Adenocarcinoma of the Gastroesophageal Junction",
-    "primaryCode": "oncotree:GEJ",
+    "primaryCoding": "oncotree:GEJ",
     "mappings": [
-      {
-        "coding": {
-          "id": "oncotree:GEJ",
-          "code": "GEJ",
-          "name": "Adenocarcinoma of the Gastroesophageal Junction",
-          "system": "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=",
-          "systemVersion": "oncotree_2021_11_02"
-        },
-        "relation": "exactMatch"
-      }
+      2
     ],
     "extensions": [
       {
@@ -78,18 +51,9 @@
     "id": 3,
     "conceptType": "Disease",
     "name": "Anaplastic Large Cell Lymphoma",
-    "primaryCode": "oncotree:ALCL",
+    "primaryCoding": "oncotree:ALCL",
     "mappings": [
-      {
-        "coding": {
-          "id": "oncotree:ALCL",
-          "code": "ALCL",
-          "name": "Anaplastic Large Cell Lymphoma",
-          "system": "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=",
-          "systemVersion": "oncotree_2021_11_02"
-        },
-        "relation": "exactMatch"
-      }
+      3
     ],
     "extensions": [
       {
@@ -103,18 +67,9 @@
     "id": 4,
     "conceptType": "Disease",
     "name": "Anaplastic Thyroid Cancer",
-    "primaryCode": "oncotree:THAP",
+    "primaryCoding": "oncotree:THAP",
     "mappings": [
-      {
-        "coding": {
-          "id": "oncotree:THAP",
-          "code": "THAP",
-          "name": "Anaplastic Thyroid Cancer",
-          "system": "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=",
-          "systemVersion": "oncotree_2021_11_02"
-        },
-        "relation": "exactMatch"
-      }
+      4
     ],
     "extensions": [
       {
@@ -128,19 +83,8 @@
     "id": 5,
     "conceptType": "Disease",
     "name": "Any solid tumor",
-    "primaryCode": "oncotree:",
-    "mappings": [
-      {
-        "coding": {
-          "id": "oncotree:",
-          "code": "",
-          "name": "",
-          "system": "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=",
-          "systemVersion": "oncotree_2021_11_02"
-        },
-        "relation": "exactMatch"
-      }
-    ],
+    "primaryCoding": "oncotree:",
+    "mappings": [],
     "extensions": [
       {
         "name": "solid_tumor",
@@ -153,18 +97,9 @@
     "id": 6,
     "conceptType": "Disease",
     "name": "Astrocytoma",
-    "primaryCode": "oncotree:ASTR",
+    "primaryCoding": "oncotree:ASTR",
     "mappings": [
-      {
-        "coding": {
-          "id": "oncotree:ASTR",
-          "code": "ASTR",
-          "name": "Astrocytoma",
-          "system": "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=",
-          "systemVersion": "oncotree_2021_11_02"
-        },
-        "relation": "exactMatch"
-      }
+      6
     ],
     "extensions": [
       {
@@ -178,18 +113,9 @@
     "id": 7,
     "conceptType": "Disease",
     "name": "B-Cell Acute Lymphoid Leukemia",
-    "primaryCode": "oncotree:BALL",
+    "primaryCoding": "oncotree:BALL",
     "mappings": [
-      {
-        "coding": {
-          "id": "oncotree:BALL",
-          "code": "BALL",
-          "name": "B-Cell Acute Lymphoid Leukemia",
-          "system": "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=",
-          "systemVersion": "oncotree_2021_11_02"
-        },
-        "relation": "exactMatch"
-      }
+      7
     ],
     "extensions": [
       {
@@ -203,18 +129,9 @@
     "id": 8,
     "conceptType": "Disease",
     "name": "Bladder Urothelial Carcinoma",
-    "primaryCode": "oncotree:BLCA",
+    "primaryCoding": "oncotree:BLCA",
     "mappings": [
-      {
-        "coding": {
-          "id": "oncotree:BLCA",
-          "code": "BLCA",
-          "name": "Bladder Urothelial Carcinoma",
-          "system": "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=",
-          "systemVersion": "oncotree_2021_11_02"
-        },
-        "relation": "exactMatch"
-      }
+      8
     ],
     "extensions": [
       {
@@ -228,18 +145,9 @@
     "id": 9,
     "conceptType": "Disease",
     "name": "Invasive Breast Carcinoma",
-    "primaryCode": "oncotree:BRCA",
+    "primaryCoding": "oncotree:BRCA",
     "mappings": [
-      {
-        "coding": {
-          "id": "oncotree:BRCA",
-          "code": "BRCA",
-          "name": "Invasive Breast Carcinoma",
-          "system": "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=",
-          "systemVersion": "oncotree_2021_11_02"
-        },
-        "relation": "exactMatch"
-      }
+      9
     ],
     "extensions": [
       {
@@ -253,18 +161,9 @@
     "id": 10,
     "conceptType": "Disease",
     "name": "APL with PML-RARA",
-    "primaryCode": "oncotree:APLPMLRARA",
+    "primaryCoding": "oncotree:APLPMLRARA",
     "mappings": [
-      {
-        "coding": {
-          "id": "oncotree:APLPMLRARA",
-          "code": "APLPMLRARA",
-          "name": "APL with PML-RARA",
-          "system": "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=",
-          "systemVersion": "oncotree_2021_11_02"
-        },
-        "relation": "exactMatch"
-      }
+      10
     ],
     "extensions": [
       {
@@ -278,18 +177,9 @@
     "id": 11,
     "conceptType": "Disease",
     "name": "Cholangiocarcinoma",
-    "primaryCode": "oncotree:CHOL",
+    "primaryCoding": "oncotree:CHOL",
     "mappings": [
-      {
-        "coding": {
-          "id": "oncotree:CHOL",
-          "code": "CHOL",
-          "name": "Cholangiocarcinoma",
-          "system": "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=",
-          "systemVersion": "oncotree_2021_11_02"
-        },
-        "relation": "exactMatch"
-      }
+      11
     ],
     "extensions": [
       {
@@ -303,18 +193,9 @@
     "id": 12,
     "conceptType": "Disease",
     "name": "Chronic Eosinophilic Leukemia, NOS",
-    "primaryCode": "oncotree:CELNOS",
+    "primaryCoding": "oncotree:CELNOS",
     "mappings": [
-      {
-        "coding": {
-          "id": "oncotree:CELNOS",
-          "code": "CELNOS",
-          "name": "Chronic Eosinophilic Leukemia, NOS",
-          "system": "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=",
-          "systemVersion": "oncotree_2021_11_02"
-        },
-        "relation": "exactMatch"
-      }
+      12
     ],
     "extensions": [
       {
@@ -328,18 +209,9 @@
     "id": 13,
     "conceptType": "Disease",
     "name": "Chronic Myelogenous Leukemia",
-    "primaryCode": "oncotree:CML",
+    "primaryCoding": "oncotree:CML",
     "mappings": [
-      {
-        "coding": {
-          "id": "oncotree:CML",
-          "code": "CML",
-          "name": "Chronic Myelogenous Leukemia",
-          "system": "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=",
-          "systemVersion": "oncotree_2021_11_02"
-        },
-        "relation": "exactMatch"
-      }
+      13
     ],
     "extensions": [
       {
@@ -353,18 +225,9 @@
     "id": 14,
     "conceptType": "Disease",
     "name": "Chronic Myelomonocytic Leukemia",
-    "primaryCode": "oncotree:CMML",
+    "primaryCoding": "oncotree:CMML",
     "mappings": [
-      {
-        "coding": {
-          "id": "oncotree:CMML",
-          "code": "CMML",
-          "name": "Chronic Myelomonocytic Leukemia",
-          "system": "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=",
-          "systemVersion": "oncotree_2021_11_02"
-        },
-        "relation": "exactMatch"
-      }
+      14
     ],
     "extensions": [
       {
@@ -378,18 +241,9 @@
     "id": 15,
     "conceptType": "Disease",
     "name": "Colorectal Adenocarcinoma",
-    "primaryCode": "oncotree:COADREAD",
+    "primaryCoding": "oncotree:COADREAD",
     "mappings": [
-      {
-        "coding": {
-          "id": "oncotree:COADREAD",
-          "code": "COADREAD",
-          "name": "Colorectal Adenocarcinoma",
-          "system": "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=",
-          "systemVersion": "oncotree_2021_11_02"
-        },
-        "relation": "exactMatch"
-      }
+      15
     ],
     "extensions": [
       {
@@ -403,18 +257,9 @@
     "id": 16,
     "conceptType": "Disease",
     "name": "Dedifferentiated Lipsarcoma",
-    "primaryCode": "oncotree:DDLS",
+    "primaryCoding": "oncotree:DDLS",
     "mappings": [
-      {
-        "coding": {
-          "id": "oncotree:DDLS",
-          "code": "DDLS",
-          "name": "Dedifferentiated Lipsarcoma",
-          "system": "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=",
-          "systemVersion": "oncotree_2021_11_02"
-        },
-        "relation": "exactMatch"
-      }
+      16
     ],
     "extensions": [
       {
@@ -428,18 +273,9 @@
     "id": 17,
     "conceptType": "Disease",
     "name": "Dermatofibrosarcoma Protuberans",
-    "primaryCode": "oncotree:DFSP",
+    "primaryCoding": "oncotree:DFSP",
     "mappings": [
-      {
-        "coding": {
-          "id": "oncotree:DFSP",
-          "code": "DFSP",
-          "name": "Dermatofibrosarcoma Protuberans",
-          "system": "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=",
-          "systemVersion": "oncotree_2021_11_02"
-        },
-        "relation": "exactMatch"
-      }
+      17
     ],
     "extensions": [
       {
@@ -453,18 +289,9 @@
     "id": 18,
     "conceptType": "Disease",
     "name": "Endometrial Carcinoma",
-    "primaryCode": "oncotree:UCEC",
+    "primaryCoding": "oncotree:UCEC",
     "mappings": [
-      {
-        "coding": {
-          "id": "oncotree:UCEC",
-          "code": "UCEC",
-          "name": "Endometrial Carcinoma",
-          "system": "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=",
-          "systemVersion": "oncotree_2021_11_02"
-        },
-        "relation": "exactMatch"
-      }
+      18
     ],
     "extensions": [
       {
@@ -478,18 +305,9 @@
     "id": 19,
     "conceptType": "Disease",
     "name": "Ewing Sarcoma",
-    "primaryCode": "oncotree:ES",
+    "primaryCoding": "oncotree:ES",
     "mappings": [
-      {
-        "coding": {
-          "id": "oncotree:ES",
-          "code": "ES",
-          "name": "Ewing Sarcoma",
-          "system": "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=",
-          "systemVersion": "oncotree_2021_11_02"
-        },
-        "relation": "exactMatch"
-      }
+      19
     ],
     "extensions": [
       {
@@ -503,18 +321,9 @@
     "id": 20,
     "conceptType": "Disease",
     "name": "Follicular Lymphoma",
-    "primaryCode": "oncotree:FL",
+    "primaryCoding": "oncotree:FL",
     "mappings": [
-      {
-        "coding": {
-          "id": "oncotree:FL",
-          "code": "FL",
-          "name": "Follicular Lymphoma",
-          "system": "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=",
-          "systemVersion": "oncotree_2021_11_02"
-        },
-        "relation": "exactMatch"
-      }
+      20
     ],
     "extensions": [
       {
@@ -528,18 +337,9 @@
     "id": 21,
     "conceptType": "Disease",
     "name": "Gastric Remnant Adenocarcinoma",
-    "primaryCode": "oncotree:GRC",
+    "primaryCoding": "oncotree:GRC",
     "mappings": [
-      {
-        "coding": {
-          "id": "oncotree:GRC",
-          "code": "GRC",
-          "name": "Gastric Remnant Adenocarcinoma",
-          "system": "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=",
-          "systemVersion": "oncotree_2021_11_02"
-        },
-        "relation": "exactMatch"
-      }
+      21
     ],
     "extensions": [
       {
@@ -553,18 +353,9 @@
     "id": 22,
     "conceptType": "Disease",
     "name": "Gastrointestinal Stromal Tumor",
-    "primaryCode": "oncotree:GIST",
+    "primaryCoding": "oncotree:GIST",
     "mappings": [
-      {
-        "coding": {
-          "id": "oncotree:GIST",
-          "code": "GIST",
-          "name": "Gastrointestinal Stromal Tumor",
-          "system": "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=",
-          "systemVersion": "oncotree_2021_11_02"
-        },
-        "relation": "exactMatch"
-      }
+      22
     ],
     "extensions": [
       {
@@ -578,18 +369,9 @@
     "id": 23,
     "conceptType": "Disease",
     "name": "Glioma",
-    "primaryCode": "oncotree:GNOS",
+    "primaryCoding": "oncotree:GNOS",
     "mappings": [
-      {
-        "coding": {
-          "id": "oncotree:GNOS",
-          "code": "GNOS",
-          "name": "Glioma",
-          "system": "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=",
-          "systemVersion": "oncotree_2021_11_02"
-        },
-        "relation": "exactMatch"
-      }
+      23
     ],
     "extensions": [
       {
@@ -603,18 +385,9 @@
     "id": 24,
     "conceptType": "Disease",
     "name": "Head and Neck Mucosal Melanoma",
-    "primaryCode": "oncotree:HNMUCM",
+    "primaryCoding": "oncotree:HNMUCM",
     "mappings": [
-      {
-        "coding": {
-          "id": "oncotree:HNMUCM",
-          "code": "HNMUCM",
-          "name": "Head and Neck Mucosal Melanoma",
-          "system": "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=",
-          "systemVersion": "oncotree_2021_11_02"
-        },
-        "relation": "exactMatch"
-      }
+      24
     ],
     "extensions": [
       {
@@ -628,18 +401,9 @@
     "id": 25,
     "conceptType": "Disease",
     "name": "Head and Neck Squamous Cell Carcinoma",
-    "primaryCode": "oncotree:HNSC",
+    "primaryCoding": "oncotree:HNSC",
     "mappings": [
-      {
-        "coding": {
-          "id": "oncotree:HNSC",
-          "code": "HNSC",
-          "name": "Head and Neck Squamous Cell Carcinoma",
-          "system": "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=",
-          "systemVersion": "oncotree_2021_11_02"
-        },
-        "relation": "exactMatch"
-      }
+      25
     ],
     "extensions": [
       {
@@ -653,18 +417,9 @@
     "id": 26,
     "conceptType": "Disease",
     "name": "High-Grade Neuroendocrine Carcinoma of the Colon and Rectum",
-    "primaryCode": "oncotree:HGNEC",
+    "primaryCoding": "oncotree:HGNEC",
     "mappings": [
-      {
-        "coding": {
-          "id": "oncotree:HGNEC",
-          "code": "HGNEC",
-          "name": "High-Grade Neuroendocrine Carcinoma of the Colon and Rectum",
-          "system": "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=",
-          "systemVersion": "oncotree_2021_11_02"
-        },
-        "relation": "exactMatch"
-      }
+      26
     ],
     "extensions": [
       {
@@ -678,18 +433,9 @@
     "id": 27,
     "conceptType": "Disease",
     "name": "High-Grade Serous Fallopian Tube Cancer",
-    "primaryCode": "oncotree:HGSFT",
+    "primaryCoding": "oncotree:HGSFT",
     "mappings": [
-      {
-        "coding": {
-          "id": "oncotree:HGSFT",
-          "code": "HGSFT",
-          "name": "High-Grade Serous Fallopian Tube Cancer",
-          "system": "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=",
-          "systemVersion": "oncotree_2021_11_02"
-        },
-        "relation": "exactMatch"
-      }
+      27
     ],
     "extensions": [
       {
@@ -703,18 +449,9 @@
     "id": 28,
     "conceptType": "Disease",
     "name": "Inflammatory Myofibroblastic Tumor",
-    "primaryCode": "oncotree:IMT",
+    "primaryCoding": "oncotree:IMT",
     "mappings": [
-      {
-        "coding": {
-          "id": "oncotree:IMT",
-          "code": "IMT",
-          "name": "Inflammatory Myofibroblastic Tumor",
-          "system": "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=",
-          "systemVersion": "oncotree_2021_11_02"
-        },
-        "relation": "exactMatch"
-      }
+      28
     ],
     "extensions": [
       {
@@ -728,18 +465,9 @@
     "id": 29,
     "conceptType": "Disease",
     "name": "Intrahepatic Cholangiocarcinoma",
-    "primaryCode": "oncotree:IHCH",
+    "primaryCoding": "oncotree:IHCH",
     "mappings": [
-      {
-        "coding": {
-          "id": "oncotree:IHCH",
-          "code": "IHCH",
-          "name": "Intrahepatic Cholangiocarcinoma",
-          "system": "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=",
-          "systemVersion": "oncotree_2021_11_02"
-        },
-        "relation": "exactMatch"
-      }
+      29
     ],
     "extensions": [
       {
@@ -753,19 +481,8 @@
     "id": 30,
     "conceptType": "Disease",
     "name": "Cutaneous T-cell Lymphoma",
-    "primaryCode": "oncotree:",
-    "mappings": [
-      {
-        "coding": {
-          "id": "oncotree:",
-          "code": "",
-          "name": "",
-          "system": "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=",
-          "systemVersion": "oncotree_2021_11_02"
-        },
-        "relation": "exactMatch"
-      }
-    ],
+    "primaryCoding": "oncotree:",
+    "mappings": [],
     "extensions": [
       {
         "name": "solid_tumor",
@@ -778,18 +495,9 @@
     "id": 31,
     "conceptType": "Disease",
     "name": "Langerhans Cell Histiocytosis",
-    "primaryCode": "oncotree:LCH",
+    "primaryCoding": "oncotree:LCH",
     "mappings": [
-      {
-        "coding": {
-          "id": "oncotree:LCH",
-          "code": "LCH",
-          "name": "Langerhans Cell Histiocytosis",
-          "system": "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=",
-          "systemVersion": "oncotree_2021_11_02"
-        },
-        "relation": "exactMatch"
-      }
+      31
     ],
     "extensions": [
       {
@@ -803,18 +511,9 @@
     "id": 32,
     "conceptType": "Disease",
     "name": "Leiomyosarcoma",
-    "primaryCode": "oncotree:LMS",
+    "primaryCoding": "oncotree:LMS",
     "mappings": [
-      {
-        "coding": {
-          "id": "oncotree:LMS",
-          "code": "LMS",
-          "name": "Leiomyosarcoma",
-          "system": "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=",
-          "systemVersion": "oncotree_2021_11_02"
-        },
-        "relation": "exactMatch"
-      }
+      32
     ],
     "extensions": [
       {
@@ -828,18 +527,9 @@
     "id": 33,
     "conceptType": "Disease",
     "name": "Leukemia",
-    "primaryCode": "oncotree:LEUK",
+    "primaryCoding": "oncotree:LEUK",
     "mappings": [
-      {
-        "coding": {
-          "id": "oncotree:LEUK",
-          "code": "LEUK",
-          "name": "Leukemia",
-          "system": "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=",
-          "systemVersion": "oncotree_2021_11_02"
-        },
-        "relation": "exactMatch"
-      }
+      33
     ],
     "extensions": [
       {
@@ -853,18 +543,9 @@
     "id": 34,
     "conceptType": "Disease",
     "name": "Liposarcoma",
-    "primaryCode": "oncotree:LIPO",
+    "primaryCoding": "oncotree:LIPO",
     "mappings": [
-      {
-        "coding": {
-          "id": "oncotree:LIPO",
-          "code": "LIPO",
-          "name": "Liposarcoma",
-          "system": "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=",
-          "systemVersion": "oncotree_2021_11_02"
-        },
-        "relation": "exactMatch"
-      }
+      34
     ],
     "extensions": [
       {
@@ -878,18 +559,9 @@
     "id": 35,
     "conceptType": "Disease",
     "name": "Low-Grade Glioma, NOS",
-    "primaryCode": "oncotree:LGGNOS",
+    "primaryCoding": "oncotree:LGGNOS",
     "mappings": [
-      {
-        "coding": {
-          "id": "oncotree:LGGNOS",
-          "code": "LGGNOS",
-          "name": "Low-Grade Glioma, NOS",
-          "system": "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=",
-          "systemVersion": "oncotree_2021_11_02"
-        },
-        "relation": "exactMatch"
-      }
+      35
     ],
     "extensions": [
       {
@@ -903,18 +575,9 @@
     "id": 36,
     "conceptType": "Disease",
     "name": "Lung Squamous Cell Carcinoma",
-    "primaryCode": "oncotree:LUSC",
+    "primaryCoding": "oncotree:LUSC",
     "mappings": [
-      {
-        "coding": {
-          "id": "oncotree:LUSC",
-          "code": "LUSC",
-          "name": "Lung Squamous Cell Carcinoma",
-          "system": "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=",
-          "systemVersion": "oncotree_2021_11_02"
-        },
-        "relation": "exactMatch"
-      }
+      36
     ],
     "extensions": [
       {
@@ -928,18 +591,9 @@
     "id": 37,
     "conceptType": "Disease",
     "name": "Mast Cell Leukemia",
-    "primaryCode": "oncotree:SMMCL",
+    "primaryCoding": "oncotree:SMMCL",
     "mappings": [
-      {
-        "coding": {
-          "id": "oncotree:SMMCL",
-          "code": "SMMCL",
-          "name": "Mast Cell Leukemia",
-          "system": "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=",
-          "systemVersion": "oncotree_2021_11_02"
-        },
-        "relation": "exactMatch"
-      }
+      37
     ],
     "extensions": [
       {
@@ -953,18 +607,9 @@
     "id": 38,
     "conceptType": "Disease",
     "name": "Medullary Thyroid Cancer",
-    "primaryCode": "oncotree:THME",
+    "primaryCoding": "oncotree:THME",
     "mappings": [
-      {
-        "coding": {
-          "id": "oncotree:THME",
-          "code": "THME",
-          "name": "Medullary Thyroid Cancer",
-          "system": "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=",
-          "systemVersion": "oncotree_2021_11_02"
-        },
-        "relation": "exactMatch"
-      }
+      38
     ],
     "extensions": [
       {
@@ -978,18 +623,9 @@
     "id": 39,
     "conceptType": "Disease",
     "name": "Medulloblastoma",
-    "primaryCode": "oncotree:MBL",
+    "primaryCoding": "oncotree:MBL",
     "mappings": [
-      {
-        "coding": {
-          "id": "oncotree:MBL",
-          "code": "MBL",
-          "name": "Medulloblastoma",
-          "system": "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=",
-          "systemVersion": "oncotree_2021_11_02"
-        },
-        "relation": "exactMatch"
-      }
+      39
     ],
     "extensions": [
       {
@@ -1003,18 +639,9 @@
     "id": 40,
     "conceptType": "Disease",
     "name": "Melanoma",
-    "primaryCode": "oncotree:MEL",
+    "primaryCoding": "oncotree:MEL",
     "mappings": [
-      {
-        "coding": {
-          "id": "oncotree:MEL",
-          "code": "MEL",
-          "name": "Melanoma",
-          "system": "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=",
-          "systemVersion": "oncotree_2021_11_02"
-        },
-        "relation": "exactMatch"
-      }
+      40
     ],
     "extensions": [
       {
@@ -1028,18 +655,9 @@
     "id": 41,
     "conceptType": "Disease",
     "name": "Multiple Myeloma",
-    "primaryCode": "oncotree:MM",
+    "primaryCoding": "oncotree:MM",
     "mappings": [
-      {
-        "coding": {
-          "id": "oncotree:MM",
-          "code": "MM",
-          "name": "Multiple Myeloma",
-          "system": "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=",
-          "systemVersion": "oncotree_2021_11_02"
-        },
-        "relation": "exactMatch"
-      }
+      41
     ],
     "extensions": [
       {
@@ -1053,18 +671,9 @@
     "id": 42,
     "conceptType": "Disease",
     "name": "Aggressive Systemic Mastocytosis",
-    "primaryCode": "oncotree:ASM",
+    "primaryCoding": "oncotree:ASM",
     "mappings": [
-      {
-        "coding": {
-          "id": "oncotree:ASM",
-          "code": "ASM",
-          "name": "Aggressive Systemic Mastocytosis",
-          "system": "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=",
-          "systemVersion": "oncotree_2021_11_02"
-        },
-        "relation": "exactMatch"
-      }
+      42
     ],
     "extensions": [
       {
@@ -1078,18 +687,9 @@
     "id": 43,
     "conceptType": "Disease",
     "name": "Myelodysplastic Syndromes",
-    "primaryCode": "oncotree:MDS",
+    "primaryCoding": "oncotree:MDS",
     "mappings": [
-      {
-        "coding": {
-          "id": "oncotree:MDS",
-          "code": "MDS",
-          "name": "Myelodysplastic Syndromes",
-          "system": "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=",
-          "systemVersion": "oncotree_2021_11_02"
-        },
-        "relation": "exactMatch"
-      }
+      43
     ],
     "extensions": [
       {
@@ -1103,18 +703,9 @@
     "id": 44,
     "conceptType": "Disease",
     "name": "Myeloid/Lymphoid Neoplasms",
-    "primaryCode": "oncotree:MLN",
+    "primaryCoding": "oncotree:MLN",
     "mappings": [
-      {
-        "coding": {
-          "id": "oncotree:MLN",
-          "code": "MLN",
-          "name": "Myeloid/Lymphoid Neoplasms",
-          "system": "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=",
-          "systemVersion": "oncotree_2021_11_02"
-        },
-        "relation": "exactMatch"
-      }
+      44
     ],
     "extensions": [
       {
@@ -1128,18 +719,9 @@
     "id": 45,
     "conceptType": "Disease",
     "name": "Myeloproliferative Neoplasm",
-    "primaryCode": "oncotree:MPN",
+    "primaryCoding": "oncotree:MPN",
     "mappings": [
-      {
-        "coding": {
-          "id": "oncotree:MPN",
-          "code": "MPN",
-          "name": "Myeloproliferative Neoplasm",
-          "system": "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=",
-          "systemVersion": "oncotree_2021_11_02"
-        },
-        "relation": "exactMatch"
-      }
+      45
     ],
     "extensions": [
       {
@@ -1153,18 +735,9 @@
     "id": 46,
     "conceptType": "Disease",
     "name": "Non-Langerhans Cell Histiocytosis/Erdheim-Chester Disease",
-    "primaryCode": "oncotree:ECD",
+    "primaryCoding": "oncotree:ECD",
     "mappings": [
-      {
-        "coding": {
-          "id": "oncotree:ECD",
-          "code": "ECD",
-          "name": "Non-Langerhans Cell Histiocytosis/Erdheim-Chester Disease",
-          "system": "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=",
-          "systemVersion": "oncotree_2021_11_02"
-        },
-        "relation": "exactMatch"
-      }
+      46
     ],
     "extensions": [
       {
@@ -1178,18 +751,9 @@
     "id": 47,
     "conceptType": "Disease",
     "name": "Non-Small Cell Lung Cancer",
-    "primaryCode": "oncotree:NSCLC",
+    "primaryCoding": "oncotree:NSCLC",
     "mappings": [
-      {
-        "coding": {
-          "id": "oncotree:NSCLC",
-          "code": "NSCLC",
-          "name": "Non-Small Cell Lung Cancer",
-          "system": "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=",
-          "systemVersion": "oncotree_2021_11_02"
-        },
-        "relation": "exactMatch"
-      }
+      47
     ],
     "extensions": [
       {
@@ -1203,18 +767,9 @@
     "id": 48,
     "conceptType": "Disease",
     "name": "Oligodendroglioma",
-    "primaryCode": "oncotree:ODG",
+    "primaryCoding": "oncotree:ODG",
     "mappings": [
-      {
-        "coding": {
-          "id": "oncotree:ODG",
-          "code": "ODG",
-          "name": "Oligodendroglioma",
-          "system": "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=",
-          "systemVersion": "oncotree_2021_11_02"
-        },
-        "relation": "exactMatch"
-      }
+      48
     ],
     "extensions": [
       {
@@ -1228,18 +783,9 @@
     "id": 49,
     "conceptType": "Disease",
     "name": "Osteosarcoma",
-    "primaryCode": "oncotree:OS",
+    "primaryCoding": "oncotree:OS",
     "mappings": [
-      {
-        "coding": {
-          "id": "oncotree:OS",
-          "code": "OS",
-          "name": "Osteosarcoma",
-          "system": "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=",
-          "systemVersion": "oncotree_2021_11_02"
-        },
-        "relation": "exactMatch"
-      }
+      49
     ],
     "extensions": [
       {
@@ -1253,18 +799,9 @@
     "id": 50,
     "conceptType": "Disease",
     "name": "Ovarian Cancer, Other",
-    "primaryCode": "oncotree:OOVC",
+    "primaryCoding": "oncotree:OOVC",
     "mappings": [
-      {
-        "coding": {
-          "id": "oncotree:OOVC",
-          "code": "OOVC",
-          "name": "Ovarian Cancer, Other",
-          "system": "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=",
-          "systemVersion": "oncotree_2021_11_02"
-        },
-        "relation": "exactMatch"
-      }
+      50
     ],
     "extensions": [
       {
@@ -1278,18 +815,9 @@
     "id": 51,
     "conceptType": "Disease",
     "name": "Ovarian Epithelial Tumor",
-    "primaryCode": "oncotree:OVT",
+    "primaryCoding": "oncotree:OVT",
     "mappings": [
-      {
-        "coding": {
-          "id": "oncotree:OVT",
-          "code": "OVT",
-          "name": "Ovarian Epithelial Tumor",
-          "system": "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=",
-          "systemVersion": "oncotree_2021_11_02"
-        },
-        "relation": "exactMatch"
-      }
+      51
     ],
     "extensions": [
       {
@@ -1303,18 +831,9 @@
     "id": 52,
     "conceptType": "Disease",
     "name": "Pancreatic Adenocarcinoma",
-    "primaryCode": "oncotree:PAAD",
+    "primaryCoding": "oncotree:PAAD",
     "mappings": [
-      {
-        "coding": {
-          "id": "oncotree:PAAD",
-          "code": "PAAD",
-          "name": "Pancreatic Adenocarcinoma",
-          "system": "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=",
-          "systemVersion": "oncotree_2021_11_02"
-        },
-        "relation": "exactMatch"
-      }
+      52
     ],
     "extensions": [
       {
@@ -1328,18 +847,9 @@
     "id": 53,
     "conceptType": "Disease",
     "name": "Peritoneal Mesothelioma",
-    "primaryCode": "oncotree:PEMESO",
+    "primaryCoding": "oncotree:PEMESO",
     "mappings": [
-      {
-        "coding": {
-          "id": "oncotree:PEMESO",
-          "code": "PEMESO",
-          "name": "Peritoneal Mesothelioma",
-          "system": "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=",
-          "systemVersion": "oncotree_2021_11_02"
-        },
-        "relation": "exactMatch"
-      }
+      53
     ],
     "extensions": [
       {
@@ -1353,18 +863,9 @@
     "id": 54,
     "conceptType": "Disease",
     "name": "Peritoneal Serous Carcinoma",
-    "primaryCode": "oncotree:PSEC",
+    "primaryCoding": "oncotree:PSEC",
     "mappings": [
-      {
-        "coding": {
-          "id": "oncotree:PSEC",
-          "code": "PSEC",
-          "name": "Peritoneal Serous Carcinoma",
-          "system": "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=",
-          "systemVersion": "oncotree_2021_11_02"
-        },
-        "relation": "exactMatch"
-      }
+      54
     ],
     "extensions": [
       {
@@ -1378,18 +879,9 @@
     "id": 55,
     "conceptType": "Disease",
     "name": "Prostate Adenocarcinoma",
-    "primaryCode": "oncotree:PRAD",
+    "primaryCoding": "oncotree:PRAD",
     "mappings": [
-      {
-        "coding": {
-          "id": "oncotree:PRAD",
-          "code": "PRAD",
-          "name": "Prostate Adenocarcinoma",
-          "system": "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=",
-          "systemVersion": "oncotree_2021_11_02"
-        },
-        "relation": "exactMatch"
-      }
+      55
     ],
     "extensions": [
       {
@@ -1403,18 +895,9 @@
     "id": 56,
     "conceptType": "Disease",
     "name": "Prostate Neuroendocrine Cancer",
-    "primaryCode": "oncotree:PRNE",
+    "primaryCoding": "oncotree:PRNE",
     "mappings": [
-      {
-        "coding": {
-          "id": "oncotree:PRNE",
-          "code": "PRNE",
-          "name": "Prostate Neuroendocrine Cancer",
-          "system": "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=",
-          "systemVersion": "oncotree_2021_11_02"
-        },
-        "relation": "exactMatch"
-      }
+      56
     ],
     "extensions": [
       {
@@ -1428,18 +911,9 @@
     "id": 57,
     "conceptType": "Disease",
     "name": "Rectal Adenocarcinoma",
-    "primaryCode": "oncotree:READ",
+    "primaryCoding": "oncotree:READ",
     "mappings": [
-      {
-        "coding": {
-          "id": "oncotree:READ",
-          "code": "READ",
-          "name": "Rectal Adenocarcinoma",
-          "system": "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=",
-          "systemVersion": "oncotree_2021_11_02"
-        },
-        "relation": "exactMatch"
-      }
+      57
     ],
     "extensions": [
       {
@@ -1453,18 +927,9 @@
     "id": 58,
     "conceptType": "Disease",
     "name": "Renal Cell Carcinoma",
-    "primaryCode": "oncotree:RCC",
+    "primaryCoding": "oncotree:RCC",
     "mappings": [
-      {
-        "coding": {
-          "id": "oncotree:RCC",
-          "code": "RCC",
-          "name": "Renal Cell Carcinoma",
-          "system": "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=",
-          "systemVersion": "oncotree_2021_11_02"
-        },
-        "relation": "exactMatch"
-      }
+      58
     ],
     "extensions": [
       {
@@ -1478,18 +943,9 @@
     "id": 59,
     "conceptType": "Disease",
     "name": "Renal Clear Cell Carcinoma",
-    "primaryCode": "oncotree:CCRCC",
+    "primaryCoding": "oncotree:CCRCC",
     "mappings": [
-      {
-        "coding": {
-          "id": "oncotree:CCRCC",
-          "code": "CCRCC",
-          "name": "Renal Clear Cell Carcinoma",
-          "system": "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=",
-          "systemVersion": "oncotree_2021_11_02"
-        },
-        "relation": "exactMatch"
-      }
+      59
     ],
     "extensions": [
       {
@@ -1503,18 +959,9 @@
     "id": 60,
     "conceptType": "Disease",
     "name": "Serous Ovarian Cancer",
-    "primaryCode": "oncotree:SOC",
+    "primaryCoding": "oncotree:SOC",
     "mappings": [
-      {
-        "coding": {
-          "id": "oncotree:SOC",
-          "code": "SOC",
-          "name": "Serous Ovarian Cancer",
-          "system": "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=",
-          "systemVersion": "oncotree_2021_11_02"
-        },
-        "relation": "exactMatch"
-      }
+      60
     ],
     "extensions": [
       {
@@ -1528,18 +975,9 @@
     "id": 61,
     "conceptType": "Disease",
     "name": "Small Cell Lung Cancer",
-    "primaryCode": "oncotree:SCLC",
+    "primaryCoding": "oncotree:SCLC",
     "mappings": [
-      {
-        "coding": {
-          "id": "oncotree:SCLC",
-          "code": "SCLC",
-          "name": "Small Cell Lung Cancer",
-          "system": "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=",
-          "systemVersion": "oncotree_2021_11_02"
-        },
-        "relation": "exactMatch"
-      }
+      61
     ],
     "extensions": [
       {
@@ -1553,18 +991,9 @@
     "id": 62,
     "conceptType": "Disease",
     "name": "Squamous Cell Carcinoma, NOS",
-    "primaryCode": "oncotree:SCCNOS",
+    "primaryCoding": "oncotree:SCCNOS",
     "mappings": [
-      {
-        "coding": {
-          "id": "oncotree:SCCNOS",
-          "code": "SCCNOS",
-          "name": "Squamous Cell Carcinoma, NOS",
-          "system": "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=",
-          "systemVersion": "oncotree_2021_11_02"
-        },
-        "relation": "exactMatch"
-      }
+      62
     ],
     "extensions": [
       {
@@ -1578,18 +1007,9 @@
     "id": 63,
     "conceptType": "Disease",
     "name": "Stomach Adenocarcinoma",
-    "primaryCode": "oncotree:STAD",
+    "primaryCoding": "oncotree:STAD",
     "mappings": [
-      {
-        "coding": {
-          "id": "oncotree:STAD",
-          "code": "STAD",
-          "name": "Stomach Adenocarcinoma",
-          "system": "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=",
-          "systemVersion": "oncotree_2021_11_02"
-        },
-        "relation": "exactMatch"
-      }
+      63
     ],
     "extensions": [
       {
@@ -1603,18 +1023,9 @@
     "id": 64,
     "conceptType": "Disease",
     "name": "T-Cell Acute Lymphoid Leukemia",
-    "primaryCode": "oncotree:TALL",
+    "primaryCoding": "oncotree:TALL",
     "mappings": [
-      {
-        "coding": {
-          "id": "oncotree:TALL",
-          "code": "TALL",
-          "name": "T-Cell Acute Lymphoid Leukemia",
-          "system": "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=",
-          "systemVersion": "oncotree_2021_11_02"
-        },
-        "relation": "exactMatch"
-      }
+      64
     ],
     "extensions": [
       {
@@ -1628,18 +1039,9 @@
     "id": 65,
     "conceptType": "Disease",
     "name": "Testicular Germ Cell Tumors",
-    "primaryCode": "oncotree:TGCT",
+    "primaryCoding": "oncotree:TGCT",
     "mappings": [
-      {
-        "coding": {
-          "id": "oncotree:TGCT",
-          "code": "TGCT",
-          "name": "Testicular Germ Cell Tumors",
-          "system": "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=",
-          "systemVersion": "oncotree_2021_11_02"
-        },
-        "relation": "exactMatch"
-      }
+      65
     ],
     "extensions": [
       {
@@ -1653,18 +1055,9 @@
     "id": 66,
     "conceptType": "Disease",
     "name": "Thymic Carcinoma",
-    "primaryCode": "oncotree:THYC",
+    "primaryCoding": "oncotree:THYC",
     "mappings": [
-      {
-        "coding": {
-          "id": "oncotree:THYC",
-          "code": "THYC",
-          "name": "Thymic Carcinoma",
-          "system": "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=",
-          "systemVersion": "oncotree_2021_11_02"
-        },
-        "relation": "exactMatch"
-      }
+      66
     ],
     "extensions": [
       {
@@ -1678,18 +1071,9 @@
     "id": 67,
     "conceptType": "Disease",
     "name": "Urethral Urothelial Carcinoma",
-    "primaryCode": "oncotree:UCU",
+    "primaryCoding": "oncotree:UCU",
     "mappings": [
-      {
-        "coding": {
-          "id": "oncotree:UCU",
-          "code": "UCU",
-          "name": "Urethral Urothelial Carcinoma",
-          "system": "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=",
-          "systemVersion": "oncotree_2021_11_02"
-        },
-        "relation": "exactMatch"
-      }
+      67
     ],
     "extensions": [
       {
@@ -1703,18 +1087,9 @@
     "id": 68,
     "conceptType": "Disease",
     "name": "Uterine Leiomyoma",
-    "primaryCode": "oncotree:ULM",
+    "primaryCoding": "oncotree:ULM",
     "mappings": [
-      {
-        "coding": {
-          "id": "oncotree:ULM",
-          "code": "ULM",
-          "name": "Uterine Leiomyoma",
-          "system": "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=",
-          "systemVersion": "oncotree_2021_11_02"
-        },
-        "relation": "exactMatch"
-      }
+      68
     ],
     "extensions": [
       {
@@ -1728,18 +1103,9 @@
     "id": 69,
     "conceptType": "Disease",
     "name": "Uterine Leiomyosarcoma",
-    "primaryCode": "oncotree:ULMS",
+    "primaryCoding": "oncotree:ULMS",
     "mappings": [
-      {
-        "coding": {
-          "id": "oncotree:ULMS",
-          "code": "ULMS",
-          "name": "Uterine Leiomyosarcoma",
-          "system": "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=",
-          "systemVersion": "oncotree_2021_11_02"
-        },
-        "relation": "exactMatch"
-      }
+      69
     ],
     "extensions": [
       {
@@ -1753,18 +1119,9 @@
     "id": 70,
     "conceptType": "Disease",
     "name": "Well-Differentiated Liposarcoma",
-    "primaryCode": "oncotree:WDLS",
+    "primaryCoding": "oncotree:WDLS",
     "mappings": [
-      {
-        "coding": {
-          "id": "oncotree:WDLS",
-          "code": "WDLS",
-          "name": "Well-Differentiated Liposarcoma",
-          "system": "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=",
-          "systemVersion": "oncotree_2021_11_02"
-        },
-        "relation": "exactMatch"
-      }
+      70
     ],
     "extensions": [
       {
@@ -1778,18 +1135,9 @@
     "id": 71,
     "conceptType": "Disease",
     "name": "Chronic Myeloid Leukemia, BCR-ABL1+",
-    "primaryCode": "oncotree:CMLBCRABL1",
+    "primaryCoding": "oncotree:CMLBCRABL1",
     "mappings": [
-      {
-        "coding": {
-          "id": "oncotree:CMLBCRABL1",
-          "code": "CMLBCRABL1",
-          "name": "Chronic Myeloid Leukemia, BCR-ABL1+",
-          "system": "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=",
-          "systemVersion": "oncotree_2021_11_02"
-        },
-        "relation": "exactMatch"
-      }
+      71
     ],
     "extensions": [
       {
@@ -1803,18 +1151,9 @@
     "id": 72,
     "conceptType": "Disease",
     "name": "Cervical Adenocarcinoma",
-    "primaryCode": "oncotree:CEAD",
+    "primaryCoding": "oncotree:CEAD",
     "mappings": [
-      {
-        "coding": {
-          "id": "oncotree:CEAD",
-          "code": "CEAD",
-          "name": "Cervical Adenocarcinoma",
-          "system": "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=",
-          "systemVersion": "oncotree_2021_11_02"
-        },
-        "relation": "exactMatch"
-      }
+      72
     ],
     "extensions": [
       {
@@ -1828,18 +1167,9 @@
     "id": 73,
     "conceptType": "Disease",
     "name": "Cervical Squamous Cell Carcinoma",
-    "primaryCode": "oncotree:CESC",
+    "primaryCoding": "oncotree:CESC",
     "mappings": [
-      {
-        "coding": {
-          "id": "oncotree:CESC",
-          "code": "CESC",
-          "name": "Cervical Squamous Cell Carcinoma",
-          "system": "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=",
-          "systemVersion": "oncotree_2021_11_02"
-        },
-        "relation": "exactMatch"
-      }
+      73
     ],
     "extensions": [
       {
@@ -1853,18 +1183,9 @@
     "id": 74,
     "conceptType": "Disease",
     "name": "Esophageal Adenocarcinoma",
-    "primaryCode": "oncotree:ESCA",
+    "primaryCoding": "oncotree:ESCA",
     "mappings": [
-      {
-        "coding": {
-          "id": "oncotree:ESCA",
-          "code": "ESCA",
-          "name": "Esophageal Adenocarcinoma",
-          "system": "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=",
-          "systemVersion": "oncotree_2021_11_02"
-        },
-        "relation": "exactMatch"
-      }
+      74
     ],
     "extensions": [
       {
@@ -1878,18 +1199,9 @@
     "id": 75,
     "conceptType": "Disease",
     "name": "Papillary Thyroid Cancer",
-    "primaryCode": "oncotree:THPA",
+    "primaryCoding": "oncotree:THPA",
     "mappings": [
-      {
-        "coding": {
-          "id": "oncotree:THPA",
-          "code": "THPA",
-          "name": "Papillary Thyroid Cancer",
-          "system": "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=",
-          "systemVersion": "oncotree_2021_11_02"
-        },
-        "relation": "exactMatch"
-      }
+      75
     ],
     "extensions": [
       {
@@ -1903,18 +1215,9 @@
     "id": 76,
     "conceptType": "Disease",
     "name": "Non-Hodgkin Lymphoma",
-    "primaryCode": "oncotree:NHL",
+    "primaryCoding": "oncotree:NHL",
     "mappings": [
-      {
-        "coding": {
-          "id": "oncotree:NHL",
-          "code": "NHL",
-          "name": "Non-Hodgkin Lymphoma",
-          "system": "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=",
-          "systemVersion": "oncotree_2021_11_02"
-        },
-        "relation": "exactMatch"
-      }
+      76
     ],
     "extensions": [
       {
@@ -1928,18 +1231,9 @@
     "id": 77,
     "conceptType": "Disease",
     "name": "Diffuse Large B-Cell Lymphoma",
-    "primaryCode": "oncotree:DLBCLNOS",
+    "primaryCoding": "oncotree:DLBCLNOS",
     "mappings": [
-      {
-        "coding": {
-          "id": "oncotree:DLBCLNOS",
-          "code": "DLBCLNOS",
-          "name": "Diffuse Large B-Cell Lymphoma",
-          "system": "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=",
-          "systemVersion": "oncotree_2021_11_02"
-        },
-        "relation": "exactMatch"
-      }
+      77
     ],
     "extensions": [
       {
@@ -1953,18 +1247,9 @@
     "id": 78,
     "conceptType": "Disease",
     "name": "Burkitt Lymphoma",
-    "primaryCode": "oncotree:BL",
+    "primaryCoding": "oncotree:BL",
     "mappings": [
-      {
-        "coding": {
-          "id": "oncotree:BL",
-          "code": "BL",
-          "name": "Burkitt Lymphoma",
-          "system": "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=",
-          "systemVersion": "oncotree_2021_11_02"
-        },
-        "relation": "exactMatch"
-      }
+      78
     ],
     "extensions": [
       {
@@ -1978,18 +1263,9 @@
     "id": 79,
     "conceptType": "Disease",
     "name": "Mature B-Cell Neoplasms",
-    "primaryCode": "oncotree:MBN",
+    "primaryCoding": "oncotree:MBN",
     "mappings": [
-      {
-        "coding": {
-          "id": "oncotree:MBN",
-          "code": "MBN",
-          "name": "Mature B-Cell Neoplasms",
-          "system": "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=",
-          "systemVersion": "oncotree_2021_11_02"
-        },
-        "relation": "exactMatch"
-      }
+      79
     ],
     "extensions": [
       {
@@ -2003,18 +1279,9 @@
     "id": 80,
     "conceptType": "Disease",
     "name": "Hodgkin Lymphoma",
-    "primaryCode": "oncotree:HL",
+    "primaryCoding": "oncotree:HL",
     "mappings": [
-      {
-        "coding": {
-          "id": "oncotree:HL",
-          "code": "HL",
-          "name": "Hodgkin Lymphoma",
-          "system": "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=",
-          "systemVersion": "oncotree_2021_11_02"
-        },
-        "relation": "exactMatch"
-      }
+      80
     ],
     "extensions": [
       {
@@ -2028,18 +1295,9 @@
     "id": 81,
     "conceptType": "Disease",
     "name": "Esophagogastric Adenocarcinoma",
-    "primaryCode": "oncotree:EGC",
+    "primaryCoding": "oncotree:EGC",
     "mappings": [
-      {
-        "coding": {
-          "id": "oncotree:EGC",
-          "code": "EGC",
-          "name": "Esophagogastric Adenocarcinoma",
-          "system": "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=",
-          "systemVersion": "oncotree_2021_11_02"
-        },
-        "relation": "exactMatch"
-      }
+      81
     ],
     "extensions": [
       {
@@ -2053,18 +1311,9 @@
     "id": 82,
     "conceptType": "Disease",
     "name": "Esophageal Squamous Cell Carcinoma",
-    "primaryCode": "oncotree:ESCC",
+    "primaryCoding": "oncotree:ESCC",
     "mappings": [
-      {
-        "coding": {
-          "id": "oncotree:ESCC",
-          "code": "ESCC",
-          "name": "Esophageal Squamous Cell Carcinoma",
-          "system": "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=",
-          "systemVersion": "oncotree_2021_11_02"
-        },
-        "relation": "exactMatch"
-      }
+      82
     ],
     "extensions": [
       {
@@ -2078,18 +1327,9 @@
     "id": 83,
     "conceptType": "Disease",
     "name": "High-Grade Glioma, NOS",
-    "primaryCode": "oncotree:HGGNOS",
+    "primaryCoding": "oncotree:HGGNOS",
     "mappings": [
-      {
-        "coding": {
-          "id": "oncotree:HGGNOS",
-          "code": "HGGNOS",
-          "name": "High-Grade Glioma, NOS",
-          "system": "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=",
-          "systemVersion": "oncotree_2021_11_02"
-        },
-        "relation": "exactMatch"
-      }
+      83
     ],
     "extensions": [
       {
@@ -2103,19 +1343,8 @@
     "id": 84,
     "conceptType": "Disease",
     "name": "Chronic Lymphocytic Leukemia",
-    "primaryCode": "oncotree:",
-    "mappings": [
-      {
-        "coding": {
-          "id": "oncotree:",
-          "code": "",
-          "name": "",
-          "system": "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=",
-          "systemVersion": "oncotree_2021_11_02"
-        },
-        "relation": "exactMatch"
-      }
-    ],
+    "primaryCoding": "oncotree:",
+    "mappings": [],
     "extensions": [
       {
         "name": "solid_tumor",
@@ -2128,18 +1357,9 @@
     "id": 85,
     "conceptType": "Disease",
     "name": "Intraductal Papillary Neoplasm of the Bile Duct",
-    "primaryCode": "oncotree:IPN",
+    "primaryCoding": "oncotree:IPN",
     "mappings": [
-      {
-        "coding": {
-          "id": "oncotree:IPN",
-          "code": "IPN",
-          "name": "Intraductal Papillary Neoplasm of the Bile Duct",
-          "system": "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=",
-          "systemVersion": "oncotree_2021_11_02"
-        },
-        "relation": "exactMatch"
-      }
+      85
     ],
     "extensions": [
       {
@@ -2153,18 +1373,9 @@
     "id": 86,
     "conceptType": "Disease",
     "name": "Intracholecystic Papillary Neoplasm",
-    "primaryCode": "oncotree:ICPN",
+    "primaryCoding": "oncotree:ICPN",
     "mappings": [
-      {
-        "coding": {
-          "id": "oncotree:ICPN",
-          "code": "ICPN",
-          "name": "Intracholecystic Papillary Neoplasm",
-          "system": "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=",
-          "systemVersion": "oncotree_2021_11_02"
-        },
-        "relation": "exactMatch"
-      }
+      86
     ],
     "extensions": [
       {
@@ -2178,18 +1389,9 @@
     "id": 87,
     "conceptType": "Disease",
     "name": "Acute Leukemias of Ambiguous Lineage",
-    "primaryCode": "oncotree:ALAL",
+    "primaryCoding": "oncotree:ALAL",
     "mappings": [
-      {
-        "coding": {
-          "id": "oncotree:ALAL",
-          "code": "ALAL",
-          "name": "Acute Leukemias of Ambiguous Lineage",
-          "system": "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=",
-          "systemVersion": "oncotree_2021_11_02"
-        },
-        "relation": "exactMatch"
-      }
+      87
     ],
     "extensions": [
       {
@@ -2203,18 +1405,9 @@
     "id": 88,
     "conceptType": "Disease",
     "name": "Renal Angiomyolipoma",
-    "primaryCode": "oncotree:RAML",
+    "primaryCoding": "oncotree:RAML",
     "mappings": [
-      {
-        "coding": {
-          "id": "oncotree:RAML",
-          "code": "RAML",
-          "name": "Renal Angiomyolipoma",
-          "system": "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=",
-          "systemVersion": "oncotree_2021_11_02"
-        },
-        "relation": "exactMatch"
-      }
+      88
     ],
     "extensions": [
       {

--- a/referenced/genes.json
+++ b/referenced/genes.json
@@ -5,10 +5,9 @@
     "name": "ABL1",
     "primaryCoding": "hgnc:76",
     "mappings": [
-      89,
-      90,
-      91,
-      92
+      0,
+      1,
+      2
     ],
     "extensions": [
       {
@@ -27,10 +26,9 @@
     "name": "AKT1",
     "primaryCoding": "hgnc:391",
     "mappings": [
-      93,
-      94,
-      95,
-      96
+      3,
+      4,
+      5
     ],
     "extensions": [
       {
@@ -49,10 +47,9 @@
     "name": "ALK",
     "primaryCoding": "hgnc:427",
     "mappings": [
-      97,
-      98,
-      99,
-      100
+      6,
+      7,
+      8
     ],
     "extensions": [
       {
@@ -71,10 +68,9 @@
     "name": "ATM",
     "primaryCoding": "hgnc:795",
     "mappings": [
-      101,
-      102,
-      103,
-      104
+      9,
+      10,
+      11
     ],
     "extensions": [
       {
@@ -93,10 +89,9 @@
     "name": "BAIAP2L1",
     "primaryCoding": "hgnc:21649",
     "mappings": [
-      105,
-      106,
-      107,
-      108
+      12,
+      13,
+      14
     ],
     "extensions": [
       {
@@ -115,10 +110,9 @@
     "name": "BARD1",
     "primaryCoding": "hgnc:952",
     "mappings": [
-      109,
-      110,
-      111,
-      112
+      15,
+      16,
+      17
     ],
     "extensions": [
       {
@@ -137,10 +131,9 @@
     "name": "BCR",
     "primaryCoding": "hgnc:1014",
     "mappings": [
-      113,
-      114,
-      115,
-      116
+      18,
+      19,
+      20
     ],
     "extensions": [
       {
@@ -159,10 +152,9 @@
     "name": "BICC1",
     "primaryCoding": "hgnc:19351",
     "mappings": [
-      117,
-      118,
-      119,
-      120
+      21,
+      22,
+      23
     ],
     "extensions": [
       {
@@ -181,10 +173,9 @@
     "name": "BRAF",
     "primaryCoding": "hgnc:1097",
     "mappings": [
-      121,
-      122,
-      123,
-      124
+      24,
+      25,
+      26
     ],
     "extensions": [
       {
@@ -203,10 +194,9 @@
     "name": "BRCA1",
     "primaryCoding": "hgnc:1100",
     "mappings": [
-      125,
-      126,
-      127,
-      128
+      27,
+      28,
+      29
     ],
     "extensions": [
       {
@@ -225,10 +215,9 @@
     "name": "BRCA2",
     "primaryCoding": "hgnc:1101",
     "mappings": [
-      129,
-      130,
-      131,
-      132
+      30,
+      31,
+      32
     ],
     "extensions": [
       {
@@ -247,10 +236,9 @@
     "name": "BRIP1",
     "primaryCoding": "hgnc:20473",
     "mappings": [
-      133,
-      134,
-      135,
-      136
+      33,
+      34,
+      35
     ],
     "extensions": [
       {
@@ -269,10 +257,9 @@
     "name": "CASP7",
     "primaryCoding": "hgnc:1508",
     "mappings": [
-      137,
-      138,
-      139,
-      140
+      36,
+      37,
+      38
     ],
     "extensions": [
       {
@@ -291,10 +278,9 @@
     "name": "CD274",
     "primaryCoding": "hgnc:17635",
     "mappings": [
-      141,
-      142,
-      143,
-      144
+      39,
+      40,
+      41
     ],
     "extensions": [
       {
@@ -313,10 +299,9 @@
     "name": "CDK12",
     "primaryCoding": "hgnc:24224",
     "mappings": [
-      145,
-      146,
-      147,
-      148
+      42,
+      43,
+      44
     ],
     "extensions": [
       {
@@ -335,10 +320,9 @@
     "name": "CHEK1",
     "primaryCoding": "hgnc:1925",
     "mappings": [
-      149,
-      150,
-      151,
-      152
+      45,
+      46,
+      47
     ],
     "extensions": [
       {
@@ -357,10 +341,9 @@
     "name": "CHEK2",
     "primaryCoding": "hgnc:16627",
     "mappings": [
-      153,
-      154,
-      155,
-      156
+      48,
+      49,
+      50
     ],
     "extensions": [
       {
@@ -379,10 +362,9 @@
     "name": "EGFR",
     "primaryCoding": "hgnc:3236",
     "mappings": [
-      157,
-      158,
-      159,
-      160
+      51,
+      52,
+      53
     ],
     "extensions": [
       {
@@ -401,10 +383,9 @@
     "name": "ERBB2",
     "primaryCoding": "hgnc:3430",
     "mappings": [
-      161,
-      162,
-      163,
-      164
+      54,
+      55,
+      56
     ],
     "extensions": [
       {
@@ -423,10 +404,9 @@
     "name": "ESR1",
     "primaryCoding": "hgnc:3467",
     "mappings": [
-      165,
-      166,
-      167,
-      168
+      57,
+      58,
+      59
     ],
     "extensions": [
       {
@@ -445,10 +425,9 @@
     "name": "EZH2",
     "primaryCoding": "hgnc:3527",
     "mappings": [
-      169,
-      170,
-      171,
-      172
+      60,
+      61,
+      62
     ],
     "extensions": [
       {
@@ -467,10 +446,9 @@
     "name": "FANCL",
     "primaryCoding": "hgnc:20748",
     "mappings": [
-      173,
-      174,
-      175,
-      176
+      63,
+      64,
+      65
     ],
     "extensions": [
       {
@@ -489,10 +467,9 @@
     "name": "FGFR1",
     "primaryCoding": "hgnc:3688",
     "mappings": [
-      177,
-      178,
-      179,
-      180
+      66,
+      67,
+      68
     ],
     "extensions": [
       {
@@ -511,10 +488,9 @@
     "name": "FGFR2",
     "primaryCoding": "hgnc:3689",
     "mappings": [
-      181,
-      182,
-      183,
-      184
+      69,
+      70,
+      71
     ],
     "extensions": [
       {
@@ -533,10 +509,9 @@
     "name": "FGFR3",
     "primaryCoding": "hgnc:3690",
     "mappings": [
-      185,
-      186,
-      187,
-      188
+      72,
+      73,
+      74
     ],
     "extensions": [
       {
@@ -555,10 +530,9 @@
     "name": "FIP1L1",
     "primaryCoding": "hgnc:19124",
     "mappings": [
-      189,
-      190,
-      191,
-      192
+      75,
+      76,
+      77
     ],
     "extensions": [
       {
@@ -577,10 +551,9 @@
     "name": "FLT3",
     "primaryCoding": "hgnc:3765",
     "mappings": [
-      193,
-      194,
-      195,
-      196
+      78,
+      79,
+      80
     ],
     "extensions": [
       {
@@ -599,10 +572,9 @@
     "name": "HRAS",
     "primaryCoding": "hgnc:5173",
     "mappings": [
-      197,
-      198,
-      199,
-      200
+      81,
+      82,
+      83
     ],
     "extensions": [
       {
@@ -621,10 +593,9 @@
     "name": "IDH1",
     "primaryCoding": "hgnc:5382",
     "mappings": [
-      201,
-      202,
-      203,
-      204
+      84,
+      85,
+      86
     ],
     "extensions": [
       {
@@ -643,10 +614,9 @@
     "name": "IDH2",
     "primaryCoding": "hgnc:5383",
     "mappings": [
-      205,
-      206,
-      207,
-      208
+      87,
+      88,
+      89
     ],
     "extensions": [
       {
@@ -665,10 +635,9 @@
     "name": "KIT",
     "primaryCoding": "hgnc:6342",
     "mappings": [
-      209,
-      210,
-      211,
-      212
+      90,
+      91,
+      92
     ],
     "extensions": [
       {
@@ -687,10 +656,9 @@
     "name": "KRAS",
     "primaryCoding": "hgnc:6407",
     "mappings": [
-      213,
-      214,
-      215,
-      216
+      93,
+      94,
+      95
     ],
     "extensions": [
       {
@@ -709,10 +677,9 @@
     "name": "MET",
     "primaryCoding": "hgnc:7029",
     "mappings": [
-      217,
-      218,
-      219,
-      220
+      96,
+      97,
+      98
     ],
     "extensions": [
       {
@@ -731,10 +698,9 @@
     "name": "NRAS",
     "primaryCoding": "hgnc:7989",
     "mappings": [
-      221,
-      222,
-      223,
-      224
+      99,
+      100,
+      101
     ],
     "extensions": [
       {
@@ -753,10 +719,9 @@
     "name": "NRG1",
     "primaryCoding": "hgnc:7997",
     "mappings": [
-      225,
-      226,
-      227,
-      228
+      102,
+      103,
+      104
     ],
     "extensions": [
       {
@@ -775,10 +740,9 @@
     "name": "NTRK1",
     "primaryCoding": "hgnc:8031",
     "mappings": [
-      229,
-      230,
-      231,
-      232
+      105,
+      106,
+      107
     ],
     "extensions": [
       {
@@ -797,10 +761,9 @@
     "name": "NTRK2",
     "primaryCoding": "hgnc:8032",
     "mappings": [
-      233,
-      234,
-      235,
-      236
+      108,
+      109,
+      110
     ],
     "extensions": [
       {
@@ -819,10 +782,9 @@
     "name": "NTRK3",
     "primaryCoding": "hgnc:8033",
     "mappings": [
-      237,
-      238,
-      239,
-      240
+      111,
+      112,
+      113
     ],
     "extensions": [
       {
@@ -841,10 +803,9 @@
     "name": "PALB2",
     "primaryCoding": "hgnc:26144",
     "mappings": [
-      241,
-      242,
-      243,
-      244
+      114,
+      115,
+      116
     ],
     "extensions": [
       {
@@ -863,10 +824,9 @@
     "name": "PDGFRA",
     "primaryCoding": "hgnc:8803",
     "mappings": [
-      245,
-      246,
-      247,
-      248
+      117,
+      118,
+      119
     ],
     "extensions": [
       {
@@ -885,10 +845,9 @@
     "name": "PDGFRB",
     "primaryCoding": "hgnc:8804",
     "mappings": [
-      249,
-      250,
-      251,
-      252
+      120,
+      121,
+      122
     ],
     "extensions": [
       {
@@ -907,10 +866,9 @@
     "name": "PIK3CA",
     "primaryCoding": "hgnc:8975",
     "mappings": [
-      253,
-      254,
-      255,
-      256
+      123,
+      124,
+      125
     ],
     "extensions": [
       {
@@ -929,10 +887,9 @@
     "name": "PML",
     "primaryCoding": "hgnc:9113",
     "mappings": [
-      257,
-      258,
-      259,
-      260
+      126,
+      127,
+      128
     ],
     "extensions": [
       {
@@ -951,10 +908,9 @@
     "name": "PTEN",
     "primaryCoding": "hgnc:9588",
     "mappings": [
-      261,
-      262,
-      263,
-      264
+      129,
+      130,
+      131
     ],
     "extensions": [
       {
@@ -973,10 +929,9 @@
     "name": "RAD51B",
     "primaryCoding": "hgnc:9822",
     "mappings": [
-      265,
-      266,
-      267,
-      268
+      132,
+      133,
+      134
     ],
     "extensions": [
       {
@@ -995,10 +950,9 @@
     "name": "RAD51C",
     "primaryCoding": "hgnc:9820",
     "mappings": [
-      269,
-      270,
-      271,
-      272
+      135,
+      136,
+      137
     ],
     "extensions": [
       {
@@ -1017,10 +971,9 @@
     "name": "RAD51D",
     "primaryCoding": "hgnc:9823",
     "mappings": [
-      273,
-      274,
-      275,
-      276
+      138,
+      139,
+      140
     ],
     "extensions": [
       {
@@ -1039,10 +992,9 @@
     "name": "RAD54L",
     "primaryCoding": "hgnc:9826",
     "mappings": [
-      277,
-      278,
-      279,
-      280
+      141,
+      142,
+      143
     ],
     "extensions": [
       {
@@ -1061,10 +1013,9 @@
     "name": "RARA",
     "primaryCoding": "hgnc:9864",
     "mappings": [
-      281,
-      282,
-      283,
-      284
+      144,
+      145,
+      146
     ],
     "extensions": [
       {
@@ -1083,10 +1034,9 @@
     "name": "RET",
     "primaryCoding": "hgnc:9967",
     "mappings": [
-      285,
-      286,
-      287,
-      288
+      147,
+      148,
+      149
     ],
     "extensions": [
       {
@@ -1105,10 +1055,9 @@
     "name": "ROS1",
     "primaryCoding": "hgnc:10261",
     "mappings": [
-      289,
-      290,
-      291,
-      292
+      150,
+      151,
+      152
     ],
     "extensions": [
       {
@@ -1127,10 +1076,9 @@
     "name": "TACC3",
     "primaryCoding": "hgnc:11524",
     "mappings": [
-      293,
-      294,
-      295,
-      296
+      153,
+      154,
+      155
     ],
     "extensions": [
       {
@@ -1149,10 +1097,9 @@
     "name": "TP53",
     "primaryCoding": "hgnc:11998",
     "mappings": [
-      297,
-      298,
-      299,
-      300
+      156,
+      157,
+      158
     ],
     "extensions": [
       {
@@ -1171,9 +1118,8 @@
     "name": "KMT2A",
     "primaryCoding": "hgnc:7131",
     "mappings": [
-      301,
-      302,
-      303
+      159,
+      160
     ]
   },
   {
@@ -1182,9 +1128,8 @@
     "name": "TSC1",
     "primaryCoding": "hgnc:12362",
     "mappings": [
-      304,
-      305,
-      306
+      161,
+      162
     ]
   },
   {
@@ -1193,9 +1138,8 @@
     "name": "TSC2",
     "primaryCoding": "hgnc:12363",
     "mappings": [
-      307,
-      308,
-      309
+      163,
+      164
     ]
   },
   {
@@ -1204,9 +1148,8 @@
     "name": "ATR",
     "primaryCoding": "hgnc:882",
     "mappings": [
-      310,
-      311,
-      312
+      165,
+      166
     ]
   },
   {
@@ -1215,9 +1158,8 @@
     "name": "FANCA",
     "primaryCoding": "hgnc:3582",
     "mappings": [
-      313,
-      314,
-      315
+      167,
+      168
     ]
   },
   {
@@ -1226,9 +1168,8 @@
     "name": "MLH1",
     "primaryCoding": "hgnc:7127",
     "mappings": [
-      316,
-      317,
-      318
+      169,
+      170
     ]
   },
   {
@@ -1237,9 +1178,8 @@
     "name": "MRE11",
     "primaryCoding": "hgnc:7230",
     "mappings": [
-      319,
-      320,
-      321
+      171,
+      172
     ]
   },
   {
@@ -1248,9 +1188,8 @@
     "name": "NBN",
     "primaryCoding": "hgnc:7652",
     "mappings": [
-      322,
-      323,
-      324
+      173,
+      174
     ]
   }
 ]

--- a/referenced/genes.json
+++ b/referenced/genes.json
@@ -2,48 +2,13 @@
   {
     "id": 0,
     "conceptType": "Gene",
-    "primaryCode": "hgnc:76",
     "name": "ABL1",
+    "primaryCoding": "hgnc:76",
     "mappings": [
-      {
-        "coding": {
-          "id": "hgnc:76",
-          "code": "HGNC:76",
-          "system": "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ensembl:ensg00000097007",
-          "code": "ENSG00000097007",
-          "system": "https://www.ensembl.org/id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ncbi:25",
-          "code": "25",
-          "system": "https://www.ncbi.nlm.nih.gov/gene"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "refseq:NM_005157.6",
-          "code": "NM_005157.6",
-          "system": "https://www.ncbi.nlm.nih.gov/nuccore"
-        },
-        "relation": "relatedMatch",
-        "extensions": [
-          {
-            "name": "mane_select",
-            "value": true,
-            "description": "Boolean value for if this transcript is a MANE Select transcript"
-          }
-        ]
-      }
+      89,
+      90,
+      91,
+      92
     ],
     "extensions": [
       {
@@ -59,48 +24,13 @@
   {
     "id": 1,
     "conceptType": "Gene",
-    "primaryCode": "hgnc:391",
     "name": "AKT1",
+    "primaryCoding": "hgnc:391",
     "mappings": [
-      {
-        "coding": {
-          "id": "hgnc:391",
-          "code": "HGNC:391",
-          "system": "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ensembl:ensg00000142208",
-          "code": "ENSG00000142208",
-          "system": "https://www.ensembl.org/id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ncbi:207",
-          "code": "207",
-          "system": "https://www.ncbi.nlm.nih.gov/gene"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "refseq:NM_001382430.1",
-          "code": "NM_001382430.1",
-          "system": "https://www.ncbi.nlm.nih.gov/nuccore"
-        },
-        "relation": "relatedMatch",
-        "extensions": [
-          {
-            "name": "mane_select",
-            "value": true,
-            "description": "Boolean value for if this transcript is a MANE Select transcript"
-          }
-        ]
-      }
+      93,
+      94,
+      95,
+      96
     ],
     "extensions": [
       {
@@ -116,48 +46,13 @@
   {
     "id": 2,
     "conceptType": "Gene",
-    "primaryCode": "hgnc:427",
     "name": "ALK",
+    "primaryCoding": "hgnc:427",
     "mappings": [
-      {
-        "coding": {
-          "id": "hgnc:427",
-          "code": "HGNC:427",
-          "system": "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ensembl:ensg00000171094",
-          "code": "ENSG00000171094",
-          "system": "https://www.ensembl.org/id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ncbi:238",
-          "code": "238",
-          "system": "https://www.ncbi.nlm.nih.gov/gene"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "refseq:NM_004304.5",
-          "code": "NM_004304.5",
-          "system": "https://www.ncbi.nlm.nih.gov/nuccore"
-        },
-        "relation": "relatedMatch",
-        "extensions": [
-          {
-            "name": "mane_select",
-            "value": true,
-            "description": "Boolean value for if this transcript is a MANE Select transcript"
-          }
-        ]
-      }
+      97,
+      98,
+      99,
+      100
     ],
     "extensions": [
       {
@@ -173,48 +68,13 @@
   {
     "id": 3,
     "conceptType": "Gene",
-    "primaryCode": "hgnc:795",
     "name": "ATM",
+    "primaryCoding": "hgnc:795",
     "mappings": [
-      {
-        "coding": {
-          "id": "hgnc:795",
-          "code": "HGNC:795",
-          "system": "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ensembl:ensg00000149311",
-          "code": "ENSG00000149311",
-          "system": "https://www.ensembl.org/id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ncbi:472",
-          "code": "472",
-          "system": "https://www.ncbi.nlm.nih.gov/gene"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "refseq:NM_000051.4",
-          "code": "NM_000051.4",
-          "system": "https://www.ncbi.nlm.nih.gov/nuccore"
-        },
-        "relation": "relatedMatch",
-        "extensions": [
-          {
-            "name": "mane_select",
-            "value": true,
-            "description": "Boolean value for if this transcript is a MANE Select transcript"
-          }
-        ]
-      }
+      101,
+      102,
+      103,
+      104
     ],
     "extensions": [
       {
@@ -230,48 +90,13 @@
   {
     "id": 4,
     "conceptType": "Gene",
-    "primaryCode": "hgnc:21649",
     "name": "BAIAP2L1",
+    "primaryCoding": "hgnc:21649",
     "mappings": [
-      {
-        "coding": {
-          "id": "hgnc:21649",
-          "code": "HGNC:21649",
-          "system": "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ensembl:ensg00000006453",
-          "code": "ENSG00000006453",
-          "system": "https://www.ensembl.org/id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ncbi:55971",
-          "code": "55971",
-          "system": "https://www.ncbi.nlm.nih.gov/gene"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "refseq:NM_018842.5",
-          "code": "NM_018842.5",
-          "system": "https://www.ncbi.nlm.nih.gov/nuccore"
-        },
-        "relation": "relatedMatch",
-        "extensions": [
-          {
-            "name": "mane_select",
-            "value": true,
-            "description": "Boolean value for if this transcript is a MANE Select transcript"
-          }
-        ]
-      }
+      105,
+      106,
+      107,
+      108
     ],
     "extensions": [
       {
@@ -287,48 +112,13 @@
   {
     "id": 5,
     "conceptType": "Gene",
-    "primaryCode": "hgnc:952",
     "name": "BARD1",
+    "primaryCoding": "hgnc:952",
     "mappings": [
-      {
-        "coding": {
-          "id": "hgnc:952",
-          "code": "HGNC:952",
-          "system": "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ensembl:ensg00000138376",
-          "code": "ENSG00000138376",
-          "system": "https://www.ensembl.org/id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ncbi:580",
-          "code": "580",
-          "system": "https://www.ncbi.nlm.nih.gov/gene"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "refseq:NM_000465.4",
-          "code": "NM_000465.4",
-          "system": "https://www.ncbi.nlm.nih.gov/nuccore"
-        },
-        "relation": "relatedMatch",
-        "extensions": [
-          {
-            "name": "mane_select",
-            "value": true,
-            "description": "Boolean value for if this transcript is a MANE Select transcript"
-          }
-        ]
-      }
+      109,
+      110,
+      111,
+      112
     ],
     "extensions": [
       {
@@ -344,48 +134,13 @@
   {
     "id": 6,
     "conceptType": "Gene",
-    "primaryCode": "hgnc:1014",
     "name": "BCR",
+    "primaryCoding": "hgnc:1014",
     "mappings": [
-      {
-        "coding": {
-          "id": "hgnc:1014",
-          "code": "HGNC:1014",
-          "system": "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ensembl:ensg00000186716",
-          "code": "ENSG00000186716",
-          "system": "https://www.ensembl.org/id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ncbi:613",
-          "code": "613",
-          "system": "https://www.ncbi.nlm.nih.gov/gene"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "refseq:NM_004327.4",
-          "code": "NM_004327.4",
-          "system": "https://www.ncbi.nlm.nih.gov/nuccore"
-        },
-        "relation": "relatedMatch",
-        "extensions": [
-          {
-            "name": "mane_select",
-            "value": true,
-            "description": "Boolean value for if this transcript is a MANE Select transcript"
-          }
-        ]
-      }
+      113,
+      114,
+      115,
+      116
     ],
     "extensions": [
       {
@@ -401,48 +156,13 @@
   {
     "id": 7,
     "conceptType": "Gene",
-    "primaryCode": "hgnc:19351",
     "name": "BICC1",
+    "primaryCoding": "hgnc:19351",
     "mappings": [
-      {
-        "coding": {
-          "id": "hgnc:19351",
-          "code": "HGNC:19351",
-          "system": "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ensembl:ensg00000122870",
-          "code": "ENSG00000122870",
-          "system": "https://www.ensembl.org/id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ncbi:80114",
-          "code": "80114",
-          "system": "https://www.ncbi.nlm.nih.gov/gene"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "refseq:NM_001080512.3",
-          "code": "NM_001080512.3",
-          "system": "https://www.ncbi.nlm.nih.gov/nuccore"
-        },
-        "relation": "relatedMatch",
-        "extensions": [
-          {
-            "name": "mane_select",
-            "value": true,
-            "description": "Boolean value for if this transcript is a MANE Select transcript"
-          }
-        ]
-      }
+      117,
+      118,
+      119,
+      120
     ],
     "extensions": [
       {
@@ -458,48 +178,13 @@
   {
     "id": 8,
     "conceptType": "Gene",
-    "primaryCode": "hgnc:1097",
     "name": "BRAF",
+    "primaryCoding": "hgnc:1097",
     "mappings": [
-      {
-        "coding": {
-          "id": "hgnc:1097",
-          "code": "HGNC:1097",
-          "system": "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ensembl:ensg00000157764",
-          "code": "ENSG00000157764",
-          "system": "https://www.ensembl.org/id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ncbi:673",
-          "code": "673",
-          "system": "https://www.ncbi.nlm.nih.gov/gene"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "refseq:NM_004333.6",
-          "code": "NM_004333.6",
-          "system": "https://www.ncbi.nlm.nih.gov/nuccore"
-        },
-        "relation": "relatedMatch",
-        "extensions": [
-          {
-            "name": "mane_select",
-            "value": true,
-            "description": "Boolean value for if this transcript is a MANE Select transcript"
-          }
-        ]
-      }
+      121,
+      122,
+      123,
+      124
     ],
     "extensions": [
       {
@@ -515,48 +200,13 @@
   {
     "id": 9,
     "conceptType": "Gene",
-    "primaryCode": "hgnc:1100",
     "name": "BRCA1",
+    "primaryCoding": "hgnc:1100",
     "mappings": [
-      {
-        "coding": {
-          "id": "hgnc:1100",
-          "code": "HGNC:1100",
-          "system": "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ensembl:ensg00000012048",
-          "code": "ENSG00000012048",
-          "system": "https://www.ensembl.org/id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ncbi:672",
-          "code": "672",
-          "system": "https://www.ncbi.nlm.nih.gov/gene"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "refseq:NM_007294.4",
-          "code": "NM_007294.4",
-          "system": "https://www.ncbi.nlm.nih.gov/nuccore"
-        },
-        "relation": "relatedMatch",
-        "extensions": [
-          {
-            "name": "mane_select",
-            "value": true,
-            "description": "Boolean value for if this transcript is a MANE Select transcript"
-          }
-        ]
-      }
+      125,
+      126,
+      127,
+      128
     ],
     "extensions": [
       {
@@ -572,48 +222,13 @@
   {
     "id": 10,
     "conceptType": "Gene",
-    "primaryCode": "hgnc:1101",
     "name": "BRCA2",
+    "primaryCoding": "hgnc:1101",
     "mappings": [
-      {
-        "coding": {
-          "id": "hgnc:1101",
-          "code": "HGNC:1101",
-          "system": "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ensembl:ensg00000139618",
-          "code": "ENSG00000139618",
-          "system": "https://www.ensembl.org/id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ncbi:675",
-          "code": "675",
-          "system": "https://www.ncbi.nlm.nih.gov/gene"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "refseq:NM_000059.4",
-          "code": "NM_000059.4",
-          "system": "https://www.ncbi.nlm.nih.gov/nuccore"
-        },
-        "relation": "relatedMatch",
-        "extensions": [
-          {
-            "name": "mane_select",
-            "value": true,
-            "description": "Boolean value for if this transcript is a MANE Select transcript"
-          }
-        ]
-      }
+      129,
+      130,
+      131,
+      132
     ],
     "extensions": [
       {
@@ -629,48 +244,13 @@
   {
     "id": 11,
     "conceptType": "Gene",
-    "primaryCode": "hgnc:20473",
     "name": "BRIP1",
+    "primaryCoding": "hgnc:20473",
     "mappings": [
-      {
-        "coding": {
-          "id": "hgnc:20473",
-          "code": "HGNC:20473",
-          "system": "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ensembl:ensg00000136492",
-          "code": "ENSG00000136492",
-          "system": "https://www.ensembl.org/id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ncbi:83990",
-          "code": "83990",
-          "system": "https://www.ncbi.nlm.nih.gov/gene"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "refseq:NM_032043.3",
-          "code": "NM_032043.3",
-          "system": "https://www.ncbi.nlm.nih.gov/nuccore"
-        },
-        "relation": "relatedMatch",
-        "extensions": [
-          {
-            "name": "mane_select",
-            "value": true,
-            "description": "Boolean value for if this transcript is a MANE Select transcript"
-          }
-        ]
-      }
+      133,
+      134,
+      135,
+      136
     ],
     "extensions": [
       {
@@ -686,48 +266,13 @@
   {
     "id": 12,
     "conceptType": "Gene",
-    "primaryCode": "hgnc:1508",
     "name": "CASP7",
+    "primaryCoding": "hgnc:1508",
     "mappings": [
-      {
-        "coding": {
-          "id": "hgnc:1508",
-          "code": "HGNC:1508",
-          "system": "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ensembl:ensg00000165806",
-          "code": "ENSG00000165806",
-          "system": "https://www.ensembl.org/id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ncbi:840",
-          "code": "840",
-          "system": "https://www.ncbi.nlm.nih.gov/gene"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "refseq:NM_001227.5",
-          "code": "NM_001227.5",
-          "system": "https://www.ncbi.nlm.nih.gov/nuccore"
-        },
-        "relation": "relatedMatch",
-        "extensions": [
-          {
-            "name": "mane_select",
-            "value": true,
-            "description": "Boolean value for if this transcript is a MANE Select transcript"
-          }
-        ]
-      }
+      137,
+      138,
+      139,
+      140
     ],
     "extensions": [
       {
@@ -743,48 +288,13 @@
   {
     "id": 13,
     "conceptType": "Gene",
-    "primaryCode": "hgnc:17635",
     "name": "CD274",
+    "primaryCoding": "hgnc:17635",
     "mappings": [
-      {
-        "coding": {
-          "id": "hgnc:17635",
-          "code": "HGNC:17635",
-          "system": "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ensembl:ensg00000120217",
-          "code": "ENSG00000120217",
-          "system": "https://www.ensembl.org/id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ncbi:29126",
-          "code": "29126",
-          "system": "https://www.ncbi.nlm.nih.gov/gene"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "refseq:NM_014143.4",
-          "code": "NM_014143.4",
-          "system": "https://www.ncbi.nlm.nih.gov/nuccore"
-        },
-        "relation": "relatedMatch",
-        "extensions": [
-          {
-            "name": "mane_select",
-            "value": true,
-            "description": "Boolean value for if this transcript is a MANE Select transcript"
-          }
-        ]
-      }
+      141,
+      142,
+      143,
+      144
     ],
     "extensions": [
       {
@@ -800,48 +310,13 @@
   {
     "id": 14,
     "conceptType": "Gene",
-    "primaryCode": "hgnc:24224",
     "name": "CDK12",
+    "primaryCoding": "hgnc:24224",
     "mappings": [
-      {
-        "coding": {
-          "id": "hgnc:24224",
-          "code": "HGNC:24224",
-          "system": "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ensembl:ensg00000167258",
-          "code": "ENSG00000167258",
-          "system": "https://www.ensembl.org/id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ncbi:51755",
-          "code": "51755",
-          "system": "https://www.ncbi.nlm.nih.gov/gene"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "refseq:NM_016507.4",
-          "code": "NM_016507.4",
-          "system": "https://www.ncbi.nlm.nih.gov/nuccore"
-        },
-        "relation": "relatedMatch",
-        "extensions": [
-          {
-            "name": "mane_select",
-            "value": true,
-            "description": "Boolean value for if this transcript is a MANE Select transcript"
-          }
-        ]
-      }
+      145,
+      146,
+      147,
+      148
     ],
     "extensions": [
       {
@@ -857,48 +332,13 @@
   {
     "id": 15,
     "conceptType": "Gene",
-    "primaryCode": "hgnc:1925",
     "name": "CHEK1",
+    "primaryCoding": "hgnc:1925",
     "mappings": [
-      {
-        "coding": {
-          "id": "hgnc:1925",
-          "code": "HGNC:1925",
-          "system": "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ensembl:ensg00000149554",
-          "code": "ENSG00000149554",
-          "system": "https://www.ensembl.org/id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ncbi:1111",
-          "code": "1111",
-          "system": "https://www.ncbi.nlm.nih.gov/gene"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "refseq:NM_001114122.3",
-          "code": "NM_001114122.3",
-          "system": "https://www.ncbi.nlm.nih.gov/nuccore"
-        },
-        "relation": "relatedMatch",
-        "extensions": [
-          {
-            "name": "mane_select",
-            "value": true,
-            "description": "Boolean value for if this transcript is a MANE Select transcript"
-          }
-        ]
-      }
+      149,
+      150,
+      151,
+      152
     ],
     "extensions": [
       {
@@ -914,48 +354,13 @@
   {
     "id": 16,
     "conceptType": "Gene",
-    "primaryCode": "hgnc:16627",
     "name": "CHEK2",
+    "primaryCoding": "hgnc:16627",
     "mappings": [
-      {
-        "coding": {
-          "id": "hgnc:16627",
-          "code": "HGNC:16627",
-          "system": "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ensembl:ensg00000183765",
-          "code": "ENSG00000183765",
-          "system": "https://www.ensembl.org/id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ncbi:11200",
-          "code": "11200",
-          "system": "https://www.ncbi.nlm.nih.gov/gene"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "refseq:NM_007194.4",
-          "code": "NM_007194.4",
-          "system": "https://www.ncbi.nlm.nih.gov/nuccore"
-        },
-        "relation": "relatedMatch",
-        "extensions": [
-          {
-            "name": "mane_select",
-            "value": true,
-            "description": "Boolean value for if this transcript is a MANE Select transcript"
-          }
-        ]
-      }
+      153,
+      154,
+      155,
+      156
     ],
     "extensions": [
       {
@@ -971,48 +376,13 @@
   {
     "id": 17,
     "conceptType": "Gene",
-    "primaryCode": "hgnc:3236",
     "name": "EGFR",
+    "primaryCoding": "hgnc:3236",
     "mappings": [
-      {
-        "coding": {
-          "id": "hgnc:3236",
-          "code": "HGNC:3236",
-          "system": "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ensembl:ensg00000146648",
-          "code": "ENSG00000146648",
-          "system": "https://www.ensembl.org/id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ncbi:1956",
-          "code": "1956",
-          "system": "https://www.ncbi.nlm.nih.gov/gene"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "refseq:NM_005228.5",
-          "code": "NM_005228.5",
-          "system": "https://www.ncbi.nlm.nih.gov/nuccore"
-        },
-        "relation": "relatedMatch",
-        "extensions": [
-          {
-            "name": "mane_select",
-            "value": true,
-            "description": "Boolean value for if this transcript is a MANE Select transcript"
-          }
-        ]
-      }
+      157,
+      158,
+      159,
+      160
     ],
     "extensions": [
       {
@@ -1028,48 +398,13 @@
   {
     "id": 18,
     "conceptType": "Gene",
-    "primaryCode": "hgnc:3430",
     "name": "ERBB2",
+    "primaryCoding": "hgnc:3430",
     "mappings": [
-      {
-        "coding": {
-          "id": "hgnc:3430",
-          "code": "HGNC:3430",
-          "system": "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ensembl:ensg00000141736",
-          "code": "ENSG00000141736",
-          "system": "https://www.ensembl.org/id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ncbi:2064",
-          "code": "2064",
-          "system": "https://www.ncbi.nlm.nih.gov/gene"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "refseq:NM_004448.4",
-          "code": "NM_004448.4",
-          "system": "https://www.ncbi.nlm.nih.gov/nuccore"
-        },
-        "relation": "relatedMatch",
-        "extensions": [
-          {
-            "name": "mane_select",
-            "value": true,
-            "description": "Boolean value for if this transcript is a MANE Select transcript"
-          }
-        ]
-      }
+      161,
+      162,
+      163,
+      164
     ],
     "extensions": [
       {
@@ -1085,48 +420,13 @@
   {
     "id": 19,
     "conceptType": "Gene",
-    "primaryCode": "hgnc:3467",
     "name": "ESR1",
+    "primaryCoding": "hgnc:3467",
     "mappings": [
-      {
-        "coding": {
-          "id": "hgnc:3467",
-          "code": "HGNC:3467",
-          "system": "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ensembl:ensg00000091831",
-          "code": "ENSG00000091831",
-          "system": "https://www.ensembl.org/id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ncbi:2099",
-          "code": "2099",
-          "system": "https://www.ncbi.nlm.nih.gov/gene"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "refseq:NM_000125.4",
-          "code": "NM_000125.4",
-          "system": "https://www.ncbi.nlm.nih.gov/nuccore"
-        },
-        "relation": "relatedMatch",
-        "extensions": [
-          {
-            "name": "mane_select",
-            "value": true,
-            "description": "Boolean value for if this transcript is a MANE Select transcript"
-          }
-        ]
-      }
+      165,
+      166,
+      167,
+      168
     ],
     "extensions": [
       {
@@ -1142,48 +442,13 @@
   {
     "id": 20,
     "conceptType": "Gene",
-    "primaryCode": "hgnc:3527",
     "name": "EZH2",
+    "primaryCoding": "hgnc:3527",
     "mappings": [
-      {
-        "coding": {
-          "id": "hgnc:3527",
-          "code": "HGNC:3527",
-          "system": "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ensembl:ensg00000106462",
-          "code": "ENSG00000106462",
-          "system": "https://www.ensembl.org/id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ncbi:2146",
-          "code": "2146",
-          "system": "https://www.ncbi.nlm.nih.gov/gene"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "refseq:NM_004456.5",
-          "code": "NM_004456.5",
-          "system": "https://www.ncbi.nlm.nih.gov/nuccore"
-        },
-        "relation": "relatedMatch",
-        "extensions": [
-          {
-            "name": "mane_select",
-            "value": true,
-            "description": "Boolean value for if this transcript is a MANE Select transcript"
-          }
-        ]
-      }
+      169,
+      170,
+      171,
+      172
     ],
     "extensions": [
       {
@@ -1199,48 +464,13 @@
   {
     "id": 21,
     "conceptType": "Gene",
-    "primaryCode": "hgnc:20748",
     "name": "FANCL",
+    "primaryCoding": "hgnc:20748",
     "mappings": [
-      {
-        "coding": {
-          "id": "hgnc:20748",
-          "code": "HGNC:20748",
-          "system": "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ensembl:ensg00000115392",
-          "code": "ENSG00000115392",
-          "system": "https://www.ensembl.org/id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ncbi:55120",
-          "code": "55120",
-          "system": "https://www.ncbi.nlm.nih.gov/gene"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "refseq:NM_018062.4",
-          "code": "NM_018062.4",
-          "system": "https://www.ncbi.nlm.nih.gov/nuccore"
-        },
-        "relation": "relatedMatch",
-        "extensions": [
-          {
-            "name": "mane_select",
-            "value": true,
-            "description": "Boolean value for if this transcript is a MANE Select transcript"
-          }
-        ]
-      }
+      173,
+      174,
+      175,
+      176
     ],
     "extensions": [
       {
@@ -1256,48 +486,13 @@
   {
     "id": 22,
     "conceptType": "Gene",
-    "primaryCode": "hgnc:3688",
     "name": "FGFR1",
+    "primaryCoding": "hgnc:3688",
     "mappings": [
-      {
-        "coding": {
-          "id": "hgnc:3688",
-          "code": "HGNC:3688",
-          "system": "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ensembl:ensg00000077782",
-          "code": "ENSG00000077782",
-          "system": "https://www.ensembl.org/id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ncbi:2260",
-          "code": "2260",
-          "system": "https://www.ncbi.nlm.nih.gov/gene"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "refseq:NM_023110.3",
-          "code": "NM_023110.3",
-          "system": "https://www.ncbi.nlm.nih.gov/nuccore"
-        },
-        "relation": "relatedMatch",
-        "extensions": [
-          {
-            "name": "mane_select",
-            "value": true,
-            "description": "Boolean value for if this transcript is a MANE Select transcript"
-          }
-        ]
-      }
+      177,
+      178,
+      179,
+      180
     ],
     "extensions": [
       {
@@ -1313,48 +508,13 @@
   {
     "id": 23,
     "conceptType": "Gene",
-    "primaryCode": "hgnc:3689",
     "name": "FGFR2",
+    "primaryCoding": "hgnc:3689",
     "mappings": [
-      {
-        "coding": {
-          "id": "hgnc:3689",
-          "code": "HGNC:3689",
-          "system": "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ensembl:ensg00000066468",
-          "code": "ENSG00000066468",
-          "system": "https://www.ensembl.org/id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ncbi:2263",
-          "code": "2263",
-          "system": "https://www.ncbi.nlm.nih.gov/gene"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "refseq:NM_000141.5",
-          "code": "NM_000141.5",
-          "system": "https://www.ncbi.nlm.nih.gov/nuccore"
-        },
-        "relation": "relatedMatch",
-        "extensions": [
-          {
-            "name": "mane_select",
-            "value": true,
-            "description": "Boolean value for if this transcript is a MANE Select transcript"
-          }
-        ]
-      }
+      181,
+      182,
+      183,
+      184
     ],
     "extensions": [
       {
@@ -1370,48 +530,13 @@
   {
     "id": 24,
     "conceptType": "Gene",
-    "primaryCode": "hgnc:3690",
     "name": "FGFR3",
+    "primaryCoding": "hgnc:3690",
     "mappings": [
-      {
-        "coding": {
-          "id": "hgnc:3690",
-          "code": "HGNC:3690",
-          "system": "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ensembl:ensg00000068078",
-          "code": "ENSG00000068078",
-          "system": "https://www.ensembl.org/id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ncbi:2261",
-          "code": "2261",
-          "system": "https://www.ncbi.nlm.nih.gov/gene"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "refseq:NM_000142.5",
-          "code": "NM_000142.5",
-          "system": "https://www.ncbi.nlm.nih.gov/nuccore"
-        },
-        "relation": "relatedMatch",
-        "extensions": [
-          {
-            "name": "mane_select",
-            "value": true,
-            "description": "Boolean value for if this transcript is a MANE Select transcript"
-          }
-        ]
-      }
+      185,
+      186,
+      187,
+      188
     ],
     "extensions": [
       {
@@ -1427,48 +552,13 @@
   {
     "id": 25,
     "conceptType": "Gene",
-    "primaryCode": "hgnc:19124",
     "name": "FIP1L1",
+    "primaryCoding": "hgnc:19124",
     "mappings": [
-      {
-        "coding": {
-          "id": "hgnc:19124",
-          "code": "HGNC:19124",
-          "system": "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ensembl:ensg00000145216",
-          "code": "ENSG00000145216",
-          "system": "https://www.ensembl.org/id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ncbi:81608",
-          "code": "81608",
-          "system": "https://www.ncbi.nlm.nih.gov/gene"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "refseq:NM_030917.4",
-          "code": "NM_030917.4",
-          "system": "https://www.ncbi.nlm.nih.gov/nuccore"
-        },
-        "relation": "relatedMatch",
-        "extensions": [
-          {
-            "name": "mane_select",
-            "value": true,
-            "description": "Boolean value for if this transcript is a MANE Select transcript"
-          }
-        ]
-      }
+      189,
+      190,
+      191,
+      192
     ],
     "extensions": [
       {
@@ -1484,48 +574,13 @@
   {
     "id": 26,
     "conceptType": "Gene",
-    "primaryCode": "hgnc:3765",
     "name": "FLT3",
+    "primaryCoding": "hgnc:3765",
     "mappings": [
-      {
-        "coding": {
-          "id": "hgnc:3765",
-          "code": "HGNC:3765",
-          "system": "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ensembl:ensg00000122025",
-          "code": "ENSG00000122025",
-          "system": "https://www.ensembl.org/id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ncbi:2322",
-          "code": "2322",
-          "system": "https://www.ncbi.nlm.nih.gov/gene"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "refseq:NM_004119.3",
-          "code": "NM_004119.3",
-          "system": "https://www.ncbi.nlm.nih.gov/nuccore"
-        },
-        "relation": "relatedMatch",
-        "extensions": [
-          {
-            "name": "mane_select",
-            "value": true,
-            "description": "Boolean value for if this transcript is a MANE Select transcript"
-          }
-        ]
-      }
+      193,
+      194,
+      195,
+      196
     ],
     "extensions": [
       {
@@ -1541,48 +596,13 @@
   {
     "id": 27,
     "conceptType": "Gene",
-    "primaryCode": "hgnc:5173",
     "name": "HRAS",
+    "primaryCoding": "hgnc:5173",
     "mappings": [
-      {
-        "coding": {
-          "id": "hgnc:5173",
-          "code": "HGNC:5173",
-          "system": "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ensembl:ensg00000174775",
-          "code": "ENSG00000174775",
-          "system": "https://www.ensembl.org/id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ncbi:3265",
-          "code": "3265",
-          "system": "https://www.ncbi.nlm.nih.gov/gene"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "refseq:NM_005343.4",
-          "code": "NM_005343.4",
-          "system": "https://www.ncbi.nlm.nih.gov/nuccore"
-        },
-        "relation": "relatedMatch",
-        "extensions": [
-          {
-            "name": "mane_select",
-            "value": true,
-            "description": "Boolean value for if this transcript is a MANE Select transcript"
-          }
-        ]
-      }
+      197,
+      198,
+      199,
+      200
     ],
     "extensions": [
       {
@@ -1598,48 +618,13 @@
   {
     "id": 28,
     "conceptType": "Gene",
-    "primaryCode": "hgnc:5382",
     "name": "IDH1",
+    "primaryCoding": "hgnc:5382",
     "mappings": [
-      {
-        "coding": {
-          "id": "hgnc:5382",
-          "code": "HGNC:5382",
-          "system": "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ensembl:ensg00000138413",
-          "code": "ENSG00000138413",
-          "system": "https://www.ensembl.org/id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ncbi:3417",
-          "code": "3417",
-          "system": "https://www.ncbi.nlm.nih.gov/gene"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "refseq:NM_005896.4",
-          "code": "NM_005896.4",
-          "system": "https://www.ncbi.nlm.nih.gov/nuccore"
-        },
-        "relation": "relatedMatch",
-        "extensions": [
-          {
-            "name": "mane_select",
-            "value": true,
-            "description": "Boolean value for if this transcript is a MANE Select transcript"
-          }
-        ]
-      }
+      201,
+      202,
+      203,
+      204
     ],
     "extensions": [
       {
@@ -1655,48 +640,13 @@
   {
     "id": 29,
     "conceptType": "Gene",
-    "primaryCode": "hgnc:5383",
     "name": "IDH2",
+    "primaryCoding": "hgnc:5383",
     "mappings": [
-      {
-        "coding": {
-          "id": "hgnc:5383",
-          "code": "HGNC:5383",
-          "system": "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ensembl:ensg00000182054",
-          "code": "ENSG00000182054",
-          "system": "https://www.ensembl.org/id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ncbi:3418",
-          "code": "3418",
-          "system": "https://www.ncbi.nlm.nih.gov/gene"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "refseq:NM_002168.4",
-          "code": "NM_002168.4",
-          "system": "https://www.ncbi.nlm.nih.gov/nuccore"
-        },
-        "relation": "relatedMatch",
-        "extensions": [
-          {
-            "name": "mane_select",
-            "value": true,
-            "description": "Boolean value for if this transcript is a MANE Select transcript"
-          }
-        ]
-      }
+      205,
+      206,
+      207,
+      208
     ],
     "extensions": [
       {
@@ -1712,48 +662,13 @@
   {
     "id": 30,
     "conceptType": "Gene",
-    "primaryCode": "hgnc:6342",
     "name": "KIT",
+    "primaryCoding": "hgnc:6342",
     "mappings": [
-      {
-        "coding": {
-          "id": "hgnc:6342",
-          "code": "HGNC:6342",
-          "system": "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ensembl:ensg00000157404",
-          "code": "ENSG00000157404",
-          "system": "https://www.ensembl.org/id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ncbi:3815",
-          "code": "3815",
-          "system": "https://www.ncbi.nlm.nih.gov/gene"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "refseq:NM_000222.3",
-          "code": "NM_000222.3",
-          "system": "https://www.ncbi.nlm.nih.gov/nuccore"
-        },
-        "relation": "relatedMatch",
-        "extensions": [
-          {
-            "name": "mane_select",
-            "value": true,
-            "description": "Boolean value for if this transcript is a MANE Select transcript"
-          }
-        ]
-      }
+      209,
+      210,
+      211,
+      212
     ],
     "extensions": [
       {
@@ -1769,48 +684,13 @@
   {
     "id": 31,
     "conceptType": "Gene",
-    "primaryCode": "hgnc:6407",
     "name": "KRAS",
+    "primaryCoding": "hgnc:6407",
     "mappings": [
-      {
-        "coding": {
-          "id": "hgnc:6407",
-          "code": "HGNC:6407",
-          "system": "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ensembl:ensg00000133703",
-          "code": "ENSG00000133703",
-          "system": "https://www.ensembl.org/id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ncbi:3845",
-          "code": "3845",
-          "system": "https://www.ncbi.nlm.nih.gov/gene"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "refseq:NM_004985.5",
-          "code": "NM_004985.5",
-          "system": "https://www.ncbi.nlm.nih.gov/nuccore"
-        },
-        "relation": "relatedMatch",
-        "extensions": [
-          {
-            "name": "mane_select",
-            "value": true,
-            "description": "Boolean value for if this transcript is a MANE Select transcript"
-          }
-        ]
-      }
+      213,
+      214,
+      215,
+      216
     ],
     "extensions": [
       {
@@ -1826,48 +706,13 @@
   {
     "id": 32,
     "conceptType": "Gene",
-    "primaryCode": "hgnc:7029",
     "name": "MET",
+    "primaryCoding": "hgnc:7029",
     "mappings": [
-      {
-        "coding": {
-          "id": "hgnc:7029",
-          "code": "HGNC:7029",
-          "system": "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ensembl:ensg00000105976",
-          "code": "ENSG00000105976",
-          "system": "https://www.ensembl.org/id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ncbi:4233",
-          "code": "4233",
-          "system": "https://www.ncbi.nlm.nih.gov/gene"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "refseq:NM_000245.4",
-          "code": "NM_000245.4",
-          "system": "https://www.ncbi.nlm.nih.gov/nuccore"
-        },
-        "relation": "relatedMatch",
-        "extensions": [
-          {
-            "name": "mane_select",
-            "value": true,
-            "description": "Boolean value for if this transcript is a MANE Select transcript"
-          }
-        ]
-      }
+      217,
+      218,
+      219,
+      220
     ],
     "extensions": [
       {
@@ -1883,48 +728,13 @@
   {
     "id": 33,
     "conceptType": "Gene",
-    "primaryCode": "hgnc:7989",
     "name": "NRAS",
+    "primaryCoding": "hgnc:7989",
     "mappings": [
-      {
-        "coding": {
-          "id": "hgnc:7989",
-          "code": "HGNC:7989",
-          "system": "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ensembl:ensg00000213281",
-          "code": "ENSG00000213281",
-          "system": "https://www.ensembl.org/id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ncbi:4893",
-          "code": "4893",
-          "system": "https://www.ncbi.nlm.nih.gov/gene"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "refseq:NM_002524.5",
-          "code": "NM_002524.5",
-          "system": "https://www.ncbi.nlm.nih.gov/nuccore"
-        },
-        "relation": "relatedMatch",
-        "extensions": [
-          {
-            "name": "mane_select",
-            "value": true,
-            "description": "Boolean value for if this transcript is a MANE Select transcript"
-          }
-        ]
-      }
+      221,
+      222,
+      223,
+      224
     ],
     "extensions": [
       {
@@ -1940,48 +750,13 @@
   {
     "id": 34,
     "conceptType": "Gene",
-    "primaryCode": "hgnc:7997",
     "name": "NRG1",
+    "primaryCoding": "hgnc:7997",
     "mappings": [
-      {
-        "coding": {
-          "id": "hgnc:7997",
-          "code": "HGNC:7997",
-          "system": "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ensembl:ensg00000157168",
-          "code": "ENSG00000157168",
-          "system": "https://www.ensembl.org/id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ncbi:3084",
-          "code": "3084",
-          "system": "https://www.ncbi.nlm.nih.gov/gene"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "refseq:NM_013964.5",
-          "code": "NM_013964.5",
-          "system": "https://www.ncbi.nlm.nih.gov/nuccore"
-        },
-        "relation": "relatedMatch",
-        "extensions": [
-          {
-            "name": "mane_select",
-            "value": true,
-            "description": "Boolean value for if this transcript is a MANE Select transcript"
-          }
-        ]
-      }
+      225,
+      226,
+      227,
+      228
     ],
     "extensions": [
       {
@@ -1997,48 +772,13 @@
   {
     "id": 35,
     "conceptType": "Gene",
-    "primaryCode": "hgnc:8031",
     "name": "NTRK1",
+    "primaryCoding": "hgnc:8031",
     "mappings": [
-      {
-        "coding": {
-          "id": "hgnc:8031",
-          "code": "HGNC:8031",
-          "system": "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ensembl:ensg00000198400",
-          "code": "ENSG00000198400",
-          "system": "https://www.ensembl.org/id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ncbi:4914",
-          "code": "4914",
-          "system": "https://www.ncbi.nlm.nih.gov/gene"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "refseq:NM_002529.4",
-          "code": "NM_002529.4",
-          "system": "https://www.ncbi.nlm.nih.gov/nuccore"
-        },
-        "relation": "relatedMatch",
-        "extensions": [
-          {
-            "name": "mane_select",
-            "value": true,
-            "description": "Boolean value for if this transcript is a MANE Select transcript"
-          }
-        ]
-      }
+      229,
+      230,
+      231,
+      232
     ],
     "extensions": [
       {
@@ -2054,48 +794,13 @@
   {
     "id": 36,
     "conceptType": "Gene",
-    "primaryCode": "hgnc:8032",
     "name": "NTRK2",
+    "primaryCoding": "hgnc:8032",
     "mappings": [
-      {
-        "coding": {
-          "id": "hgnc:8032",
-          "code": "HGNC:8032",
-          "system": "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ensembl:ensg00000148053",
-          "code": "ENSG00000148053",
-          "system": "https://www.ensembl.org/id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ncbi:4915",
-          "code": "4915",
-          "system": "https://www.ncbi.nlm.nih.gov/gene"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "refseq:NM_006180.6",
-          "code": "NM_006180.6",
-          "system": "https://www.ncbi.nlm.nih.gov/nuccore"
-        },
-        "relation": "relatedMatch",
-        "extensions": [
-          {
-            "name": "mane_select",
-            "value": true,
-            "description": "Boolean value for if this transcript is a MANE Select transcript"
-          }
-        ]
-      }
+      233,
+      234,
+      235,
+      236
     ],
     "extensions": [
       {
@@ -2111,48 +816,13 @@
   {
     "id": 37,
     "conceptType": "Gene",
-    "primaryCode": "hgnc:8033",
     "name": "NTRK3",
+    "primaryCoding": "hgnc:8033",
     "mappings": [
-      {
-        "coding": {
-          "id": "hgnc:8033",
-          "code": "HGNC:8033",
-          "system": "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ensembl:ensg00000140538",
-          "code": "ENSG00000140538",
-          "system": "https://www.ensembl.org/id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ncbi:4916",
-          "code": "4916",
-          "system": "https://www.ncbi.nlm.nih.gov/gene"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "refseq:NM_001012338.3",
-          "code": "NM_001012338.3",
-          "system": "https://www.ncbi.nlm.nih.gov/nuccore"
-        },
-        "relation": "relatedMatch",
-        "extensions": [
-          {
-            "name": "mane_select",
-            "value": true,
-            "description": "Boolean value for if this transcript is a MANE Select transcript"
-          }
-        ]
-      }
+      237,
+      238,
+      239,
+      240
     ],
     "extensions": [
       {
@@ -2168,48 +838,13 @@
   {
     "id": 38,
     "conceptType": "Gene",
-    "primaryCode": "hgnc:26144",
     "name": "PALB2",
+    "primaryCoding": "hgnc:26144",
     "mappings": [
-      {
-        "coding": {
-          "id": "hgnc:26144",
-          "code": "HGNC:26144",
-          "system": "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ensembl:ensg00000083093",
-          "code": "ENSG00000083093",
-          "system": "https://www.ensembl.org/id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ncbi:79728",
-          "code": "79728",
-          "system": "https://www.ncbi.nlm.nih.gov/gene"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "refseq:NM_024675.4",
-          "code": "NM_024675.4",
-          "system": "https://www.ncbi.nlm.nih.gov/nuccore"
-        },
-        "relation": "relatedMatch",
-        "extensions": [
-          {
-            "name": "mane_select",
-            "value": true,
-            "description": "Boolean value for if this transcript is a MANE Select transcript"
-          }
-        ]
-      }
+      241,
+      242,
+      243,
+      244
     ],
     "extensions": [
       {
@@ -2225,48 +860,13 @@
   {
     "id": 39,
     "conceptType": "Gene",
-    "primaryCode": "hgnc:8803",
     "name": "PDGFRA",
+    "primaryCoding": "hgnc:8803",
     "mappings": [
-      {
-        "coding": {
-          "id": "hgnc:8803",
-          "code": "HGNC:8803",
-          "system": "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ensembl:ensg00000134853",
-          "code": "ENSG00000134853",
-          "system": "https://www.ensembl.org/id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ncbi:5156",
-          "code": "5156",
-          "system": "https://www.ncbi.nlm.nih.gov/gene"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "refseq:NM_006206.6",
-          "code": "NM_006206.6",
-          "system": "https://www.ncbi.nlm.nih.gov/nuccore"
-        },
-        "relation": "relatedMatch",
-        "extensions": [
-          {
-            "name": "mane_select",
-            "value": true,
-            "description": "Boolean value for if this transcript is a MANE Select transcript"
-          }
-        ]
-      }
+      245,
+      246,
+      247,
+      248
     ],
     "extensions": [
       {
@@ -2282,48 +882,13 @@
   {
     "id": 40,
     "conceptType": "Gene",
-    "primaryCode": "hgnc:8804",
     "name": "PDGFRB",
+    "primaryCoding": "hgnc:8804",
     "mappings": [
-      {
-        "coding": {
-          "id": "hgnc:8804",
-          "code": "HGNC:8804",
-          "system": "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ensembl:ensg00000113721",
-          "code": "ENSG00000113721",
-          "system": "https://www.ensembl.org/id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ncbi:5159",
-          "code": "5159",
-          "system": "https://www.ncbi.nlm.nih.gov/gene"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "refseq:NM_002609.4",
-          "code": "NM_002609.4",
-          "system": "https://www.ncbi.nlm.nih.gov/nuccore"
-        },
-        "relation": "relatedMatch",
-        "extensions": [
-          {
-            "name": "mane_select",
-            "value": true,
-            "description": "Boolean value for if this transcript is a MANE Select transcript"
-          }
-        ]
-      }
+      249,
+      250,
+      251,
+      252
     ],
     "extensions": [
       {
@@ -2339,48 +904,13 @@
   {
     "id": 41,
     "conceptType": "Gene",
-    "primaryCode": "hgnc:8975",
     "name": "PIK3CA",
+    "primaryCoding": "hgnc:8975",
     "mappings": [
-      {
-        "coding": {
-          "id": "hgnc:8975",
-          "code": "HGNC:8975",
-          "system": "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ensembl:ensg00000121879",
-          "code": "ENSG00000121879",
-          "system": "https://www.ensembl.org/id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ncbi:5290",
-          "code": "5290",
-          "system": "https://www.ncbi.nlm.nih.gov/gene"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "refseq:NM_006218.4",
-          "code": "NM_006218.4",
-          "system": "https://www.ncbi.nlm.nih.gov/nuccore"
-        },
-        "relation": "relatedMatch",
-        "extensions": [
-          {
-            "name": "mane_select",
-            "value": true,
-            "description": "Boolean value for if this transcript is a MANE Select transcript"
-          }
-        ]
-      }
+      253,
+      254,
+      255,
+      256
     ],
     "extensions": [
       {
@@ -2396,48 +926,13 @@
   {
     "id": 42,
     "conceptType": "Gene",
-    "primaryCode": "hgnc:9113",
     "name": "PML",
+    "primaryCoding": "hgnc:9113",
     "mappings": [
-      {
-        "coding": {
-          "id": "hgnc:9113",
-          "code": "HGNC:9113",
-          "system": "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ensembl:ensg00000140464",
-          "code": "ENSG00000140464",
-          "system": "https://www.ensembl.org/id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ncbi:5371",
-          "code": "5371",
-          "system": "https://www.ncbi.nlm.nih.gov/gene"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "refseq:NM_033238.3",
-          "code": "NM_033238.3",
-          "system": "https://www.ncbi.nlm.nih.gov/nuccore"
-        },
-        "relation": "relatedMatch",
-        "extensions": [
-          {
-            "name": "mane_select",
-            "value": true,
-            "description": "Boolean value for if this transcript is a MANE Select transcript"
-          }
-        ]
-      }
+      257,
+      258,
+      259,
+      260
     ],
     "extensions": [
       {
@@ -2453,48 +948,13 @@
   {
     "id": 43,
     "conceptType": "Gene",
-    "primaryCode": "hgnc:9588",
     "name": "PTEN",
+    "primaryCoding": "hgnc:9588",
     "mappings": [
-      {
-        "coding": {
-          "id": "hgnc:9588",
-          "code": "HGNC:9588",
-          "system": "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ensembl:ensg00000171862",
-          "code": "ENSG00000171862",
-          "system": "https://www.ensembl.org/id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ncbi:5728",
-          "code": "5728",
-          "system": "https://www.ncbi.nlm.nih.gov/gene"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "refseq:NM_000314.8",
-          "code": "NM_000314.8",
-          "system": "https://www.ncbi.nlm.nih.gov/nuccore"
-        },
-        "relation": "relatedMatch",
-        "extensions": [
-          {
-            "name": "mane_select",
-            "value": true,
-            "description": "Boolean value for if this transcript is a MANE Select transcript"
-          }
-        ]
-      }
+      261,
+      262,
+      263,
+      264
     ],
     "extensions": [
       {
@@ -2510,48 +970,13 @@
   {
     "id": 44,
     "conceptType": "Gene",
-    "primaryCode": "hgnc:9822",
     "name": "RAD51B",
+    "primaryCoding": "hgnc:9822",
     "mappings": [
-      {
-        "coding": {
-          "id": "hgnc:9822",
-          "code": "HGNC:9822",
-          "system": "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ensembl:ensg00000182185",
-          "code": "ENSG00000182185",
-          "system": "https://www.ensembl.org/id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ncbi:5890",
-          "code": "5890",
-          "system": "https://www.ncbi.nlm.nih.gov/gene"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "refseq:NM_133510.4",
-          "code": "NM_133510.4",
-          "system": "https://www.ncbi.nlm.nih.gov/nuccore"
-        },
-        "relation": "relatedMatch",
-        "extensions": [
-          {
-            "name": "mane_select",
-            "value": true,
-            "description": "Boolean value for if this transcript is a MANE Select transcript"
-          }
-        ]
-      }
+      265,
+      266,
+      267,
+      268
     ],
     "extensions": [
       {
@@ -2567,48 +992,13 @@
   {
     "id": 45,
     "conceptType": "Gene",
-    "primaryCode": "hgnc:9820",
     "name": "RAD51C",
+    "primaryCoding": "hgnc:9820",
     "mappings": [
-      {
-        "coding": {
-          "id": "hgnc:9820",
-          "code": "HGNC:9820",
-          "system": "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ensembl:ensg00000108384",
-          "code": "ENSG00000108384",
-          "system": "https://www.ensembl.org/id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ncbi:5889",
-          "code": "5889",
-          "system": "https://www.ncbi.nlm.nih.gov/gene"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "refseq:NM_058216.3",
-          "code": "NM_058216.3",
-          "system": "https://www.ncbi.nlm.nih.gov/nuccore"
-        },
-        "relation": "relatedMatch",
-        "extensions": [
-          {
-            "name": "mane_select",
-            "value": true,
-            "description": "Boolean value for if this transcript is a MANE Select transcript"
-          }
-        ]
-      }
+      269,
+      270,
+      271,
+      272
     ],
     "extensions": [
       {
@@ -2624,48 +1014,13 @@
   {
     "id": 46,
     "conceptType": "Gene",
-    "primaryCode": "hgnc:9823",
     "name": "RAD51D",
+    "primaryCoding": "hgnc:9823",
     "mappings": [
-      {
-        "coding": {
-          "id": "hgnc:9823",
-          "code": "HGNC:9823",
-          "system": "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ensembl:ensg00000185379",
-          "code": "ENSG00000185379",
-          "system": "https://www.ensembl.org/id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ncbi:5892",
-          "code": "5892",
-          "system": "https://www.ncbi.nlm.nih.gov/gene"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "refseq:NM_002878.4",
-          "code": "NM_002878.4",
-          "system": "https://www.ncbi.nlm.nih.gov/nuccore"
-        },
-        "relation": "relatedMatch",
-        "extensions": [
-          {
-            "name": "mane_select",
-            "value": true,
-            "description": "Boolean value for if this transcript is a MANE Select transcript"
-          }
-        ]
-      }
+      273,
+      274,
+      275,
+      276
     ],
     "extensions": [
       {
@@ -2681,48 +1036,13 @@
   {
     "id": 47,
     "conceptType": "Gene",
-    "primaryCode": "hgnc:9826",
     "name": "RAD54L",
+    "primaryCoding": "hgnc:9826",
     "mappings": [
-      {
-        "coding": {
-          "id": "hgnc:9826",
-          "code": "HGNC:9826",
-          "system": "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ensembl:ensg00000085999",
-          "code": "ENSG00000085999",
-          "system": "https://www.ensembl.org/id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ncbi:8438",
-          "code": "8438",
-          "system": "https://www.ncbi.nlm.nih.gov/gene"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "refseq:NM_003579.4",
-          "code": "NM_003579.4",
-          "system": "https://www.ncbi.nlm.nih.gov/nuccore"
-        },
-        "relation": "relatedMatch",
-        "extensions": [
-          {
-            "name": "mane_select",
-            "value": true,
-            "description": "Boolean value for if this transcript is a MANE Select transcript"
-          }
-        ]
-      }
+      277,
+      278,
+      279,
+      280
     ],
     "extensions": [
       {
@@ -2738,48 +1058,13 @@
   {
     "id": 48,
     "conceptType": "Gene",
-    "primaryCode": "hgnc:9864",
     "name": "RARA",
+    "primaryCoding": "hgnc:9864",
     "mappings": [
-      {
-        "coding": {
-          "id": "hgnc:9864",
-          "code": "HGNC:9864",
-          "system": "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ensembl:ensg00000131759",
-          "code": "ENSG00000131759",
-          "system": "https://www.ensembl.org/id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ncbi:5914",
-          "code": "5914",
-          "system": "https://www.ncbi.nlm.nih.gov/gene"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "refseq:NM_000964.4",
-          "code": "NM_000964.4",
-          "system": "https://www.ncbi.nlm.nih.gov/nuccore"
-        },
-        "relation": "relatedMatch",
-        "extensions": [
-          {
-            "name": "mane_select",
-            "value": true,
-            "description": "Boolean value for if this transcript is a MANE Select transcript"
-          }
-        ]
-      }
+      281,
+      282,
+      283,
+      284
     ],
     "extensions": [
       {
@@ -2795,48 +1080,13 @@
   {
     "id": 49,
     "conceptType": "Gene",
-    "primaryCode": "hgnc:9967",
     "name": "RET",
+    "primaryCoding": "hgnc:9967",
     "mappings": [
-      {
-        "coding": {
-          "id": "hgnc:9967",
-          "code": "HGNC:9967",
-          "system": "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ensembl:ensg00000165731",
-          "code": "ENSG00000165731",
-          "system": "https://www.ensembl.org/id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ncbi:5979",
-          "code": "5979",
-          "system": "https://www.ncbi.nlm.nih.gov/gene"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "refseq:NM_020975.6",
-          "code": "NM_020975.6",
-          "system": "https://www.ncbi.nlm.nih.gov/nuccore"
-        },
-        "relation": "relatedMatch",
-        "extensions": [
-          {
-            "name": "mane_select",
-            "value": true,
-            "description": "Boolean value for if this transcript is a MANE Select transcript"
-          }
-        ]
-      }
+      285,
+      286,
+      287,
+      288
     ],
     "extensions": [
       {
@@ -2852,48 +1102,13 @@
   {
     "id": 50,
     "conceptType": "Gene",
-    "primaryCode": "hgnc:10261",
     "name": "ROS1",
+    "primaryCoding": "hgnc:10261",
     "mappings": [
-      {
-        "coding": {
-          "id": "hgnc:10261",
-          "code": "HGNC:10261",
-          "system": "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ensembl:ensg00000047936",
-          "code": "ENSG00000047936",
-          "system": "https://www.ensembl.org/id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ncbi:6098",
-          "code": "6098",
-          "system": "https://www.ncbi.nlm.nih.gov/gene"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "refseq:NM_001378902.1",
-          "code": "NM_001378902.1",
-          "system": "https://www.ncbi.nlm.nih.gov/nuccore"
-        },
-        "relation": "relatedMatch",
-        "extensions": [
-          {
-            "name": "mane_select",
-            "value": true,
-            "description": "Boolean value for if this transcript is a MANE Select transcript"
-          }
-        ]
-      }
+      289,
+      290,
+      291,
+      292
     ],
     "extensions": [
       {
@@ -2909,48 +1124,13 @@
   {
     "id": 51,
     "conceptType": "Gene",
-    "primaryCode": "hgnc:11524",
     "name": "TACC3",
+    "primaryCoding": "hgnc:11524",
     "mappings": [
-      {
-        "coding": {
-          "id": "hgnc:11524",
-          "code": "HGNC:11524",
-          "system": "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ensembl:ensg00000013810",
-          "code": "ENSG00000013810",
-          "system": "https://www.ensembl.org/id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ncbi:10460",
-          "code": "10460",
-          "system": "https://www.ncbi.nlm.nih.gov/gene"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "refseq:NM_006342.3",
-          "code": "NM_006342.3",
-          "system": "https://www.ncbi.nlm.nih.gov/nuccore"
-        },
-        "relation": "relatedMatch",
-        "extensions": [
-          {
-            "name": "mane_select",
-            "value": true,
-            "description": "Boolean value for if this transcript is a MANE Select transcript"
-          }
-        ]
-      }
+      293,
+      294,
+      295,
+      296
     ],
     "extensions": [
       {
@@ -2966,48 +1146,13 @@
   {
     "id": 52,
     "conceptType": "Gene",
-    "primaryCode": "hgnc:11998",
     "name": "TP53",
+    "primaryCoding": "hgnc:11998",
     "mappings": [
-      {
-        "coding": {
-          "id": "hgnc:11998",
-          "code": "HGNC:11998",
-          "system": "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ensembl:ensg00000141510",
-          "code": "ENSG00000141510",
-          "system": "https://www.ensembl.org/id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ncbi:7157",
-          "code": "7157",
-          "system": "https://www.ncbi.nlm.nih.gov/gene"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "refseq:NM_000546.6",
-          "code": "NM_000546.6",
-          "system": "https://www.ncbi.nlm.nih.gov/nuccore"
-        },
-        "relation": "relatedMatch",
-        "extensions": [
-          {
-            "name": "mane_select",
-            "value": true,
-            "description": "Boolean value for if this transcript is a MANE Select transcript"
-          }
-        ]
-      }
+      297,
+      298,
+      299,
+      300
     ],
     "extensions": [
       {
@@ -3023,257 +1168,89 @@
   {
     "id": 53,
     "conceptType": "Gene",
-    "primaryCode": "hgnc:7131",
     "name": "KMT2A",
+    "primaryCoding": "hgnc:7131",
     "mappings": [
-      {
-        "coding": {
-          "id": "hgnc:7131",
-          "code": "HGNC:7131",
-          "system": "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ensembl:ensg00000118058",
-          "code": "ENSG00000118058",
-          "system": "https://www.ensembl.org/id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ncbi:4297",
-          "code": "4297",
-          "system": "https://www.ncbi.nlm.nih.gov/gene"
-        },
-        "relation": "exactMatch"
-      }
+      301,
+      302,
+      303
     ]
   },
   {
     "id": 54,
     "conceptType": "Gene",
-    "primaryCode": "hgnc:12362",
     "name": "TSC1",
+    "primaryCoding": "hgnc:12362",
     "mappings": [
-      {
-        "coding": {
-          "id": "hgnc:12362",
-          "code": "HGNC:12362",
-          "system": "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ensembl:ENSG00000165699",
-          "code": "ENSG00000165699",
-          "system": "https://www.ensembl.org/id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ncbi:7248",
-          "code": "7248",
-          "system": "https://www.ncbi.nlm.nih.gov/gene"
-        },
-        "relation": "exactMatch"
-      }
+      304,
+      305,
+      306
     ]
   },
   {
     "id": 55,
     "conceptType": "Gene",
-    "primaryCode": "hgnc:12363",
     "name": "TSC2",
+    "primaryCoding": "hgnc:12363",
     "mappings": [
-      {
-        "coding": {
-          "id": "hgnc:12363",
-          "code": "HGNC:12363",
-          "system": "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ensembl:ENSG00000103197",
-          "code": "ENSG00000103197",
-          "system": "https://www.ensembl.org/id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ncbi:7249",
-          "code": "7249",
-          "system": "https://www.ncbi.nlm.nih.gov/gene"
-        },
-        "relation": "exactMatch"
-      }
+      307,
+      308,
+      309
     ]
   },
   {
     "id": 56,
     "conceptType": "Gene",
-    "primaryCode": "hgnc:882",
     "name": "ATR",
+    "primaryCoding": "hgnc:882",
     "mappings": [
-      {
-        "coding": {
-          "id": "hgnc:882",
-          "code": "HGNC:882",
-          "system": "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ensembl:ENSG00000175054",
-          "code": "ENSG00000175054",
-          "system": "https://www.ensembl.org/id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ncbi:545",
-          "code": "545",
-          "system": "https://www.ncbi.nlm.nih.gov/gene"
-        },
-        "relation": "exactMatch"
-      }
+      310,
+      311,
+      312
     ]
   },
   {
     "id": 57,
     "conceptType": "Gene",
-    "primaryCode": "hgnc:3582",
     "name": "FANCA",
+    "primaryCoding": "hgnc:3582",
     "mappings": [
-      {
-        "coding": {
-          "id": "hgnc:3582",
-          "code": "HGNC:3582",
-          "system": "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ensembl:ENSG00000187741",
-          "code": "ENSG00000187741",
-          "system": "https://www.ensembl.org/id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ncbi:2175",
-          "code": "2175",
-          "system": "https://www.ncbi.nlm.nih.gov/gene"
-        },
-        "relation": "exactMatch"
-      }
+      313,
+      314,
+      315
     ]
   },
   {
     "id": 58,
     "conceptType": "Gene",
-    "primaryCode": "hgnc:7127",
     "name": "MLH1",
+    "primaryCoding": "hgnc:7127",
     "mappings": [
-      {
-        "coding": {
-          "id": "hgnc:7127",
-          "code": "HGNC:7127",
-          "system": "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ensembl:ENSG00000076242",
-          "code": "ENSG00000076242",
-          "system": "https://www.ensembl.org/id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ncbi:4292",
-          "code": "4292",
-          "system": "https://www.ncbi.nlm.nih.gov/gene"
-        },
-        "relation": "exactMatch"
-      }
+      316,
+      317,
+      318
     ]
   },
   {
     "id": 59,
     "conceptType": "Gene",
-    "primaryCode": "hgnc:7230",
     "name": "MRE11",
+    "primaryCoding": "hgnc:7230",
     "mappings": [
-      {
-        "coding": {
-          "id": "hgnc:7230",
-          "code": "HGNC:7230",
-          "system": "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ensembl:ENSG00000020922",
-          "code": "ENSG00000020922",
-          "system": "https://www.ensembl.org/id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ncbi:4361",
-          "code": "4361",
-          "system": "https://www.ncbi.nlm.nih.gov/gene"
-        },
-        "relation": "exactMatch"
-      }
+      319,
+      320,
+      321
     ]
   },
   {
     "id": 60,
     "conceptType": "Gene",
-    "primaryCode": "hgnc:7652",
     "name": "NBN",
+    "primaryCoding": "hgnc:7652",
     "mappings": [
-      {
-        "coding": {
-          "id": "hgnc:7652",
-          "code": "HGNC:7652",
-          "system": "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ensembl:ENSG00000104320",
-          "code": "ENSG00000104320",
-          "system": "https://www.ensembl.org/id"
-        },
-        "relation": "exactMatch"
-      },
-      {
-        "coding": {
-          "id": "ncbi:4683",
-          "code": "4683",
-          "system": "https://www.ncbi.nlm.nih.gov/gene"
-        },
-        "relation": "exactMatch"
-      }
+      322,
+      323,
+      324
     ]
   }
 ]

--- a/referenced/genes.json
+++ b/referenced/genes.json
@@ -3,7 +3,7 @@
     "id": 0,
     "conceptType": "Gene",
     "name": "ABL1",
-    "primaryCoding": "hgnc:76",
+    "primary_coding_id": "hgnc:76",
     "mappings": [
       0,
       1,
@@ -24,7 +24,7 @@
     "id": 1,
     "conceptType": "Gene",
     "name": "AKT1",
-    "primaryCoding": "hgnc:391",
+    "primary_coding_id": "hgnc:391",
     "mappings": [
       3,
       4,
@@ -45,7 +45,7 @@
     "id": 2,
     "conceptType": "Gene",
     "name": "ALK",
-    "primaryCoding": "hgnc:427",
+    "primary_coding_id": "hgnc:427",
     "mappings": [
       6,
       7,
@@ -66,7 +66,7 @@
     "id": 3,
     "conceptType": "Gene",
     "name": "ATM",
-    "primaryCoding": "hgnc:795",
+    "primary_coding_id": "hgnc:795",
     "mappings": [
       9,
       10,
@@ -87,7 +87,7 @@
     "id": 4,
     "conceptType": "Gene",
     "name": "BAIAP2L1",
-    "primaryCoding": "hgnc:21649",
+    "primary_coding_id": "hgnc:21649",
     "mappings": [
       12,
       13,
@@ -108,7 +108,7 @@
     "id": 5,
     "conceptType": "Gene",
     "name": "BARD1",
-    "primaryCoding": "hgnc:952",
+    "primary_coding_id": "hgnc:952",
     "mappings": [
       15,
       16,
@@ -129,7 +129,7 @@
     "id": 6,
     "conceptType": "Gene",
     "name": "BCR",
-    "primaryCoding": "hgnc:1014",
+    "primary_coding_id": "hgnc:1014",
     "mappings": [
       18,
       19,
@@ -150,7 +150,7 @@
     "id": 7,
     "conceptType": "Gene",
     "name": "BICC1",
-    "primaryCoding": "hgnc:19351",
+    "primary_coding_id": "hgnc:19351",
     "mappings": [
       21,
       22,
@@ -171,7 +171,7 @@
     "id": 8,
     "conceptType": "Gene",
     "name": "BRAF",
-    "primaryCoding": "hgnc:1097",
+    "primary_coding_id": "hgnc:1097",
     "mappings": [
       24,
       25,
@@ -192,7 +192,7 @@
     "id": 9,
     "conceptType": "Gene",
     "name": "BRCA1",
-    "primaryCoding": "hgnc:1100",
+    "primary_coding_id": "hgnc:1100",
     "mappings": [
       27,
       28,
@@ -213,7 +213,7 @@
     "id": 10,
     "conceptType": "Gene",
     "name": "BRCA2",
-    "primaryCoding": "hgnc:1101",
+    "primary_coding_id": "hgnc:1101",
     "mappings": [
       30,
       31,
@@ -234,7 +234,7 @@
     "id": 11,
     "conceptType": "Gene",
     "name": "BRIP1",
-    "primaryCoding": "hgnc:20473",
+    "primary_coding_id": "hgnc:20473",
     "mappings": [
       33,
       34,
@@ -255,7 +255,7 @@
     "id": 12,
     "conceptType": "Gene",
     "name": "CASP7",
-    "primaryCoding": "hgnc:1508",
+    "primary_coding_id": "hgnc:1508",
     "mappings": [
       36,
       37,
@@ -276,7 +276,7 @@
     "id": 13,
     "conceptType": "Gene",
     "name": "CD274",
-    "primaryCoding": "hgnc:17635",
+    "primary_coding_id": "hgnc:17635",
     "mappings": [
       39,
       40,
@@ -297,7 +297,7 @@
     "id": 14,
     "conceptType": "Gene",
     "name": "CDK12",
-    "primaryCoding": "hgnc:24224",
+    "primary_coding_id": "hgnc:24224",
     "mappings": [
       42,
       43,
@@ -318,7 +318,7 @@
     "id": 15,
     "conceptType": "Gene",
     "name": "CHEK1",
-    "primaryCoding": "hgnc:1925",
+    "primary_coding_id": "hgnc:1925",
     "mappings": [
       45,
       46,
@@ -339,7 +339,7 @@
     "id": 16,
     "conceptType": "Gene",
     "name": "CHEK2",
-    "primaryCoding": "hgnc:16627",
+    "primary_coding_id": "hgnc:16627",
     "mappings": [
       48,
       49,
@@ -360,7 +360,7 @@
     "id": 17,
     "conceptType": "Gene",
     "name": "EGFR",
-    "primaryCoding": "hgnc:3236",
+    "primary_coding_id": "hgnc:3236",
     "mappings": [
       51,
       52,
@@ -381,7 +381,7 @@
     "id": 18,
     "conceptType": "Gene",
     "name": "ERBB2",
-    "primaryCoding": "hgnc:3430",
+    "primary_coding_id": "hgnc:3430",
     "mappings": [
       54,
       55,
@@ -402,7 +402,7 @@
     "id": 19,
     "conceptType": "Gene",
     "name": "ESR1",
-    "primaryCoding": "hgnc:3467",
+    "primary_coding_id": "hgnc:3467",
     "mappings": [
       57,
       58,
@@ -423,7 +423,7 @@
     "id": 20,
     "conceptType": "Gene",
     "name": "EZH2",
-    "primaryCoding": "hgnc:3527",
+    "primary_coding_id": "hgnc:3527",
     "mappings": [
       60,
       61,
@@ -444,7 +444,7 @@
     "id": 21,
     "conceptType": "Gene",
     "name": "FANCL",
-    "primaryCoding": "hgnc:20748",
+    "primary_coding_id": "hgnc:20748",
     "mappings": [
       63,
       64,
@@ -465,7 +465,7 @@
     "id": 22,
     "conceptType": "Gene",
     "name": "FGFR1",
-    "primaryCoding": "hgnc:3688",
+    "primary_coding_id": "hgnc:3688",
     "mappings": [
       66,
       67,
@@ -486,7 +486,7 @@
     "id": 23,
     "conceptType": "Gene",
     "name": "FGFR2",
-    "primaryCoding": "hgnc:3689",
+    "primary_coding_id": "hgnc:3689",
     "mappings": [
       69,
       70,
@@ -507,7 +507,7 @@
     "id": 24,
     "conceptType": "Gene",
     "name": "FGFR3",
-    "primaryCoding": "hgnc:3690",
+    "primary_coding_id": "hgnc:3690",
     "mappings": [
       72,
       73,
@@ -528,7 +528,7 @@
     "id": 25,
     "conceptType": "Gene",
     "name": "FIP1L1",
-    "primaryCoding": "hgnc:19124",
+    "primary_coding_id": "hgnc:19124",
     "mappings": [
       75,
       76,
@@ -549,7 +549,7 @@
     "id": 26,
     "conceptType": "Gene",
     "name": "FLT3",
-    "primaryCoding": "hgnc:3765",
+    "primary_coding_id": "hgnc:3765",
     "mappings": [
       78,
       79,
@@ -570,7 +570,7 @@
     "id": 27,
     "conceptType": "Gene",
     "name": "HRAS",
-    "primaryCoding": "hgnc:5173",
+    "primary_coding_id": "hgnc:5173",
     "mappings": [
       81,
       82,
@@ -591,7 +591,7 @@
     "id": 28,
     "conceptType": "Gene",
     "name": "IDH1",
-    "primaryCoding": "hgnc:5382",
+    "primary_coding_id": "hgnc:5382",
     "mappings": [
       84,
       85,
@@ -612,7 +612,7 @@
     "id": 29,
     "conceptType": "Gene",
     "name": "IDH2",
-    "primaryCoding": "hgnc:5383",
+    "primary_coding_id": "hgnc:5383",
     "mappings": [
       87,
       88,
@@ -633,7 +633,7 @@
     "id": 30,
     "conceptType": "Gene",
     "name": "KIT",
-    "primaryCoding": "hgnc:6342",
+    "primary_coding_id": "hgnc:6342",
     "mappings": [
       90,
       91,
@@ -654,7 +654,7 @@
     "id": 31,
     "conceptType": "Gene",
     "name": "KRAS",
-    "primaryCoding": "hgnc:6407",
+    "primary_coding_id": "hgnc:6407",
     "mappings": [
       93,
       94,
@@ -675,7 +675,7 @@
     "id": 32,
     "conceptType": "Gene",
     "name": "MET",
-    "primaryCoding": "hgnc:7029",
+    "primary_coding_id": "hgnc:7029",
     "mappings": [
       96,
       97,
@@ -696,7 +696,7 @@
     "id": 33,
     "conceptType": "Gene",
     "name": "NRAS",
-    "primaryCoding": "hgnc:7989",
+    "primary_coding_id": "hgnc:7989",
     "mappings": [
       99,
       100,
@@ -717,7 +717,7 @@
     "id": 34,
     "conceptType": "Gene",
     "name": "NRG1",
-    "primaryCoding": "hgnc:7997",
+    "primary_coding_id": "hgnc:7997",
     "mappings": [
       102,
       103,
@@ -738,7 +738,7 @@
     "id": 35,
     "conceptType": "Gene",
     "name": "NTRK1",
-    "primaryCoding": "hgnc:8031",
+    "primary_coding_id": "hgnc:8031",
     "mappings": [
       105,
       106,
@@ -759,7 +759,7 @@
     "id": 36,
     "conceptType": "Gene",
     "name": "NTRK2",
-    "primaryCoding": "hgnc:8032",
+    "primary_coding_id": "hgnc:8032",
     "mappings": [
       108,
       109,
@@ -780,7 +780,7 @@
     "id": 37,
     "conceptType": "Gene",
     "name": "NTRK3",
-    "primaryCoding": "hgnc:8033",
+    "primary_coding_id": "hgnc:8033",
     "mappings": [
       111,
       112,
@@ -801,7 +801,7 @@
     "id": 38,
     "conceptType": "Gene",
     "name": "PALB2",
-    "primaryCoding": "hgnc:26144",
+    "primary_coding_id": "hgnc:26144",
     "mappings": [
       114,
       115,
@@ -822,7 +822,7 @@
     "id": 39,
     "conceptType": "Gene",
     "name": "PDGFRA",
-    "primaryCoding": "hgnc:8803",
+    "primary_coding_id": "hgnc:8803",
     "mappings": [
       117,
       118,
@@ -843,7 +843,7 @@
     "id": 40,
     "conceptType": "Gene",
     "name": "PDGFRB",
-    "primaryCoding": "hgnc:8804",
+    "primary_coding_id": "hgnc:8804",
     "mappings": [
       120,
       121,
@@ -864,7 +864,7 @@
     "id": 41,
     "conceptType": "Gene",
     "name": "PIK3CA",
-    "primaryCoding": "hgnc:8975",
+    "primary_coding_id": "hgnc:8975",
     "mappings": [
       123,
       124,
@@ -885,7 +885,7 @@
     "id": 42,
     "conceptType": "Gene",
     "name": "PML",
-    "primaryCoding": "hgnc:9113",
+    "primary_coding_id": "hgnc:9113",
     "mappings": [
       126,
       127,
@@ -906,7 +906,7 @@
     "id": 43,
     "conceptType": "Gene",
     "name": "PTEN",
-    "primaryCoding": "hgnc:9588",
+    "primary_coding_id": "hgnc:9588",
     "mappings": [
       129,
       130,
@@ -927,7 +927,7 @@
     "id": 44,
     "conceptType": "Gene",
     "name": "RAD51B",
-    "primaryCoding": "hgnc:9822",
+    "primary_coding_id": "hgnc:9822",
     "mappings": [
       132,
       133,
@@ -948,7 +948,7 @@
     "id": 45,
     "conceptType": "Gene",
     "name": "RAD51C",
-    "primaryCoding": "hgnc:9820",
+    "primary_coding_id": "hgnc:9820",
     "mappings": [
       135,
       136,
@@ -969,7 +969,7 @@
     "id": 46,
     "conceptType": "Gene",
     "name": "RAD51D",
-    "primaryCoding": "hgnc:9823",
+    "primary_coding_id": "hgnc:9823",
     "mappings": [
       138,
       139,
@@ -990,7 +990,7 @@
     "id": 47,
     "conceptType": "Gene",
     "name": "RAD54L",
-    "primaryCoding": "hgnc:9826",
+    "primary_coding_id": "hgnc:9826",
     "mappings": [
       141,
       142,
@@ -1011,7 +1011,7 @@
     "id": 48,
     "conceptType": "Gene",
     "name": "RARA",
-    "primaryCoding": "hgnc:9864",
+    "primary_coding_id": "hgnc:9864",
     "mappings": [
       144,
       145,
@@ -1032,7 +1032,7 @@
     "id": 49,
     "conceptType": "Gene",
     "name": "RET",
-    "primaryCoding": "hgnc:9967",
+    "primary_coding_id": "hgnc:9967",
     "mappings": [
       147,
       148,
@@ -1053,7 +1053,7 @@
     "id": 50,
     "conceptType": "Gene",
     "name": "ROS1",
-    "primaryCoding": "hgnc:10261",
+    "primary_coding_id": "hgnc:10261",
     "mappings": [
       150,
       151,
@@ -1074,7 +1074,7 @@
     "id": 51,
     "conceptType": "Gene",
     "name": "TACC3",
-    "primaryCoding": "hgnc:11524",
+    "primary_coding_id": "hgnc:11524",
     "mappings": [
       153,
       154,
@@ -1095,7 +1095,7 @@
     "id": 52,
     "conceptType": "Gene",
     "name": "TP53",
-    "primaryCoding": "hgnc:11998",
+    "primary_coding_id": "hgnc:11998",
     "mappings": [
       156,
       157,
@@ -1116,7 +1116,7 @@
     "id": 53,
     "conceptType": "Gene",
     "name": "KMT2A",
-    "primaryCoding": "hgnc:7131",
+    "primary_coding_id": "hgnc:7131",
     "mappings": [
       159,
       160
@@ -1126,7 +1126,7 @@
     "id": 54,
     "conceptType": "Gene",
     "name": "TSC1",
-    "primaryCoding": "hgnc:12362",
+    "primary_coding_id": "hgnc:12362",
     "mappings": [
       161,
       162
@@ -1136,7 +1136,7 @@
     "id": 55,
     "conceptType": "Gene",
     "name": "TSC2",
-    "primaryCoding": "hgnc:12363",
+    "primary_coding_id": "hgnc:12363",
     "mappings": [
       163,
       164
@@ -1146,7 +1146,7 @@
     "id": 56,
     "conceptType": "Gene",
     "name": "ATR",
-    "primaryCoding": "hgnc:882",
+    "primary_coding_id": "hgnc:882",
     "mappings": [
       165,
       166
@@ -1156,7 +1156,7 @@
     "id": 57,
     "conceptType": "Gene",
     "name": "FANCA",
-    "primaryCoding": "hgnc:3582",
+    "primary_coding_id": "hgnc:3582",
     "mappings": [
       167,
       168
@@ -1166,7 +1166,7 @@
     "id": 58,
     "conceptType": "Gene",
     "name": "MLH1",
-    "primaryCoding": "hgnc:7127",
+    "primary_coding_id": "hgnc:7127",
     "mappings": [
       169,
       170
@@ -1176,7 +1176,7 @@
     "id": 59,
     "conceptType": "Gene",
     "name": "MRE11",
-    "primaryCoding": "hgnc:7230",
+    "primary_coding_id": "hgnc:7230",
     "mappings": [
       171,
       172
@@ -1186,7 +1186,7 @@
     "id": 60,
     "conceptType": "Gene",
     "name": "NBN",
-    "primaryCoding": "hgnc:7652",
+    "primary_coding_id": "hgnc:7652",
     "mappings": [
       173,
       174

--- a/referenced/mappings.json
+++ b/referenced/mappings.json
@@ -1625,11 +1625,6 @@
     "relation": "exactMatch"
   },
   {
-    "id": 325,
-    "coding_id": "ncit:C25425",
-    "relation": "exactMatch"
-  },
-  {
     "id": 326,
     "coding_id": "ncit:C66944",
     "relation": "exactMatch"

--- a/referenced/mappings.json
+++ b/referenced/mappings.json
@@ -1,0 +1,2377 @@
+[
+  {
+    "id": 0,
+    "coding": "oncotree:ALL",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 1,
+    "coding": "oncotree:AML",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 2,
+    "coding": "oncotree:GEJ",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 3,
+    "coding": "oncotree:ALCL",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 4,
+    "coding": "oncotree:THAP",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 5,
+    "coding": "oncotree:",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 6,
+    "coding": "oncotree:ASTR",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 7,
+    "coding": "oncotree:BALL",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 8,
+    "coding": "oncotree:BLCA",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 9,
+    "coding": "oncotree:BRCA",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 10,
+    "coding": "oncotree:APLPMLRARA",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 11,
+    "coding": "oncotree:CHOL",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 12,
+    "coding": "oncotree:CELNOS",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 13,
+    "coding": "oncotree:CML",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 14,
+    "coding": "oncotree:CMML",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 15,
+    "coding": "oncotree:COADREAD",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 16,
+    "coding": "oncotree:DDLS",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 17,
+    "coding": "oncotree:DFSP",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 18,
+    "coding": "oncotree:UCEC",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 19,
+    "coding": "oncotree:ES",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 20,
+    "coding": "oncotree:FL",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 21,
+    "coding": "oncotree:GRC",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 22,
+    "coding": "oncotree:GIST",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 23,
+    "coding": "oncotree:GNOS",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 24,
+    "coding": "oncotree:HNMUCM",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 25,
+    "coding": "oncotree:HNSC",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 26,
+    "coding": "oncotree:HGNEC",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 27,
+    "coding": "oncotree:HGSFT",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 28,
+    "coding": "oncotree:IMT",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 29,
+    "coding": "oncotree:IHCH",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 30,
+    "coding": "oncotree:",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 31,
+    "coding": "oncotree:LCH",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 32,
+    "coding": "oncotree:LMS",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 33,
+    "coding": "oncotree:LEUK",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 34,
+    "coding": "oncotree:LIPO",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 35,
+    "coding": "oncotree:LGGNOS",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 36,
+    "coding": "oncotree:LUSC",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 37,
+    "coding": "oncotree:SMMCL",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 38,
+    "coding": "oncotree:THME",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 39,
+    "coding": "oncotree:MBL",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 40,
+    "coding": "oncotree:MEL",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 41,
+    "coding": "oncotree:MM",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 42,
+    "coding": "oncotree:ASM",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 43,
+    "coding": "oncotree:MDS",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 44,
+    "coding": "oncotree:MLN",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 45,
+    "coding": "oncotree:MPN",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 46,
+    "coding": "oncotree:ECD",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 47,
+    "coding": "oncotree:NSCLC",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 48,
+    "coding": "oncotree:ODG",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 49,
+    "coding": "oncotree:OS",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 50,
+    "coding": "oncotree:OOVC",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 51,
+    "coding": "oncotree:OVT",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 52,
+    "coding": "oncotree:PAAD",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 53,
+    "coding": "oncotree:PEMESO",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 54,
+    "coding": "oncotree:PSEC",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 55,
+    "coding": "oncotree:PRAD",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 56,
+    "coding": "oncotree:PRNE",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 57,
+    "coding": "oncotree:READ",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 58,
+    "coding": "oncotree:RCC",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 59,
+    "coding": "oncotree:CCRCC",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 60,
+    "coding": "oncotree:SOC",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 61,
+    "coding": "oncotree:SCLC",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 62,
+    "coding": "oncotree:SCCNOS",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 63,
+    "coding": "oncotree:STAD",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 64,
+    "coding": "oncotree:TALL",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 65,
+    "coding": "oncotree:TGCT",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 66,
+    "coding": "oncotree:THYC",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 67,
+    "coding": "oncotree:UCU",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 68,
+    "coding": "oncotree:ULM",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 69,
+    "coding": "oncotree:ULMS",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 70,
+    "coding": "oncotree:WDLS",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 71,
+    "coding": "oncotree:CMLBCRABL1",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 72,
+    "coding": "oncotree:CEAD",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 73,
+    "coding": "oncotree:CESC",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 74,
+    "coding": "oncotree:ESCA",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 75,
+    "coding": "oncotree:THPA",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 76,
+    "coding": "oncotree:NHL",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 77,
+    "coding": "oncotree:DLBCLNOS",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 78,
+    "coding": "oncotree:BL",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 79,
+    "coding": "oncotree:MBN",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 80,
+    "coding": "oncotree:HL",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 81,
+    "coding": "oncotree:EGC",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 82,
+    "coding": "oncotree:ESCC",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 83,
+    "coding": "oncotree:HGGNOS",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 84,
+    "coding": "oncotree:",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 85,
+    "coding": "oncotree:IPN",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 86,
+    "coding": "oncotree:ICPN",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 87,
+    "coding": "oncotree:ALAL",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 88,
+    "coding": "oncotree:RAML",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 89,
+    "coding": "hgnc:76",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 90,
+    "coding": "ensembl:ensg00000097007",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 91,
+    "coding": "ncbi:25",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 92,
+    "coding": "refseq:NM_005157.6",
+    "relation": "relatedMatch"
+  },
+  {
+    "id": 93,
+    "coding": "hgnc:391",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 94,
+    "coding": "ensembl:ensg00000142208",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 95,
+    "coding": "ncbi:207",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 96,
+    "coding": "refseq:NM_001382430.1",
+    "relation": "relatedMatch"
+  },
+  {
+    "id": 97,
+    "coding": "hgnc:427",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 98,
+    "coding": "ensembl:ensg00000171094",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 99,
+    "coding": "ncbi:238",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 100,
+    "coding": "refseq:NM_004304.5",
+    "relation": "relatedMatch"
+  },
+  {
+    "id": 101,
+    "coding": "hgnc:795",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 102,
+    "coding": "ensembl:ensg00000149311",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 103,
+    "coding": "ncbi:472",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 104,
+    "coding": "refseq:NM_000051.4",
+    "relation": "relatedMatch"
+  },
+  {
+    "id": 105,
+    "coding": "hgnc:21649",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 106,
+    "coding": "ensembl:ensg00000006453",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 107,
+    "coding": "ncbi:55971",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 108,
+    "coding": "refseq:NM_018842.5",
+    "relation": "relatedMatch"
+  },
+  {
+    "id": 109,
+    "coding": "hgnc:952",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 110,
+    "coding": "ensembl:ensg00000138376",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 111,
+    "coding": "ncbi:580",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 112,
+    "coding": "refseq:NM_000465.4",
+    "relation": "relatedMatch"
+  },
+  {
+    "id": 113,
+    "coding": "hgnc:1014",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 114,
+    "coding": "ensembl:ensg00000186716",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 115,
+    "coding": "ncbi:613",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 116,
+    "coding": "refseq:NM_004327.4",
+    "relation": "relatedMatch"
+  },
+  {
+    "id": 117,
+    "coding": "hgnc:19351",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 118,
+    "coding": "ensembl:ensg00000122870",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 119,
+    "coding": "ncbi:80114",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 120,
+    "coding": "refseq:NM_001080512.3",
+    "relation": "relatedMatch"
+  },
+  {
+    "id": 121,
+    "coding": "hgnc:1097",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 122,
+    "coding": "ensembl:ensg00000157764",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 123,
+    "coding": "ncbi:673",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 124,
+    "coding": "refseq:NM_004333.6",
+    "relation": "relatedMatch"
+  },
+  {
+    "id": 125,
+    "coding": "hgnc:1100",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 126,
+    "coding": "ensembl:ensg00000012048",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 127,
+    "coding": "ncbi:672",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 128,
+    "coding": "refseq:NM_007294.4",
+    "relation": "relatedMatch"
+  },
+  {
+    "id": 129,
+    "coding": "hgnc:1101",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 130,
+    "coding": "ensembl:ensg00000139618",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 131,
+    "coding": "ncbi:675",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 132,
+    "coding": "refseq:NM_000059.4",
+    "relation": "relatedMatch"
+  },
+  {
+    "id": 133,
+    "coding": "hgnc:20473",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 134,
+    "coding": "ensembl:ensg00000136492",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 135,
+    "coding": "ncbi:83990",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 136,
+    "coding": "refseq:NM_032043.3",
+    "relation": "relatedMatch"
+  },
+  {
+    "id": 137,
+    "coding": "hgnc:1508",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 138,
+    "coding": "ensembl:ensg00000165806",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 139,
+    "coding": "ncbi:840",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 140,
+    "coding": "refseq:NM_001227.5",
+    "relation": "relatedMatch"
+  },
+  {
+    "id": 141,
+    "coding": "hgnc:17635",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 142,
+    "coding": "ensembl:ensg00000120217",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 143,
+    "coding": "ncbi:29126",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 144,
+    "coding": "refseq:NM_014143.4",
+    "relation": "relatedMatch"
+  },
+  {
+    "id": 145,
+    "coding": "hgnc:24224",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 146,
+    "coding": "ensembl:ensg00000167258",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 147,
+    "coding": "ncbi:51755",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 148,
+    "coding": "refseq:NM_016507.4",
+    "relation": "relatedMatch"
+  },
+  {
+    "id": 149,
+    "coding": "hgnc:1925",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 150,
+    "coding": "ensembl:ensg00000149554",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 151,
+    "coding": "ncbi:1111",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 152,
+    "coding": "refseq:NM_001114122.3",
+    "relation": "relatedMatch"
+  },
+  {
+    "id": 153,
+    "coding": "hgnc:16627",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 154,
+    "coding": "ensembl:ensg00000183765",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 155,
+    "coding": "ncbi:11200",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 156,
+    "coding": "refseq:NM_007194.4",
+    "relation": "relatedMatch"
+  },
+  {
+    "id": 157,
+    "coding": "hgnc:3236",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 158,
+    "coding": "ensembl:ensg00000146648",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 159,
+    "coding": "ncbi:1956",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 160,
+    "coding": "refseq:NM_005228.5",
+    "relation": "relatedMatch"
+  },
+  {
+    "id": 161,
+    "coding": "hgnc:3430",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 162,
+    "coding": "ensembl:ensg00000141736",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 163,
+    "coding": "ncbi:2064",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 164,
+    "coding": "refseq:NM_004448.4",
+    "relation": "relatedMatch"
+  },
+  {
+    "id": 165,
+    "coding": "hgnc:3467",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 166,
+    "coding": "ensembl:ensg00000091831",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 167,
+    "coding": "ncbi:2099",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 168,
+    "coding": "refseq:NM_000125.4",
+    "relation": "relatedMatch"
+  },
+  {
+    "id": 169,
+    "coding": "hgnc:3527",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 170,
+    "coding": "ensembl:ensg00000106462",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 171,
+    "coding": "ncbi:2146",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 172,
+    "coding": "refseq:NM_004456.5",
+    "relation": "relatedMatch"
+  },
+  {
+    "id": 173,
+    "coding": "hgnc:20748",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 174,
+    "coding": "ensembl:ensg00000115392",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 175,
+    "coding": "ncbi:55120",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 176,
+    "coding": "refseq:NM_018062.4",
+    "relation": "relatedMatch"
+  },
+  {
+    "id": 177,
+    "coding": "hgnc:3688",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 178,
+    "coding": "ensembl:ensg00000077782",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 179,
+    "coding": "ncbi:2260",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 180,
+    "coding": "refseq:NM_023110.3",
+    "relation": "relatedMatch"
+  },
+  {
+    "id": 181,
+    "coding": "hgnc:3689",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 182,
+    "coding": "ensembl:ensg00000066468",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 183,
+    "coding": "ncbi:2263",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 184,
+    "coding": "refseq:NM_000141.5",
+    "relation": "relatedMatch"
+  },
+  {
+    "id": 185,
+    "coding": "hgnc:3690",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 186,
+    "coding": "ensembl:ensg00000068078",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 187,
+    "coding": "ncbi:2261",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 188,
+    "coding": "refseq:NM_000142.5",
+    "relation": "relatedMatch"
+  },
+  {
+    "id": 189,
+    "coding": "hgnc:19124",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 190,
+    "coding": "ensembl:ensg00000145216",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 191,
+    "coding": "ncbi:81608",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 192,
+    "coding": "refseq:NM_030917.4",
+    "relation": "relatedMatch"
+  },
+  {
+    "id": 193,
+    "coding": "hgnc:3765",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 194,
+    "coding": "ensembl:ensg00000122025",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 195,
+    "coding": "ncbi:2322",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 196,
+    "coding": "refseq:NM_004119.3",
+    "relation": "relatedMatch"
+  },
+  {
+    "id": 197,
+    "coding": "hgnc:5173",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 198,
+    "coding": "ensembl:ensg00000174775",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 199,
+    "coding": "ncbi:3265",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 200,
+    "coding": "refseq:NM_005343.4",
+    "relation": "relatedMatch"
+  },
+  {
+    "id": 201,
+    "coding": "hgnc:5382",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 202,
+    "coding": "ensembl:ensg00000138413",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 203,
+    "coding": "ncbi:3417",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 204,
+    "coding": "refseq:NM_005896.4",
+    "relation": "relatedMatch"
+  },
+  {
+    "id": 205,
+    "coding": "hgnc:5383",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 206,
+    "coding": "ensembl:ensg00000182054",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 207,
+    "coding": "ncbi:3418",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 208,
+    "coding": "refseq:NM_002168.4",
+    "relation": "relatedMatch"
+  },
+  {
+    "id": 209,
+    "coding": "hgnc:6342",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 210,
+    "coding": "ensembl:ensg00000157404",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 211,
+    "coding": "ncbi:3815",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 212,
+    "coding": "refseq:NM_000222.3",
+    "relation": "relatedMatch"
+  },
+  {
+    "id": 213,
+    "coding": "hgnc:6407",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 214,
+    "coding": "ensembl:ensg00000133703",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 215,
+    "coding": "ncbi:3845",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 216,
+    "coding": "refseq:NM_004985.5",
+    "relation": "relatedMatch"
+  },
+  {
+    "id": 217,
+    "coding": "hgnc:7029",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 218,
+    "coding": "ensembl:ensg00000105976",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 219,
+    "coding": "ncbi:4233",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 220,
+    "coding": "refseq:NM_000245.4",
+    "relation": "relatedMatch"
+  },
+  {
+    "id": 221,
+    "coding": "hgnc:7989",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 222,
+    "coding": "ensembl:ensg00000213281",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 223,
+    "coding": "ncbi:4893",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 224,
+    "coding": "refseq:NM_002524.5",
+    "relation": "relatedMatch"
+  },
+  {
+    "id": 225,
+    "coding": "hgnc:7997",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 226,
+    "coding": "ensembl:ensg00000157168",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 227,
+    "coding": "ncbi:3084",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 228,
+    "coding": "refseq:NM_013964.5",
+    "relation": "relatedMatch"
+  },
+  {
+    "id": 229,
+    "coding": "hgnc:8031",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 230,
+    "coding": "ensembl:ensg00000198400",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 231,
+    "coding": "ncbi:4914",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 232,
+    "coding": "refseq:NM_002529.4",
+    "relation": "relatedMatch"
+  },
+  {
+    "id": 233,
+    "coding": "hgnc:8032",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 234,
+    "coding": "ensembl:ensg00000148053",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 235,
+    "coding": "ncbi:4915",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 236,
+    "coding": "refseq:NM_006180.6",
+    "relation": "relatedMatch"
+  },
+  {
+    "id": 237,
+    "coding": "hgnc:8033",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 238,
+    "coding": "ensembl:ensg00000140538",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 239,
+    "coding": "ncbi:4916",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 240,
+    "coding": "refseq:NM_001012338.3",
+    "relation": "relatedMatch"
+  },
+  {
+    "id": 241,
+    "coding": "hgnc:26144",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 242,
+    "coding": "ensembl:ensg00000083093",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 243,
+    "coding": "ncbi:79728",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 244,
+    "coding": "refseq:NM_024675.4",
+    "relation": "relatedMatch"
+  },
+  {
+    "id": 245,
+    "coding": "hgnc:8803",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 246,
+    "coding": "ensembl:ensg00000134853",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 247,
+    "coding": "ncbi:5156",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 248,
+    "coding": "refseq:NM_006206.6",
+    "relation": "relatedMatch"
+  },
+  {
+    "id": 249,
+    "coding": "hgnc:8804",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 250,
+    "coding": "ensembl:ensg00000113721",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 251,
+    "coding": "ncbi:5159",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 252,
+    "coding": "refseq:NM_002609.4",
+    "relation": "relatedMatch"
+  },
+  {
+    "id": 253,
+    "coding": "hgnc:8975",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 254,
+    "coding": "ensembl:ensg00000121879",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 255,
+    "coding": "ncbi:5290",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 256,
+    "coding": "refseq:NM_006218.4",
+    "relation": "relatedMatch"
+  },
+  {
+    "id": 257,
+    "coding": "hgnc:9113",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 258,
+    "coding": "ensembl:ensg00000140464",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 259,
+    "coding": "ncbi:5371",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 260,
+    "coding": "refseq:NM_033238.3",
+    "relation": "relatedMatch"
+  },
+  {
+    "id": 261,
+    "coding": "hgnc:9588",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 262,
+    "coding": "ensembl:ensg00000171862",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 263,
+    "coding": "ncbi:5728",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 264,
+    "coding": "refseq:NM_000314.8",
+    "relation": "relatedMatch"
+  },
+  {
+    "id": 265,
+    "coding": "hgnc:9822",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 266,
+    "coding": "ensembl:ensg00000182185",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 267,
+    "coding": "ncbi:5890",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 268,
+    "coding": "refseq:NM_133510.4",
+    "relation": "relatedMatch"
+  },
+  {
+    "id": 269,
+    "coding": "hgnc:9820",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 270,
+    "coding": "ensembl:ensg00000108384",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 271,
+    "coding": "ncbi:5889",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 272,
+    "coding": "refseq:NM_058216.3",
+    "relation": "relatedMatch"
+  },
+  {
+    "id": 273,
+    "coding": "hgnc:9823",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 274,
+    "coding": "ensembl:ensg00000185379",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 275,
+    "coding": "ncbi:5892",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 276,
+    "coding": "refseq:NM_002878.4",
+    "relation": "relatedMatch"
+  },
+  {
+    "id": 277,
+    "coding": "hgnc:9826",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 278,
+    "coding": "ensembl:ensg00000085999",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 279,
+    "coding": "ncbi:8438",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 280,
+    "coding": "refseq:NM_003579.4",
+    "relation": "relatedMatch"
+  },
+  {
+    "id": 281,
+    "coding": "hgnc:9864",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 282,
+    "coding": "ensembl:ensg00000131759",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 283,
+    "coding": "ncbi:5914",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 284,
+    "coding": "refseq:NM_000964.4",
+    "relation": "relatedMatch"
+  },
+  {
+    "id": 285,
+    "coding": "hgnc:9967",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 286,
+    "coding": "ensembl:ensg00000165731",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 287,
+    "coding": "ncbi:5979",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 288,
+    "coding": "refseq:NM_020975.6",
+    "relation": "relatedMatch"
+  },
+  {
+    "id": 289,
+    "coding": "hgnc:10261",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 290,
+    "coding": "ensembl:ensg00000047936",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 291,
+    "coding": "ncbi:6098",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 292,
+    "coding": "refseq:NM_001378902.1",
+    "relation": "relatedMatch"
+  },
+  {
+    "id": 293,
+    "coding": "hgnc:11524",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 294,
+    "coding": "ensembl:ensg00000013810",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 295,
+    "coding": "ncbi:10460",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 296,
+    "coding": "refseq:NM_006342.3",
+    "relation": "relatedMatch"
+  },
+  {
+    "id": 297,
+    "coding": "hgnc:11998",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 298,
+    "coding": "ensembl:ensg00000141510",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 299,
+    "coding": "ncbi:7157",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 300,
+    "coding": "refseq:NM_000546.6",
+    "relation": "relatedMatch"
+  },
+  {
+    "id": 301,
+    "coding": "hgnc:7131",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 302,
+    "coding": "ensembl:ensg00000118058",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 303,
+    "coding": "ncbi:4297",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 304,
+    "coding": "hgnc:12362",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 305,
+    "coding": "ensembl:ENSG00000165699",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 306,
+    "coding": "ncbi:7248",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 307,
+    "coding": "hgnc:12363",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 308,
+    "coding": "ensembl:ENSG00000103197",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 309,
+    "coding": "ncbi:7249",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 310,
+    "coding": "hgnc:882",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 311,
+    "coding": "ensembl:ENSG00000175054",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 312,
+    "coding": "ncbi:545",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 313,
+    "coding": "hgnc:3582",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 314,
+    "coding": "ensembl:ENSG00000187741",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 315,
+    "coding": "ncbi:2175",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 316,
+    "coding": "hgnc:7127",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 317,
+    "coding": "ensembl:ENSG00000076242",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 318,
+    "coding": "ncbi:4292",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 319,
+    "coding": "hgnc:7230",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 320,
+    "coding": "ensembl:ENSG00000020922",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 321,
+    "coding": "ncbi:4361",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 322,
+    "coding": "hgnc:7652",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 323,
+    "coding": "ensembl:ENSG00000104320",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 324,
+    "coding": "ncbi:4683",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 325,
+    "coding": "ncit:C25425",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 326,
+    "coding": "ncit:C66944",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 327,
+    "coding": "ncit:C411",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 328,
+    "coding": "ncit:C456",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 329,
+    "coding": "ncit:",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 330,
+    "coding": "ncit:C48387",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 331,
+    "coding": "ncit:C1097",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 332,
+    "coding": "ncit:C80059",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 333,
+    "coding": "ncit:C68845",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 334,
+    "coding": "ncit:C769",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 335,
+    "coding": "ncit:C101790",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 336,
+    "coding": "ncit:C98831",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 337,
+    "coding": "ncit:C2039",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 338,
+    "coding": "ncit:C65530",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 339,
+    "coding": "ncit:C123827",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 340,
+    "coding": "ncit:C71542",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 341,
+    "coding": "ncit:C62528",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 342,
+    "coding": "ncit:C60809",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 343,
+    "coding": "ncit:C84865",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 344,
+    "coding": "ncit:C98283",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 345,
+    "coding": "ncit:C1723",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 346,
+    "coding": "ncit:C2737",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 347,
+    "coding": "ncit:C68923",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 348,
+    "coding": "ncit:C64768",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 349,
+    "coding": "ncit:C70792",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 350,
+    "coding": "ncit:C1526",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 351,
+    "coding": "ncit:C1647",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 352,
+    "coding": "ncit:C128799",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 353,
+    "coding": "ncit:C62040",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 354,
+    "coding": "ncit:C1181",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 355,
+    "coding": "ncit:C505",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 356,
+    "coding": "ncit:C1379",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 357,
+    "coding": "ncit:C49176",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 358,
+    "coding": "ncit:C132295",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 359,
+    "coding": "ncit:C1855",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 360,
+    "coding": "ncit:C66940",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 361,
+    "coding": "ncit:C1411",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 362,
+    "coding": "ncit:C1607",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 363,
+    "coding": "ncit:C1282",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 364,
+    "coding": "ncit:C1794",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 365,
+    "coding": "ncit:C376",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 366,
+    "coding": "ncit:C1527",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 367,
+    "coding": "ncit:C62035",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 368,
+    "coding": "ncit:",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 369,
+    "coding": "ncit:C95777",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 370,
+    "coding": "ncit:C103194",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 371,
+    "coding": "ncit:C49085",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 372,
+    "coding": "ncit:C71721",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 373,
+    "coding": "ncit:C126799",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 374,
+    "coding": "ncit:C106432",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 375,
+    "coding": "ncit:C61614",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 376,
+    "coding": "ncit:C66876",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 377,
+    "coding": "ncit:C2688",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 378,
+    "coding": "ncit:C82492",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 379,
+    "coding": "ncit:C95701",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 380,
+    "coding": "ncit:C157493",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 381,
+    "coding": "ncit:C121540",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 382,
+    "coding": "ncit:C113655",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 383,
+    "coding": "ncit:C154287",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 384,
+    "coding": "ncit:C114283",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 385,
+    "coding": "ncit:C405",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 386,
+    "coding": "ncit:C1702",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 387,
+    "coding": "ncit:C933",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 388,
+    "coding": "ncit:C2322",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 389,
+    "coding": "ncit:C408",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 390,
+    "coding": "ncit:C491",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 391,
+    "coding": "ncit:C642",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 392,
+    "coding": "ncit:C77908",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 393,
+    "coding": "ncit:C82386",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 394,
+    "coding": "ncit:C62091",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 395,
+    "coding": "ncit:C1806",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 396,
+    "coding": "ncit:C49094",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 397,
+    "coding": "ncit:C2654",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 398,
+    "coding": "ncit:C68814",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 399,
+    "coding": "ncit:C111999",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 400,
+    "coding": "ncit:C120211",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 401,
+    "coding": "ncit:C38692",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 402,
+    "coding": "ncit:C62028",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 403,
+    "coding": "ncit:C94214",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 404,
+    "coding": "ncit:C134987",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 405,
+    "coding": "ncit:C2668",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 406,
+    "coding": "ncit:C114984",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 407,
+    "coding": "ncit:",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 408,
+    "coding": "ncit:C1872",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 409,
+    "coding": "ncit:C114494",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 410,
+    "coding": "ncit:C38713",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 411,
+    "coding": "ncit:C90564",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 412,
+    "coding": "ncit:C116377",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 413,
+    "coding": "ncit:C95733",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 414,
+    "coding": "ncit:C48375",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 415,
+    "coding": "ncit:C106250",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 416,
+    "coding": "ncit:C88314",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 417,
+    "coding": "ncit:C288",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 418,
+    "coding": "ncit:C114383",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 419,
+    "coding": "ncit:C1005",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 420,
+    "coding": "ncit:C102783",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 421,
+    "coding": "ncit:C77896",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 422,
+    "coding": "ncit:C26653",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 423,
+    "coding": "ncit:C1857",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 424,
+    "coding": "ncit:C103147",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 425,
+    "coding": "ncit:C97660",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 426,
+    "coding": "ncit:C115977",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 427,
+    "coding": "ncit:C53398",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 428,
+    "coding": "ncit:C74061",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 429,
+    "coding": "ncit:",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 430,
+    "coding": "ncit:C116722",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 431,
+    "coding": "ncit:C78825",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 432,
+    "coding": "ncit:C115112",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 433,
+    "coding": "ncit:C121775",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 434,
+    "coding": "ncit:C124993",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 435,
+    "coding": "ncit:C102564",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 436,
+    "coding": "ncit:C103273",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 437,
+    "coding": "ncit:C85475",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 438,
+    "coding": "ncit:C49094",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 439,
+    "coding": "ncit:C141428",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 440,
+    "coding": "ncit:C113442",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 441,
+    "coding": "ncit:C81934",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 442,
+    "coding": "ncit:C564",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 443,
+    "coding": "ncit:C1275",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 444,
+    "coding": "ncit:",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 445,
+    "coding": "ncit:C62078",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 446,
+    "coding": "ncit:C66952",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 447,
+    "coding": "ncit:C73261",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 448,
+    "coding": "ncit:C770",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 449,
+    "coding": "ncit:C362",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 450,
+    "coding": "ncit:C62050",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 451,
+    "coding": "ncit:C20494",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 452,
+    "coding": "ncit:C111573",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 453,
+    "coding": "ncit:C88302",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 454,
+    "coding": "ncit:C91733",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 455,
+    "coding": "ncit:C96748",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 456,
+    "coding": "ncit:C126752",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 457,
+    "coding": "ncit:C129687",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 458,
+    "coding": "ncit:C95124",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 459,
+    "coding": "ncit:C121553",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 460,
+    "coding": "ncit:C133821",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 461,
+    "coding": "ncit:C1094",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 462,
+    "coding": "ncit:C137800",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 463,
+    "coding": "ncit:C107506",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 464,
+    "coding": "ncit:C71744",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 465,
+    "coding": "ncit:C148147",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 466,
+    "coding": "ncit:C102566",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 467,
+    "coding": "ncit:C106254",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 468,
+    "coding": "ncit:C152914",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 469,
+    "coding": "ncit:C1374",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 470,
+    "coding": "ncit:C132166",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 471,
+    "coding": "ncit:C130010",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 472,
+    "coding": "ncit:C152948",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 473,
+    "coding": "ncit:C102754",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 474,
+    "coding": "ncit:C165776",
+    "relation": "exactMatch"
+  }
+]

--- a/referenced/mappings.json
+++ b/referenced/mappings.json
@@ -421,8 +421,8 @@
   },
   {
     "id": 84,
-    "coding": "oncotree:",
-    "relation": "exactMatch"
+    "coding": "oncotree:CLLSLL",
+    "relation": "broadMatch"
   },
   {
     "id": 85,

--- a/referenced/mappings.json
+++ b/referenced/mappings.json
@@ -1,2372 +1,1058 @@
 [
   {
     "id": 0,
-    "coding_id": "oncotree:ALL",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 1,
-    "coding_id": "oncotree:AML",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 2,
-    "coding_id": "oncotree:GEJ",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 3,
-    "coding_id": "oncotree:ALCL",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 4,
-    "coding_id": "oncotree:THAP",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 5,
-    "coding_id": "oncotree:",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 6,
-    "coding_id": "oncotree:ASTR",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 7,
-    "coding_id": "oncotree:BALL",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 8,
-    "coding_id": "oncotree:BLCA",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 9,
-    "coding_id": "oncotree:BRCA",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 10,
-    "coding_id": "oncotree:APLPMLRARA",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 11,
-    "coding_id": "oncotree:CHOL",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 12,
-    "coding_id": "oncotree:CELNOS",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 13,
-    "coding_id": "oncotree:CML",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 14,
-    "coding_id": "oncotree:CMML",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 15,
-    "coding_id": "oncotree:COADREAD",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 16,
-    "coding_id": "oncotree:DDLS",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 17,
-    "coding_id": "oncotree:DFSP",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 18,
-    "coding_id": "oncotree:UCEC",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 19,
-    "coding_id": "oncotree:ES",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 20,
-    "coding_id": "oncotree:FL",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 21,
-    "coding_id": "oncotree:GRC",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 22,
-    "coding_id": "oncotree:GIST",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 23,
-    "coding_id": "oncotree:GNOS",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 24,
-    "coding_id": "oncotree:HNMUCM",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 25,
-    "coding_id": "oncotree:HNSC",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 26,
-    "coding_id": "oncotree:HGNEC",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 27,
-    "coding_id": "oncotree:HGSFT",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 28,
-    "coding_id": "oncotree:IMT",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 29,
-    "coding_id": "oncotree:IHCH",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 30,
-    "coding_id": "oncotree:",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 31,
-    "coding_id": "oncotree:LCH",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 32,
-    "coding_id": "oncotree:LMS",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 33,
-    "coding_id": "oncotree:LEUK",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 34,
-    "coding_id": "oncotree:LIPO",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 35,
-    "coding_id": "oncotree:LGGNOS",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 36,
-    "coding_id": "oncotree:LUSC",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 37,
-    "coding_id": "oncotree:SMMCL",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 38,
-    "coding_id": "oncotree:THME",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 39,
-    "coding_id": "oncotree:MBL",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 40,
-    "coding_id": "oncotree:MEL",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 41,
-    "coding_id": "oncotree:MM",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 42,
-    "coding_id": "oncotree:ASM",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 43,
-    "coding_id": "oncotree:MDS",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 44,
-    "coding_id": "oncotree:MLN",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 45,
-    "coding_id": "oncotree:MPN",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 46,
-    "coding_id": "oncotree:ECD",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 47,
-    "coding_id": "oncotree:NSCLC",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 48,
-    "coding_id": "oncotree:ODG",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 49,
-    "coding_id": "oncotree:OS",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 50,
-    "coding_id": "oncotree:OOVC",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 51,
-    "coding_id": "oncotree:OVT",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 52,
-    "coding_id": "oncotree:PAAD",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 53,
-    "coding_id": "oncotree:PEMESO",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 54,
-    "coding_id": "oncotree:PSEC",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 55,
-    "coding_id": "oncotree:PRAD",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 56,
-    "coding_id": "oncotree:PRNE",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 57,
-    "coding_id": "oncotree:READ",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 58,
-    "coding_id": "oncotree:RCC",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 59,
-    "coding_id": "oncotree:CCRCC",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 60,
-    "coding_id": "oncotree:SOC",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 61,
-    "coding_id": "oncotree:SCLC",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 62,
-    "coding_id": "oncotree:SCCNOS",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 63,
-    "coding_id": "oncotree:STAD",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 64,
-    "coding_id": "oncotree:TALL",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 65,
-    "coding_id": "oncotree:TGCT",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 66,
-    "coding_id": "oncotree:THYC",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 67,
-    "coding_id": "oncotree:UCU",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 68,
-    "coding_id": "oncotree:ULM",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 69,
-    "coding_id": "oncotree:ULMS",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 70,
-    "coding_id": "oncotree:WDLS",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 71,
-    "coding_id": "oncotree:CMLBCRABL1",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 72,
-    "coding_id": "oncotree:CEAD",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 73,
-    "coding_id": "oncotree:CESC",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 74,
-    "coding_id": "oncotree:ESCA",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 75,
-    "coding_id": "oncotree:THPA",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 76,
-    "coding_id": "oncotree:NHL",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 77,
-    "coding_id": "oncotree:DLBCLNOS",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 78,
-    "coding_id": "oncotree:BL",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 79,
-    "coding_id": "oncotree:MBN",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 80,
-    "coding_id": "oncotree:HL",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 81,
-    "coding_id": "oncotree:EGC",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 82,
-    "coding_id": "oncotree:ESCC",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 83,
-    "coding_id": "oncotree:HGGNOS",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 84,
-    "coding_id": "oncotree:CLLSLL",
-    "relation": "broadMatch"
-  },
-  {
-    "id": 85,
-    "coding_id": "oncotree:IPN",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 86,
-    "coding_id": "oncotree:ICPN",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 87,
-    "coding_id": "oncotree:ALAL",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 88,
-    "coding_id": "oncotree:RAML",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 89,
-    "coding_id": "hgnc:76",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 90,
+    "primary_coding_id": "hgnc:76",
     "coding_id": "ensembl:ensg00000097007",
     "relation": "exactMatch"
   },
   {
-    "id": 91,
+    "id": 1,
+    "primary_coding_id": "hgnc:76",
     "coding_id": "ncbi:25",
     "relation": "exactMatch"
   },
   {
-    "id": 92,
+    "id": 2,
+    "primary_coding_id": "hgnc:76",
     "coding_id": "refseq:NM_005157.6",
     "relation": "relatedMatch"
   },
   {
-    "id": 93,
-    "coding_id": "hgnc:391",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 94,
-    "coding_id": "ensembl:ensg00000142208",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 95,
-    "coding_id": "ncbi:207",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 96,
+    "id": 3,
+    "primary_coding_id": "hgnc:391",
     "coding_id": "refseq:NM_001382430.1",
     "relation": "relatedMatch"
   },
   {
-    "id": 97,
-    "coding_id": "hgnc:427",
+    "id": 4,
+    "primary_coding_id": "hgnc:391",
+    "coding_id": "ensembl:ensg00000142208",
     "relation": "exactMatch"
   },
   {
-    "id": 98,
+    "id": 5,
+    "primary_coding_id": "hgnc:391",
+    "coding_id": "ncbi:207",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 6,
+    "primary_coding_id": "hgnc:427",
     "coding_id": "ensembl:ensg00000171094",
     "relation": "exactMatch"
   },
   {
-    "id": 99,
+    "id": 7,
+    "primary_coding_id": "hgnc:427",
     "coding_id": "ncbi:238",
     "relation": "exactMatch"
   },
   {
-    "id": 100,
+    "id": 8,
+    "primary_coding_id": "hgnc:427",
     "coding_id": "refseq:NM_004304.5",
     "relation": "relatedMatch"
   },
   {
-    "id": 101,
-    "coding_id": "hgnc:795",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 102,
-    "coding_id": "ensembl:ensg00000149311",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 103,
-    "coding_id": "ncbi:472",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 104,
+    "id": 9,
+    "primary_coding_id": "hgnc:795",
     "coding_id": "refseq:NM_000051.4",
     "relation": "relatedMatch"
   },
   {
-    "id": 105,
-    "coding_id": "hgnc:21649",
+    "id": 10,
+    "primary_coding_id": "hgnc:795",
+    "coding_id": "ensembl:ensg00000149311",
     "relation": "exactMatch"
   },
   {
-    "id": 106,
+    "id": 11,
+    "primary_coding_id": "hgnc:795",
+    "coding_id": "ncbi:472",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 12,
+    "primary_coding_id": "hgnc:21649",
     "coding_id": "ensembl:ensg00000006453",
     "relation": "exactMatch"
   },
   {
-    "id": 107,
+    "id": 13,
+    "primary_coding_id": "hgnc:21649",
     "coding_id": "ncbi:55971",
     "relation": "exactMatch"
   },
   {
-    "id": 108,
+    "id": 14,
+    "primary_coding_id": "hgnc:21649",
     "coding_id": "refseq:NM_018842.5",
     "relation": "relatedMatch"
   },
   {
-    "id": 109,
-    "coding_id": "hgnc:952",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 110,
-    "coding_id": "ensembl:ensg00000138376",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 111,
-    "coding_id": "ncbi:580",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 112,
+    "id": 15,
+    "primary_coding_id": "hgnc:952",
     "coding_id": "refseq:NM_000465.4",
     "relation": "relatedMatch"
   },
   {
-    "id": 113,
-    "coding_id": "hgnc:1014",
+    "id": 16,
+    "primary_coding_id": "hgnc:952",
+    "coding_id": "ensembl:ensg00000138376",
     "relation": "exactMatch"
   },
   {
-    "id": 114,
+    "id": 17,
+    "primary_coding_id": "hgnc:952",
+    "coding_id": "ncbi:580",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 18,
+    "primary_coding_id": "hgnc:1014",
     "coding_id": "ensembl:ensg00000186716",
     "relation": "exactMatch"
   },
   {
-    "id": 115,
+    "id": 19,
+    "primary_coding_id": "hgnc:1014",
     "coding_id": "ncbi:613",
     "relation": "exactMatch"
   },
   {
-    "id": 116,
+    "id": 20,
+    "primary_coding_id": "hgnc:1014",
     "coding_id": "refseq:NM_004327.4",
     "relation": "relatedMatch"
   },
   {
-    "id": 117,
-    "coding_id": "hgnc:19351",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 118,
-    "coding_id": "ensembl:ensg00000122870",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 119,
-    "coding_id": "ncbi:80114",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 120,
+    "id": 21,
+    "primary_coding_id": "hgnc:19351",
     "coding_id": "refseq:NM_001080512.3",
     "relation": "relatedMatch"
   },
   {
-    "id": 121,
-    "coding_id": "hgnc:1097",
+    "id": 22,
+    "primary_coding_id": "hgnc:19351",
+    "coding_id": "ensembl:ensg00000122870",
     "relation": "exactMatch"
   },
   {
-    "id": 122,
+    "id": 23,
+    "primary_coding_id": "hgnc:19351",
+    "coding_id": "ncbi:80114",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 24,
+    "primary_coding_id": "hgnc:1097",
     "coding_id": "ensembl:ensg00000157764",
     "relation": "exactMatch"
   },
   {
-    "id": 123,
+    "id": 25,
+    "primary_coding_id": "hgnc:1097",
     "coding_id": "ncbi:673",
     "relation": "exactMatch"
   },
   {
-    "id": 124,
+    "id": 26,
+    "primary_coding_id": "hgnc:1097",
     "coding_id": "refseq:NM_004333.6",
     "relation": "relatedMatch"
   },
   {
-    "id": 125,
-    "coding_id": "hgnc:1100",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 126,
-    "coding_id": "ensembl:ensg00000012048",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 127,
-    "coding_id": "ncbi:672",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 128,
+    "id": 27,
+    "primary_coding_id": "hgnc:1100",
     "coding_id": "refseq:NM_007294.4",
     "relation": "relatedMatch"
   },
   {
-    "id": 129,
-    "coding_id": "hgnc:1101",
+    "id": 28,
+    "primary_coding_id": "hgnc:1100",
+    "coding_id": "ensembl:ensg00000012048",
     "relation": "exactMatch"
   },
   {
-    "id": 130,
+    "id": 29,
+    "primary_coding_id": "hgnc:1100",
+    "coding_id": "ncbi:672",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 30,
+    "primary_coding_id": "hgnc:1101",
     "coding_id": "ensembl:ensg00000139618",
     "relation": "exactMatch"
   },
   {
-    "id": 131,
+    "id": 31,
+    "primary_coding_id": "hgnc:1101",
     "coding_id": "ncbi:675",
     "relation": "exactMatch"
   },
   {
-    "id": 132,
+    "id": 32,
+    "primary_coding_id": "hgnc:1101",
     "coding_id": "refseq:NM_000059.4",
     "relation": "relatedMatch"
   },
   {
-    "id": 133,
-    "coding_id": "hgnc:20473",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 134,
-    "coding_id": "ensembl:ensg00000136492",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 135,
-    "coding_id": "ncbi:83990",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 136,
+    "id": 33,
+    "primary_coding_id": "hgnc:20473",
     "coding_id": "refseq:NM_032043.3",
     "relation": "relatedMatch"
   },
   {
-    "id": 137,
-    "coding_id": "hgnc:1508",
+    "id": 34,
+    "primary_coding_id": "hgnc:20473",
+    "coding_id": "ensembl:ensg00000136492",
     "relation": "exactMatch"
   },
   {
-    "id": 138,
+    "id": 35,
+    "primary_coding_id": "hgnc:20473",
+    "coding_id": "ncbi:83990",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 36,
+    "primary_coding_id": "hgnc:1508",
     "coding_id": "ensembl:ensg00000165806",
     "relation": "exactMatch"
   },
   {
-    "id": 139,
+    "id": 37,
+    "primary_coding_id": "hgnc:1508",
     "coding_id": "ncbi:840",
     "relation": "exactMatch"
   },
   {
-    "id": 140,
+    "id": 38,
+    "primary_coding_id": "hgnc:1508",
     "coding_id": "refseq:NM_001227.5",
     "relation": "relatedMatch"
   },
   {
-    "id": 141,
-    "coding_id": "hgnc:17635",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 142,
-    "coding_id": "ensembl:ensg00000120217",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 143,
-    "coding_id": "ncbi:29126",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 144,
+    "id": 39,
+    "primary_coding_id": "hgnc:17635",
     "coding_id": "refseq:NM_014143.4",
     "relation": "relatedMatch"
   },
   {
-    "id": 145,
-    "coding_id": "hgnc:24224",
+    "id": 40,
+    "primary_coding_id": "hgnc:17635",
+    "coding_id": "ensembl:ensg00000120217",
     "relation": "exactMatch"
   },
   {
-    "id": 146,
+    "id": 41,
+    "primary_coding_id": "hgnc:17635",
+    "coding_id": "ncbi:29126",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 42,
+    "primary_coding_id": "hgnc:24224",
     "coding_id": "ensembl:ensg00000167258",
     "relation": "exactMatch"
   },
   {
-    "id": 147,
+    "id": 43,
+    "primary_coding_id": "hgnc:24224",
     "coding_id": "ncbi:51755",
     "relation": "exactMatch"
   },
   {
-    "id": 148,
+    "id": 44,
+    "primary_coding_id": "hgnc:24224",
     "coding_id": "refseq:NM_016507.4",
     "relation": "relatedMatch"
   },
   {
-    "id": 149,
-    "coding_id": "hgnc:1925",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 150,
-    "coding_id": "ensembl:ensg00000149554",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 151,
-    "coding_id": "ncbi:1111",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 152,
+    "id": 45,
+    "primary_coding_id": "hgnc:1925",
     "coding_id": "refseq:NM_001114122.3",
     "relation": "relatedMatch"
   },
   {
-    "id": 153,
-    "coding_id": "hgnc:16627",
+    "id": 46,
+    "primary_coding_id": "hgnc:1925",
+    "coding_id": "ensembl:ensg00000149554",
     "relation": "exactMatch"
   },
   {
-    "id": 154,
+    "id": 47,
+    "primary_coding_id": "hgnc:1925",
+    "coding_id": "ncbi:1111",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 48,
+    "primary_coding_id": "hgnc:16627",
     "coding_id": "ensembl:ensg00000183765",
     "relation": "exactMatch"
   },
   {
-    "id": 155,
+    "id": 49,
+    "primary_coding_id": "hgnc:16627",
     "coding_id": "ncbi:11200",
     "relation": "exactMatch"
   },
   {
-    "id": 156,
+    "id": 50,
+    "primary_coding_id": "hgnc:16627",
     "coding_id": "refseq:NM_007194.4",
     "relation": "relatedMatch"
   },
   {
-    "id": 157,
-    "coding_id": "hgnc:3236",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 158,
-    "coding_id": "ensembl:ensg00000146648",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 159,
-    "coding_id": "ncbi:1956",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 160,
+    "id": 51,
+    "primary_coding_id": "hgnc:3236",
     "coding_id": "refseq:NM_005228.5",
     "relation": "relatedMatch"
   },
   {
-    "id": 161,
-    "coding_id": "hgnc:3430",
+    "id": 52,
+    "primary_coding_id": "hgnc:3236",
+    "coding_id": "ensembl:ensg00000146648",
     "relation": "exactMatch"
   },
   {
-    "id": 162,
+    "id": 53,
+    "primary_coding_id": "hgnc:3236",
+    "coding_id": "ncbi:1956",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 54,
+    "primary_coding_id": "hgnc:3430",
     "coding_id": "ensembl:ensg00000141736",
     "relation": "exactMatch"
   },
   {
-    "id": 163,
+    "id": 55,
+    "primary_coding_id": "hgnc:3430",
     "coding_id": "ncbi:2064",
     "relation": "exactMatch"
   },
   {
-    "id": 164,
+    "id": 56,
+    "primary_coding_id": "hgnc:3430",
     "coding_id": "refseq:NM_004448.4",
     "relation": "relatedMatch"
   },
   {
-    "id": 165,
-    "coding_id": "hgnc:3467",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 166,
-    "coding_id": "ensembl:ensg00000091831",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 167,
-    "coding_id": "ncbi:2099",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 168,
+    "id": 57,
+    "primary_coding_id": "hgnc:3467",
     "coding_id": "refseq:NM_000125.4",
     "relation": "relatedMatch"
   },
   {
-    "id": 169,
-    "coding_id": "hgnc:3527",
+    "id": 58,
+    "primary_coding_id": "hgnc:3467",
+    "coding_id": "ensembl:ensg00000091831",
     "relation": "exactMatch"
   },
   {
-    "id": 170,
+    "id": 59,
+    "primary_coding_id": "hgnc:3467",
+    "coding_id": "ncbi:2099",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 60,
+    "primary_coding_id": "hgnc:3527",
     "coding_id": "ensembl:ensg00000106462",
     "relation": "exactMatch"
   },
   {
-    "id": 171,
+    "id": 61,
+    "primary_coding_id": "hgnc:3527",
     "coding_id": "ncbi:2146",
     "relation": "exactMatch"
   },
   {
-    "id": 172,
+    "id": 62,
+    "primary_coding_id": "hgnc:3527",
     "coding_id": "refseq:NM_004456.5",
     "relation": "relatedMatch"
   },
   {
-    "id": 173,
-    "coding_id": "hgnc:20748",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 174,
-    "coding_id": "ensembl:ensg00000115392",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 175,
-    "coding_id": "ncbi:55120",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 176,
+    "id": 63,
+    "primary_coding_id": "hgnc:20748",
     "coding_id": "refseq:NM_018062.4",
     "relation": "relatedMatch"
   },
   {
-    "id": 177,
-    "coding_id": "hgnc:3688",
+    "id": 64,
+    "primary_coding_id": "hgnc:20748",
+    "coding_id": "ensembl:ensg00000115392",
     "relation": "exactMatch"
   },
   {
-    "id": 178,
+    "id": 65,
+    "primary_coding_id": "hgnc:20748",
+    "coding_id": "ncbi:55120",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 66,
+    "primary_coding_id": "hgnc:3688",
     "coding_id": "ensembl:ensg00000077782",
     "relation": "exactMatch"
   },
   {
-    "id": 179,
+    "id": 67,
+    "primary_coding_id": "hgnc:3688",
     "coding_id": "ncbi:2260",
     "relation": "exactMatch"
   },
   {
-    "id": 180,
+    "id": 68,
+    "primary_coding_id": "hgnc:3688",
     "coding_id": "refseq:NM_023110.3",
     "relation": "relatedMatch"
   },
   {
-    "id": 181,
-    "coding_id": "hgnc:3689",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 182,
-    "coding_id": "ensembl:ensg00000066468",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 183,
-    "coding_id": "ncbi:2263",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 184,
+    "id": 69,
+    "primary_coding_id": "hgnc:3689",
     "coding_id": "refseq:NM_000141.5",
     "relation": "relatedMatch"
   },
   {
-    "id": 185,
-    "coding_id": "hgnc:3690",
+    "id": 70,
+    "primary_coding_id": "hgnc:3689",
+    "coding_id": "ensembl:ensg00000066468",
     "relation": "exactMatch"
   },
   {
-    "id": 186,
+    "id": 71,
+    "primary_coding_id": "hgnc:3689",
+    "coding_id": "ncbi:2263",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 72,
+    "primary_coding_id": "hgnc:3690",
     "coding_id": "ensembl:ensg00000068078",
     "relation": "exactMatch"
   },
   {
-    "id": 187,
+    "id": 73,
+    "primary_coding_id": "hgnc:3690",
     "coding_id": "ncbi:2261",
     "relation": "exactMatch"
   },
   {
-    "id": 188,
+    "id": 74,
+    "primary_coding_id": "hgnc:3690",
     "coding_id": "refseq:NM_000142.5",
     "relation": "relatedMatch"
   },
   {
-    "id": 189,
-    "coding_id": "hgnc:19124",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 190,
-    "coding_id": "ensembl:ensg00000145216",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 191,
-    "coding_id": "ncbi:81608",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 192,
+    "id": 75,
+    "primary_coding_id": "hgnc:19124",
     "coding_id": "refseq:NM_030917.4",
     "relation": "relatedMatch"
   },
   {
-    "id": 193,
-    "coding_id": "hgnc:3765",
+    "id": 76,
+    "primary_coding_id": "hgnc:19124",
+    "coding_id": "ensembl:ensg00000145216",
     "relation": "exactMatch"
   },
   {
-    "id": 194,
+    "id": 77,
+    "primary_coding_id": "hgnc:19124",
+    "coding_id": "ncbi:81608",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 78,
+    "primary_coding_id": "hgnc:3765",
     "coding_id": "ensembl:ensg00000122025",
     "relation": "exactMatch"
   },
   {
-    "id": 195,
+    "id": 79,
+    "primary_coding_id": "hgnc:3765",
     "coding_id": "ncbi:2322",
     "relation": "exactMatch"
   },
   {
-    "id": 196,
+    "id": 80,
+    "primary_coding_id": "hgnc:3765",
     "coding_id": "refseq:NM_004119.3",
     "relation": "relatedMatch"
   },
   {
-    "id": 197,
-    "coding_id": "hgnc:5173",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 198,
-    "coding_id": "ensembl:ensg00000174775",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 199,
-    "coding_id": "ncbi:3265",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 200,
+    "id": 81,
+    "primary_coding_id": "hgnc:5173",
     "coding_id": "refseq:NM_005343.4",
     "relation": "relatedMatch"
   },
   {
-    "id": 201,
-    "coding_id": "hgnc:5382",
+    "id": 82,
+    "primary_coding_id": "hgnc:5173",
+    "coding_id": "ensembl:ensg00000174775",
     "relation": "exactMatch"
   },
   {
-    "id": 202,
+    "id": 83,
+    "primary_coding_id": "hgnc:5173",
+    "coding_id": "ncbi:3265",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 84,
+    "primary_coding_id": "hgnc:5382",
     "coding_id": "ensembl:ensg00000138413",
     "relation": "exactMatch"
   },
   {
-    "id": 203,
+    "id": 85,
+    "primary_coding_id": "hgnc:5382",
     "coding_id": "ncbi:3417",
     "relation": "exactMatch"
   },
   {
-    "id": 204,
+    "id": 86,
+    "primary_coding_id": "hgnc:5382",
     "coding_id": "refseq:NM_005896.4",
     "relation": "relatedMatch"
   },
   {
-    "id": 205,
-    "coding_id": "hgnc:5383",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 206,
-    "coding_id": "ensembl:ensg00000182054",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 207,
-    "coding_id": "ncbi:3418",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 208,
+    "id": 87,
+    "primary_coding_id": "hgnc:5383",
     "coding_id": "refseq:NM_002168.4",
     "relation": "relatedMatch"
   },
   {
-    "id": 209,
-    "coding_id": "hgnc:6342",
+    "id": 88,
+    "primary_coding_id": "hgnc:5383",
+    "coding_id": "ensembl:ensg00000182054",
     "relation": "exactMatch"
   },
   {
-    "id": 210,
+    "id": 89,
+    "primary_coding_id": "hgnc:5383",
+    "coding_id": "ncbi:3418",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 90,
+    "primary_coding_id": "hgnc:6342",
     "coding_id": "ensembl:ensg00000157404",
     "relation": "exactMatch"
   },
   {
-    "id": 211,
+    "id": 91,
+    "primary_coding_id": "hgnc:6342",
     "coding_id": "ncbi:3815",
     "relation": "exactMatch"
   },
   {
-    "id": 212,
+    "id": 92,
+    "primary_coding_id": "hgnc:6342",
     "coding_id": "refseq:NM_000222.3",
     "relation": "relatedMatch"
   },
   {
-    "id": 213,
-    "coding_id": "hgnc:6407",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 214,
-    "coding_id": "ensembl:ensg00000133703",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 215,
-    "coding_id": "ncbi:3845",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 216,
+    "id": 93,
+    "primary_coding_id": "hgnc:6407",
     "coding_id": "refseq:NM_004985.5",
     "relation": "relatedMatch"
   },
   {
-    "id": 217,
-    "coding_id": "hgnc:7029",
+    "id": 94,
+    "primary_coding_id": "hgnc:6407",
+    "coding_id": "ensembl:ensg00000133703",
     "relation": "exactMatch"
   },
   {
-    "id": 218,
+    "id": 95,
+    "primary_coding_id": "hgnc:6407",
+    "coding_id": "ncbi:3845",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 96,
+    "primary_coding_id": "hgnc:7029",
     "coding_id": "ensembl:ensg00000105976",
     "relation": "exactMatch"
   },
   {
-    "id": 219,
+    "id": 97,
+    "primary_coding_id": "hgnc:7029",
     "coding_id": "ncbi:4233",
     "relation": "exactMatch"
   },
   {
-    "id": 220,
+    "id": 98,
+    "primary_coding_id": "hgnc:7029",
     "coding_id": "refseq:NM_000245.4",
     "relation": "relatedMatch"
   },
   {
-    "id": 221,
-    "coding_id": "hgnc:7989",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 222,
-    "coding_id": "ensembl:ensg00000213281",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 223,
-    "coding_id": "ncbi:4893",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 224,
+    "id": 99,
+    "primary_coding_id": "hgnc:7989",
     "coding_id": "refseq:NM_002524.5",
     "relation": "relatedMatch"
   },
   {
-    "id": 225,
-    "coding_id": "hgnc:7997",
+    "id": 100,
+    "primary_coding_id": "hgnc:7989",
+    "coding_id": "ensembl:ensg00000213281",
     "relation": "exactMatch"
   },
   {
-    "id": 226,
+    "id": 101,
+    "primary_coding_id": "hgnc:7989",
+    "coding_id": "ncbi:4893",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 102,
+    "primary_coding_id": "hgnc:7997",
     "coding_id": "ensembl:ensg00000157168",
     "relation": "exactMatch"
   },
   {
-    "id": 227,
+    "id": 103,
+    "primary_coding_id": "hgnc:7997",
     "coding_id": "ncbi:3084",
     "relation": "exactMatch"
   },
   {
-    "id": 228,
+    "id": 104,
+    "primary_coding_id": "hgnc:7997",
     "coding_id": "refseq:NM_013964.5",
     "relation": "relatedMatch"
   },
   {
-    "id": 229,
-    "coding_id": "hgnc:8031",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 230,
-    "coding_id": "ensembl:ensg00000198400",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 231,
-    "coding_id": "ncbi:4914",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 232,
+    "id": 105,
+    "primary_coding_id": "hgnc:8031",
     "coding_id": "refseq:NM_002529.4",
     "relation": "relatedMatch"
   },
   {
-    "id": 233,
-    "coding_id": "hgnc:8032",
+    "id": 106,
+    "primary_coding_id": "hgnc:8031",
+    "coding_id": "ensembl:ensg00000198400",
     "relation": "exactMatch"
   },
   {
-    "id": 234,
+    "id": 107,
+    "primary_coding_id": "hgnc:8031",
+    "coding_id": "ncbi:4914",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 108,
+    "primary_coding_id": "hgnc:8032",
     "coding_id": "ensembl:ensg00000148053",
     "relation": "exactMatch"
   },
   {
-    "id": 235,
+    "id": 109,
+    "primary_coding_id": "hgnc:8032",
     "coding_id": "ncbi:4915",
     "relation": "exactMatch"
   },
   {
-    "id": 236,
+    "id": 110,
+    "primary_coding_id": "hgnc:8032",
     "coding_id": "refseq:NM_006180.6",
     "relation": "relatedMatch"
   },
   {
-    "id": 237,
-    "coding_id": "hgnc:8033",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 238,
-    "coding_id": "ensembl:ensg00000140538",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 239,
-    "coding_id": "ncbi:4916",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 240,
+    "id": 111,
+    "primary_coding_id": "hgnc:8033",
     "coding_id": "refseq:NM_001012338.3",
     "relation": "relatedMatch"
   },
   {
-    "id": 241,
-    "coding_id": "hgnc:26144",
+    "id": 112,
+    "primary_coding_id": "hgnc:8033",
+    "coding_id": "ensembl:ensg00000140538",
     "relation": "exactMatch"
   },
   {
-    "id": 242,
+    "id": 113,
+    "primary_coding_id": "hgnc:8033",
+    "coding_id": "ncbi:4916",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 114,
+    "primary_coding_id": "hgnc:26144",
     "coding_id": "ensembl:ensg00000083093",
     "relation": "exactMatch"
   },
   {
-    "id": 243,
+    "id": 115,
+    "primary_coding_id": "hgnc:26144",
     "coding_id": "ncbi:79728",
     "relation": "exactMatch"
   },
   {
-    "id": 244,
+    "id": 116,
+    "primary_coding_id": "hgnc:26144",
     "coding_id": "refseq:NM_024675.4",
     "relation": "relatedMatch"
   },
   {
-    "id": 245,
-    "coding_id": "hgnc:8803",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 246,
-    "coding_id": "ensembl:ensg00000134853",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 247,
-    "coding_id": "ncbi:5156",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 248,
+    "id": 117,
+    "primary_coding_id": "hgnc:8803",
     "coding_id": "refseq:NM_006206.6",
     "relation": "relatedMatch"
   },
   {
-    "id": 249,
-    "coding_id": "hgnc:8804",
+    "id": 118,
+    "primary_coding_id": "hgnc:8803",
+    "coding_id": "ensembl:ensg00000134853",
     "relation": "exactMatch"
   },
   {
-    "id": 250,
+    "id": 119,
+    "primary_coding_id": "hgnc:8803",
+    "coding_id": "ncbi:5156",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 120,
+    "primary_coding_id": "hgnc:8804",
     "coding_id": "ensembl:ensg00000113721",
     "relation": "exactMatch"
   },
   {
-    "id": 251,
+    "id": 121,
+    "primary_coding_id": "hgnc:8804",
     "coding_id": "ncbi:5159",
     "relation": "exactMatch"
   },
   {
-    "id": 252,
+    "id": 122,
+    "primary_coding_id": "hgnc:8804",
     "coding_id": "refseq:NM_002609.4",
     "relation": "relatedMatch"
   },
   {
-    "id": 253,
-    "coding_id": "hgnc:8975",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 254,
-    "coding_id": "ensembl:ensg00000121879",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 255,
-    "coding_id": "ncbi:5290",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 256,
+    "id": 123,
+    "primary_coding_id": "hgnc:8975",
     "coding_id": "refseq:NM_006218.4",
     "relation": "relatedMatch"
   },
   {
-    "id": 257,
-    "coding_id": "hgnc:9113",
+    "id": 124,
+    "primary_coding_id": "hgnc:8975",
+    "coding_id": "ensembl:ensg00000121879",
     "relation": "exactMatch"
   },
   {
-    "id": 258,
+    "id": 125,
+    "primary_coding_id": "hgnc:8975",
+    "coding_id": "ncbi:5290",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 126,
+    "primary_coding_id": "hgnc:9113",
     "coding_id": "ensembl:ensg00000140464",
     "relation": "exactMatch"
   },
   {
-    "id": 259,
+    "id": 127,
+    "primary_coding_id": "hgnc:9113",
     "coding_id": "ncbi:5371",
     "relation": "exactMatch"
   },
   {
-    "id": 260,
+    "id": 128,
+    "primary_coding_id": "hgnc:9113",
     "coding_id": "refseq:NM_033238.3",
     "relation": "relatedMatch"
   },
   {
-    "id": 261,
-    "coding_id": "hgnc:9588",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 262,
-    "coding_id": "ensembl:ensg00000171862",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 263,
-    "coding_id": "ncbi:5728",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 264,
+    "id": 129,
+    "primary_coding_id": "hgnc:9588",
     "coding_id": "refseq:NM_000314.8",
     "relation": "relatedMatch"
   },
   {
-    "id": 265,
-    "coding_id": "hgnc:9822",
+    "id": 130,
+    "primary_coding_id": "hgnc:9588",
+    "coding_id": "ensembl:ensg00000171862",
     "relation": "exactMatch"
   },
   {
-    "id": 266,
+    "id": 131,
+    "primary_coding_id": "hgnc:9588",
+    "coding_id": "ncbi:5728",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 132,
+    "primary_coding_id": "hgnc:9822",
     "coding_id": "ensembl:ensg00000182185",
     "relation": "exactMatch"
   },
   {
-    "id": 267,
+    "id": 133,
+    "primary_coding_id": "hgnc:9822",
     "coding_id": "ncbi:5890",
     "relation": "exactMatch"
   },
   {
-    "id": 268,
+    "id": 134,
+    "primary_coding_id": "hgnc:9822",
     "coding_id": "refseq:NM_133510.4",
     "relation": "relatedMatch"
   },
   {
-    "id": 269,
-    "coding_id": "hgnc:9820",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 270,
-    "coding_id": "ensembl:ensg00000108384",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 271,
-    "coding_id": "ncbi:5889",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 272,
+    "id": 135,
+    "primary_coding_id": "hgnc:9820",
     "coding_id": "refseq:NM_058216.3",
     "relation": "relatedMatch"
   },
   {
-    "id": 273,
-    "coding_id": "hgnc:9823",
+    "id": 136,
+    "primary_coding_id": "hgnc:9820",
+    "coding_id": "ensembl:ensg00000108384",
     "relation": "exactMatch"
   },
   {
-    "id": 274,
+    "id": 137,
+    "primary_coding_id": "hgnc:9820",
+    "coding_id": "ncbi:5889",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 138,
+    "primary_coding_id": "hgnc:9823",
     "coding_id": "ensembl:ensg00000185379",
     "relation": "exactMatch"
   },
   {
-    "id": 275,
+    "id": 139,
+    "primary_coding_id": "hgnc:9823",
     "coding_id": "ncbi:5892",
     "relation": "exactMatch"
   },
   {
-    "id": 276,
+    "id": 140,
+    "primary_coding_id": "hgnc:9823",
     "coding_id": "refseq:NM_002878.4",
     "relation": "relatedMatch"
   },
   {
-    "id": 277,
-    "coding_id": "hgnc:9826",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 278,
-    "coding_id": "ensembl:ensg00000085999",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 279,
-    "coding_id": "ncbi:8438",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 280,
+    "id": 141,
+    "primary_coding_id": "hgnc:9826",
     "coding_id": "refseq:NM_003579.4",
     "relation": "relatedMatch"
   },
   {
-    "id": 281,
-    "coding_id": "hgnc:9864",
+    "id": 142,
+    "primary_coding_id": "hgnc:9826",
+    "coding_id": "ensembl:ensg00000085999",
     "relation": "exactMatch"
   },
   {
-    "id": 282,
+    "id": 143,
+    "primary_coding_id": "hgnc:9826",
+    "coding_id": "ncbi:8438",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 144,
+    "primary_coding_id": "hgnc:9864",
     "coding_id": "ensembl:ensg00000131759",
     "relation": "exactMatch"
   },
   {
-    "id": 283,
+    "id": 145,
+    "primary_coding_id": "hgnc:9864",
     "coding_id": "ncbi:5914",
     "relation": "exactMatch"
   },
   {
-    "id": 284,
+    "id": 146,
+    "primary_coding_id": "hgnc:9864",
     "coding_id": "refseq:NM_000964.4",
     "relation": "relatedMatch"
   },
   {
-    "id": 285,
-    "coding_id": "hgnc:9967",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 286,
-    "coding_id": "ensembl:ensg00000165731",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 287,
-    "coding_id": "ncbi:5979",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 288,
+    "id": 147,
+    "primary_coding_id": "hgnc:9967",
     "coding_id": "refseq:NM_020975.6",
     "relation": "relatedMatch"
   },
   {
-    "id": 289,
-    "coding_id": "hgnc:10261",
+    "id": 148,
+    "primary_coding_id": "hgnc:9967",
+    "coding_id": "ensembl:ensg00000165731",
     "relation": "exactMatch"
   },
   {
-    "id": 290,
+    "id": 149,
+    "primary_coding_id": "hgnc:9967",
+    "coding_id": "ncbi:5979",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 150,
+    "primary_coding_id": "hgnc:10261",
     "coding_id": "ensembl:ensg00000047936",
     "relation": "exactMatch"
   },
   {
-    "id": 291,
+    "id": 151,
+    "primary_coding_id": "hgnc:10261",
     "coding_id": "ncbi:6098",
     "relation": "exactMatch"
   },
   {
-    "id": 292,
+    "id": 152,
+    "primary_coding_id": "hgnc:10261",
     "coding_id": "refseq:NM_001378902.1",
     "relation": "relatedMatch"
   },
   {
-    "id": 293,
-    "coding_id": "hgnc:11524",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 294,
-    "coding_id": "ensembl:ensg00000013810",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 295,
-    "coding_id": "ncbi:10460",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 296,
+    "id": 153,
+    "primary_coding_id": "hgnc:11524",
     "coding_id": "refseq:NM_006342.3",
     "relation": "relatedMatch"
   },
   {
-    "id": 297,
-    "coding_id": "hgnc:11998",
+    "id": 154,
+    "primary_coding_id": "hgnc:11524",
+    "coding_id": "ensembl:ensg00000013810",
     "relation": "exactMatch"
   },
   {
-    "id": 298,
+    "id": 155,
+    "primary_coding_id": "hgnc:11524",
+    "coding_id": "ncbi:10460",
+    "relation": "exactMatch"
+  },
+  {
+    "id": 156,
+    "primary_coding_id": "hgnc:11998",
     "coding_id": "ensembl:ensg00000141510",
     "relation": "exactMatch"
   },
   {
-    "id": 299,
+    "id": 157,
+    "primary_coding_id": "hgnc:11998",
     "coding_id": "ncbi:7157",
     "relation": "exactMatch"
   },
   {
-    "id": 300,
+    "id": 158,
+    "primary_coding_id": "hgnc:11998",
     "coding_id": "refseq:NM_000546.6",
     "relation": "relatedMatch"
   },
   {
-    "id": 301,
-    "coding_id": "hgnc:7131",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 302,
+    "id": 159,
+    "primary_coding_id": "hgnc:7131",
     "coding_id": "ensembl:ensg00000118058",
     "relation": "exactMatch"
   },
   {
-    "id": 303,
+    "id": 160,
+    "primary_coding_id": "hgnc:7131",
     "coding_id": "ncbi:4297",
     "relation": "exactMatch"
   },
   {
-    "id": 304,
-    "coding_id": "hgnc:12362",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 305,
+    "id": 161,
+    "primary_coding_id": "hgnc:12362",
     "coding_id": "ensembl:ENSG00000165699",
     "relation": "exactMatch"
   },
   {
-    "id": 306,
+    "id": 162,
+    "primary_coding_id": "hgnc:12362",
     "coding_id": "ncbi:7248",
     "relation": "exactMatch"
   },
   {
-    "id": 307,
-    "coding_id": "hgnc:12363",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 308,
+    "id": 163,
+    "primary_coding_id": "hgnc:12363",
     "coding_id": "ensembl:ENSG00000103197",
     "relation": "exactMatch"
   },
   {
-    "id": 309,
+    "id": 164,
+    "primary_coding_id": "hgnc:12363",
     "coding_id": "ncbi:7249",
     "relation": "exactMatch"
   },
   {
-    "id": 310,
-    "coding_id": "hgnc:882",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 311,
-    "coding_id": "ensembl:ENSG00000175054",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 312,
+    "id": 165,
+    "primary_coding_id": "hgnc:882",
     "coding_id": "ncbi:545",
     "relation": "exactMatch"
   },
   {
-    "id": 313,
-    "coding_id": "hgnc:3582",
+    "id": 166,
+    "primary_coding_id": "hgnc:882",
+    "coding_id": "ensembl:ENSG00000175054",
     "relation": "exactMatch"
   },
   {
-    "id": 314,
+    "id": 167,
+    "primary_coding_id": "hgnc:3582",
     "coding_id": "ensembl:ENSG00000187741",
     "relation": "exactMatch"
   },
   {
-    "id": 315,
+    "id": 168,
+    "primary_coding_id": "hgnc:3582",
     "coding_id": "ncbi:2175",
     "relation": "exactMatch"
   },
   {
-    "id": 316,
-    "coding_id": "hgnc:7127",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 317,
+    "id": 169,
+    "primary_coding_id": "hgnc:7127",
     "coding_id": "ensembl:ENSG00000076242",
     "relation": "exactMatch"
   },
   {
-    "id": 318,
+    "id": 170,
+    "primary_coding_id": "hgnc:7127",
     "coding_id": "ncbi:4292",
     "relation": "exactMatch"
   },
   {
-    "id": 319,
-    "coding_id": "hgnc:7230",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 320,
+    "id": 171,
+    "primary_coding_id": "hgnc:7230",
     "coding_id": "ensembl:ENSG00000020922",
     "relation": "exactMatch"
   },
   {
-    "id": 321,
+    "id": 172,
+    "primary_coding_id": "hgnc:7230",
     "coding_id": "ncbi:4361",
     "relation": "exactMatch"
   },
   {
-    "id": 322,
-    "coding_id": "hgnc:7652",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 323,
+    "id": 173,
+    "primary_coding_id": "hgnc:7652",
     "coding_id": "ensembl:ENSG00000104320",
     "relation": "exactMatch"
   },
   {
-    "id": 324,
+    "id": 174,
+    "primary_coding_id": "hgnc:7652",
     "coding_id": "ncbi:4683",
     "relation": "exactMatch"
   },
   {
-    "id": 326,
-    "coding_id": "ncit:C66944",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 327,
-    "coding_id": "ncit:C411",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 328,
-    "coding_id": "ncit:C456",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 329,
-    "coding_id": "ncit:",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 330,
-    "coding_id": "ncit:C48387",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 331,
-    "coding_id": "ncit:C1097",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 332,
-    "coding_id": "ncit:C80059",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 333,
-    "coding_id": "ncit:C68845",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 334,
-    "coding_id": "ncit:C769",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 335,
-    "coding_id": "ncit:C101790",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 336,
-    "coding_id": "ncit:C98831",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 337,
-    "coding_id": "ncit:C2039",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 338,
-    "coding_id": "ncit:C65530",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 339,
-    "coding_id": "ncit:C123827",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 340,
-    "coding_id": "ncit:C71542",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 341,
-    "coding_id": "ncit:C62528",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 342,
-    "coding_id": "ncit:C60809",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 343,
-    "coding_id": "ncit:C84865",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 344,
-    "coding_id": "ncit:C98283",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 345,
-    "coding_id": "ncit:C1723",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 346,
-    "coding_id": "ncit:C2737",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 347,
-    "coding_id": "ncit:C68923",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 348,
-    "coding_id": "ncit:C64768",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 349,
-    "coding_id": "ncit:C70792",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 350,
-    "coding_id": "ncit:C1526",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 351,
-    "coding_id": "ncit:C1647",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 352,
-    "coding_id": "ncit:C128799",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 353,
-    "coding_id": "ncit:C62040",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 354,
-    "coding_id": "ncit:C1181",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 355,
-    "coding_id": "ncit:C505",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 356,
-    "coding_id": "ncit:C1379",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 357,
-    "coding_id": "ncit:C49176",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 358,
-    "coding_id": "ncit:C132295",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 359,
-    "coding_id": "ncit:C1855",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 360,
-    "coding_id": "ncit:C66940",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 361,
-    "coding_id": "ncit:C1411",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 362,
-    "coding_id": "ncit:C1607",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 363,
-    "coding_id": "ncit:C1282",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 364,
-    "coding_id": "ncit:C1794",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 365,
-    "coding_id": "ncit:C376",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 366,
-    "coding_id": "ncit:C1527",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 367,
-    "coding_id": "ncit:C62035",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 368,
-    "coding_id": "ncit:",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 369,
-    "coding_id": "ncit:C95777",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 370,
-    "coding_id": "ncit:C103194",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 371,
-    "coding_id": "ncit:C49085",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 372,
-    "coding_id": "ncit:C71721",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 373,
-    "coding_id": "ncit:C126799",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 374,
-    "coding_id": "ncit:C106432",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 375,
-    "coding_id": "ncit:C61614",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 376,
-    "coding_id": "ncit:C66876",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 377,
-    "coding_id": "ncit:C2688",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 378,
-    "coding_id": "ncit:C82492",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 379,
-    "coding_id": "ncit:C95701",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 380,
-    "coding_id": "ncit:C157493",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 381,
-    "coding_id": "ncit:C121540",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 382,
-    "coding_id": "ncit:C113655",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 383,
-    "coding_id": "ncit:C154287",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 384,
-    "coding_id": "ncit:C114283",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 385,
-    "coding_id": "ncit:C405",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 386,
-    "coding_id": "ncit:C1702",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 387,
-    "coding_id": "ncit:C933",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 388,
-    "coding_id": "ncit:C2322",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 389,
-    "coding_id": "ncit:C408",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 390,
-    "coding_id": "ncit:C491",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 391,
-    "coding_id": "ncit:C642",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 392,
-    "coding_id": "ncit:C77908",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 393,
-    "coding_id": "ncit:C82386",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 394,
-    "coding_id": "ncit:C62091",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 395,
-    "coding_id": "ncit:C1806",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 396,
-    "coding_id": "ncit:C49094",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 397,
-    "coding_id": "ncit:C2654",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 398,
-    "coding_id": "ncit:C68814",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 399,
-    "coding_id": "ncit:C111999",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 400,
-    "coding_id": "ncit:C120211",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 401,
-    "coding_id": "ncit:C38692",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 402,
-    "coding_id": "ncit:C62028",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 403,
-    "coding_id": "ncit:C94214",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 404,
-    "coding_id": "ncit:C134987",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 405,
-    "coding_id": "ncit:C2668",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 406,
-    "coding_id": "ncit:C114984",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 407,
-    "coding_id": "ncit:",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 408,
-    "coding_id": "ncit:C1872",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 409,
-    "coding_id": "ncit:C114494",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 410,
-    "coding_id": "ncit:C38713",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 411,
-    "coding_id": "ncit:C90564",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 412,
-    "coding_id": "ncit:C116377",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 413,
-    "coding_id": "ncit:C95733",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 414,
-    "coding_id": "ncit:C48375",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 415,
-    "coding_id": "ncit:C106250",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 416,
-    "coding_id": "ncit:C88314",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 417,
-    "coding_id": "ncit:C288",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 418,
-    "coding_id": "ncit:C114383",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 419,
-    "coding_id": "ncit:C1005",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 420,
-    "coding_id": "ncit:C102783",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 421,
-    "coding_id": "ncit:C77896",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 422,
-    "coding_id": "ncit:C26653",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 423,
-    "coding_id": "ncit:C1857",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 424,
-    "coding_id": "ncit:C103147",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 425,
-    "coding_id": "ncit:C97660",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 426,
-    "coding_id": "ncit:C115977",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 427,
-    "coding_id": "ncit:C53398",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 428,
-    "coding_id": "ncit:C74061",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 429,
-    "coding_id": "ncit:",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 430,
-    "coding_id": "ncit:C116722",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 431,
-    "coding_id": "ncit:C78825",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 432,
-    "coding_id": "ncit:C115112",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 433,
-    "coding_id": "ncit:C121775",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 434,
-    "coding_id": "ncit:C124993",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 435,
-    "coding_id": "ncit:C102564",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 436,
-    "coding_id": "ncit:C103273",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 437,
-    "coding_id": "ncit:C85475",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 438,
-    "coding_id": "ncit:C49094",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 439,
-    "coding_id": "ncit:C141428",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 440,
-    "coding_id": "ncit:C113442",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 441,
-    "coding_id": "ncit:C81934",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 442,
-    "coding_id": "ncit:C564",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 443,
-    "coding_id": "ncit:C1275",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 444,
-    "coding_id": "ncit:",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 445,
-    "coding_id": "ncit:C62078",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 446,
-    "coding_id": "ncit:C66952",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 447,
-    "coding_id": "ncit:C73261",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 448,
-    "coding_id": "ncit:C770",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 449,
-    "coding_id": "ncit:C362",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 450,
-    "coding_id": "ncit:C62050",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 451,
-    "coding_id": "ncit:C20494",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 452,
-    "coding_id": "ncit:C111573",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 453,
-    "coding_id": "ncit:C88302",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 454,
-    "coding_id": "ncit:C91733",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 455,
-    "coding_id": "ncit:C96748",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 456,
-    "coding_id": "ncit:C126752",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 457,
-    "coding_id": "ncit:C129687",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 458,
-    "coding_id": "ncit:C95124",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 459,
-    "coding_id": "ncit:C121553",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 460,
-    "coding_id": "ncit:C133821",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 461,
-    "coding_id": "ncit:C1094",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 462,
-    "coding_id": "ncit:C137800",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 463,
-    "coding_id": "ncit:C107506",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 464,
-    "coding_id": "ncit:C71744",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 465,
-    "coding_id": "ncit:C148147",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 466,
-    "coding_id": "ncit:C102566",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 467,
-    "coding_id": "ncit:C106254",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 468,
-    "coding_id": "ncit:C152914",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 469,
-    "coding_id": "ncit:C1374",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 470,
-    "coding_id": "ncit:C132166",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 471,
-    "coding_id": "ncit:C130010",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 472,
-    "coding_id": "ncit:C152948",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 473,
-    "coding_id": "ncit:C102754",
-    "relation": "exactMatch"
-  },
-  {
-    "id": 474,
-    "coding_id": "ncit:C165776",
-    "relation": "exactMatch"
+    "id": 175,
+    "primary_coding_id": "ncit:C3163",
+    "coding_id": "oncotree:CLLSLL",
+    "relation": "broadMatch"
   }
 ]

--- a/referenced/mappings.json
+++ b/referenced/mappings.json
@@ -1,2377 +1,2377 @@
 [
   {
     "id": 0,
-    "coding": "oncotree:ALL",
+    "coding_id": "oncotree:ALL",
     "relation": "exactMatch"
   },
   {
     "id": 1,
-    "coding": "oncotree:AML",
+    "coding_id": "oncotree:AML",
     "relation": "exactMatch"
   },
   {
     "id": 2,
-    "coding": "oncotree:GEJ",
+    "coding_id": "oncotree:GEJ",
     "relation": "exactMatch"
   },
   {
     "id": 3,
-    "coding": "oncotree:ALCL",
+    "coding_id": "oncotree:ALCL",
     "relation": "exactMatch"
   },
   {
     "id": 4,
-    "coding": "oncotree:THAP",
+    "coding_id": "oncotree:THAP",
     "relation": "exactMatch"
   },
   {
     "id": 5,
-    "coding": "oncotree:",
+    "coding_id": "oncotree:",
     "relation": "exactMatch"
   },
   {
     "id": 6,
-    "coding": "oncotree:ASTR",
+    "coding_id": "oncotree:ASTR",
     "relation": "exactMatch"
   },
   {
     "id": 7,
-    "coding": "oncotree:BALL",
+    "coding_id": "oncotree:BALL",
     "relation": "exactMatch"
   },
   {
     "id": 8,
-    "coding": "oncotree:BLCA",
+    "coding_id": "oncotree:BLCA",
     "relation": "exactMatch"
   },
   {
     "id": 9,
-    "coding": "oncotree:BRCA",
+    "coding_id": "oncotree:BRCA",
     "relation": "exactMatch"
   },
   {
     "id": 10,
-    "coding": "oncotree:APLPMLRARA",
+    "coding_id": "oncotree:APLPMLRARA",
     "relation": "exactMatch"
   },
   {
     "id": 11,
-    "coding": "oncotree:CHOL",
+    "coding_id": "oncotree:CHOL",
     "relation": "exactMatch"
   },
   {
     "id": 12,
-    "coding": "oncotree:CELNOS",
+    "coding_id": "oncotree:CELNOS",
     "relation": "exactMatch"
   },
   {
     "id": 13,
-    "coding": "oncotree:CML",
+    "coding_id": "oncotree:CML",
     "relation": "exactMatch"
   },
   {
     "id": 14,
-    "coding": "oncotree:CMML",
+    "coding_id": "oncotree:CMML",
     "relation": "exactMatch"
   },
   {
     "id": 15,
-    "coding": "oncotree:COADREAD",
+    "coding_id": "oncotree:COADREAD",
     "relation": "exactMatch"
   },
   {
     "id": 16,
-    "coding": "oncotree:DDLS",
+    "coding_id": "oncotree:DDLS",
     "relation": "exactMatch"
   },
   {
     "id": 17,
-    "coding": "oncotree:DFSP",
+    "coding_id": "oncotree:DFSP",
     "relation": "exactMatch"
   },
   {
     "id": 18,
-    "coding": "oncotree:UCEC",
+    "coding_id": "oncotree:UCEC",
     "relation": "exactMatch"
   },
   {
     "id": 19,
-    "coding": "oncotree:ES",
+    "coding_id": "oncotree:ES",
     "relation": "exactMatch"
   },
   {
     "id": 20,
-    "coding": "oncotree:FL",
+    "coding_id": "oncotree:FL",
     "relation": "exactMatch"
   },
   {
     "id": 21,
-    "coding": "oncotree:GRC",
+    "coding_id": "oncotree:GRC",
     "relation": "exactMatch"
   },
   {
     "id": 22,
-    "coding": "oncotree:GIST",
+    "coding_id": "oncotree:GIST",
     "relation": "exactMatch"
   },
   {
     "id": 23,
-    "coding": "oncotree:GNOS",
+    "coding_id": "oncotree:GNOS",
     "relation": "exactMatch"
   },
   {
     "id": 24,
-    "coding": "oncotree:HNMUCM",
+    "coding_id": "oncotree:HNMUCM",
     "relation": "exactMatch"
   },
   {
     "id": 25,
-    "coding": "oncotree:HNSC",
+    "coding_id": "oncotree:HNSC",
     "relation": "exactMatch"
   },
   {
     "id": 26,
-    "coding": "oncotree:HGNEC",
+    "coding_id": "oncotree:HGNEC",
     "relation": "exactMatch"
   },
   {
     "id": 27,
-    "coding": "oncotree:HGSFT",
+    "coding_id": "oncotree:HGSFT",
     "relation": "exactMatch"
   },
   {
     "id": 28,
-    "coding": "oncotree:IMT",
+    "coding_id": "oncotree:IMT",
     "relation": "exactMatch"
   },
   {
     "id": 29,
-    "coding": "oncotree:IHCH",
+    "coding_id": "oncotree:IHCH",
     "relation": "exactMatch"
   },
   {
     "id": 30,
-    "coding": "oncotree:",
+    "coding_id": "oncotree:",
     "relation": "exactMatch"
   },
   {
     "id": 31,
-    "coding": "oncotree:LCH",
+    "coding_id": "oncotree:LCH",
     "relation": "exactMatch"
   },
   {
     "id": 32,
-    "coding": "oncotree:LMS",
+    "coding_id": "oncotree:LMS",
     "relation": "exactMatch"
   },
   {
     "id": 33,
-    "coding": "oncotree:LEUK",
+    "coding_id": "oncotree:LEUK",
     "relation": "exactMatch"
   },
   {
     "id": 34,
-    "coding": "oncotree:LIPO",
+    "coding_id": "oncotree:LIPO",
     "relation": "exactMatch"
   },
   {
     "id": 35,
-    "coding": "oncotree:LGGNOS",
+    "coding_id": "oncotree:LGGNOS",
     "relation": "exactMatch"
   },
   {
     "id": 36,
-    "coding": "oncotree:LUSC",
+    "coding_id": "oncotree:LUSC",
     "relation": "exactMatch"
   },
   {
     "id": 37,
-    "coding": "oncotree:SMMCL",
+    "coding_id": "oncotree:SMMCL",
     "relation": "exactMatch"
   },
   {
     "id": 38,
-    "coding": "oncotree:THME",
+    "coding_id": "oncotree:THME",
     "relation": "exactMatch"
   },
   {
     "id": 39,
-    "coding": "oncotree:MBL",
+    "coding_id": "oncotree:MBL",
     "relation": "exactMatch"
   },
   {
     "id": 40,
-    "coding": "oncotree:MEL",
+    "coding_id": "oncotree:MEL",
     "relation": "exactMatch"
   },
   {
     "id": 41,
-    "coding": "oncotree:MM",
+    "coding_id": "oncotree:MM",
     "relation": "exactMatch"
   },
   {
     "id": 42,
-    "coding": "oncotree:ASM",
+    "coding_id": "oncotree:ASM",
     "relation": "exactMatch"
   },
   {
     "id": 43,
-    "coding": "oncotree:MDS",
+    "coding_id": "oncotree:MDS",
     "relation": "exactMatch"
   },
   {
     "id": 44,
-    "coding": "oncotree:MLN",
+    "coding_id": "oncotree:MLN",
     "relation": "exactMatch"
   },
   {
     "id": 45,
-    "coding": "oncotree:MPN",
+    "coding_id": "oncotree:MPN",
     "relation": "exactMatch"
   },
   {
     "id": 46,
-    "coding": "oncotree:ECD",
+    "coding_id": "oncotree:ECD",
     "relation": "exactMatch"
   },
   {
     "id": 47,
-    "coding": "oncotree:NSCLC",
+    "coding_id": "oncotree:NSCLC",
     "relation": "exactMatch"
   },
   {
     "id": 48,
-    "coding": "oncotree:ODG",
+    "coding_id": "oncotree:ODG",
     "relation": "exactMatch"
   },
   {
     "id": 49,
-    "coding": "oncotree:OS",
+    "coding_id": "oncotree:OS",
     "relation": "exactMatch"
   },
   {
     "id": 50,
-    "coding": "oncotree:OOVC",
+    "coding_id": "oncotree:OOVC",
     "relation": "exactMatch"
   },
   {
     "id": 51,
-    "coding": "oncotree:OVT",
+    "coding_id": "oncotree:OVT",
     "relation": "exactMatch"
   },
   {
     "id": 52,
-    "coding": "oncotree:PAAD",
+    "coding_id": "oncotree:PAAD",
     "relation": "exactMatch"
   },
   {
     "id": 53,
-    "coding": "oncotree:PEMESO",
+    "coding_id": "oncotree:PEMESO",
     "relation": "exactMatch"
   },
   {
     "id": 54,
-    "coding": "oncotree:PSEC",
+    "coding_id": "oncotree:PSEC",
     "relation": "exactMatch"
   },
   {
     "id": 55,
-    "coding": "oncotree:PRAD",
+    "coding_id": "oncotree:PRAD",
     "relation": "exactMatch"
   },
   {
     "id": 56,
-    "coding": "oncotree:PRNE",
+    "coding_id": "oncotree:PRNE",
     "relation": "exactMatch"
   },
   {
     "id": 57,
-    "coding": "oncotree:READ",
+    "coding_id": "oncotree:READ",
     "relation": "exactMatch"
   },
   {
     "id": 58,
-    "coding": "oncotree:RCC",
+    "coding_id": "oncotree:RCC",
     "relation": "exactMatch"
   },
   {
     "id": 59,
-    "coding": "oncotree:CCRCC",
+    "coding_id": "oncotree:CCRCC",
     "relation": "exactMatch"
   },
   {
     "id": 60,
-    "coding": "oncotree:SOC",
+    "coding_id": "oncotree:SOC",
     "relation": "exactMatch"
   },
   {
     "id": 61,
-    "coding": "oncotree:SCLC",
+    "coding_id": "oncotree:SCLC",
     "relation": "exactMatch"
   },
   {
     "id": 62,
-    "coding": "oncotree:SCCNOS",
+    "coding_id": "oncotree:SCCNOS",
     "relation": "exactMatch"
   },
   {
     "id": 63,
-    "coding": "oncotree:STAD",
+    "coding_id": "oncotree:STAD",
     "relation": "exactMatch"
   },
   {
     "id": 64,
-    "coding": "oncotree:TALL",
+    "coding_id": "oncotree:TALL",
     "relation": "exactMatch"
   },
   {
     "id": 65,
-    "coding": "oncotree:TGCT",
+    "coding_id": "oncotree:TGCT",
     "relation": "exactMatch"
   },
   {
     "id": 66,
-    "coding": "oncotree:THYC",
+    "coding_id": "oncotree:THYC",
     "relation": "exactMatch"
   },
   {
     "id": 67,
-    "coding": "oncotree:UCU",
+    "coding_id": "oncotree:UCU",
     "relation": "exactMatch"
   },
   {
     "id": 68,
-    "coding": "oncotree:ULM",
+    "coding_id": "oncotree:ULM",
     "relation": "exactMatch"
   },
   {
     "id": 69,
-    "coding": "oncotree:ULMS",
+    "coding_id": "oncotree:ULMS",
     "relation": "exactMatch"
   },
   {
     "id": 70,
-    "coding": "oncotree:WDLS",
+    "coding_id": "oncotree:WDLS",
     "relation": "exactMatch"
   },
   {
     "id": 71,
-    "coding": "oncotree:CMLBCRABL1",
+    "coding_id": "oncotree:CMLBCRABL1",
     "relation": "exactMatch"
   },
   {
     "id": 72,
-    "coding": "oncotree:CEAD",
+    "coding_id": "oncotree:CEAD",
     "relation": "exactMatch"
   },
   {
     "id": 73,
-    "coding": "oncotree:CESC",
+    "coding_id": "oncotree:CESC",
     "relation": "exactMatch"
   },
   {
     "id": 74,
-    "coding": "oncotree:ESCA",
+    "coding_id": "oncotree:ESCA",
     "relation": "exactMatch"
   },
   {
     "id": 75,
-    "coding": "oncotree:THPA",
+    "coding_id": "oncotree:THPA",
     "relation": "exactMatch"
   },
   {
     "id": 76,
-    "coding": "oncotree:NHL",
+    "coding_id": "oncotree:NHL",
     "relation": "exactMatch"
   },
   {
     "id": 77,
-    "coding": "oncotree:DLBCLNOS",
+    "coding_id": "oncotree:DLBCLNOS",
     "relation": "exactMatch"
   },
   {
     "id": 78,
-    "coding": "oncotree:BL",
+    "coding_id": "oncotree:BL",
     "relation": "exactMatch"
   },
   {
     "id": 79,
-    "coding": "oncotree:MBN",
+    "coding_id": "oncotree:MBN",
     "relation": "exactMatch"
   },
   {
     "id": 80,
-    "coding": "oncotree:HL",
+    "coding_id": "oncotree:HL",
     "relation": "exactMatch"
   },
   {
     "id": 81,
-    "coding": "oncotree:EGC",
+    "coding_id": "oncotree:EGC",
     "relation": "exactMatch"
   },
   {
     "id": 82,
-    "coding": "oncotree:ESCC",
+    "coding_id": "oncotree:ESCC",
     "relation": "exactMatch"
   },
   {
     "id": 83,
-    "coding": "oncotree:HGGNOS",
+    "coding_id": "oncotree:HGGNOS",
     "relation": "exactMatch"
   },
   {
     "id": 84,
-    "coding": "oncotree:CLLSLL",
+    "coding_id": "oncotree:CLLSLL",
     "relation": "broadMatch"
   },
   {
     "id": 85,
-    "coding": "oncotree:IPN",
+    "coding_id": "oncotree:IPN",
     "relation": "exactMatch"
   },
   {
     "id": 86,
-    "coding": "oncotree:ICPN",
+    "coding_id": "oncotree:ICPN",
     "relation": "exactMatch"
   },
   {
     "id": 87,
-    "coding": "oncotree:ALAL",
+    "coding_id": "oncotree:ALAL",
     "relation": "exactMatch"
   },
   {
     "id": 88,
-    "coding": "oncotree:RAML",
+    "coding_id": "oncotree:RAML",
     "relation": "exactMatch"
   },
   {
     "id": 89,
-    "coding": "hgnc:76",
+    "coding_id": "hgnc:76",
     "relation": "exactMatch"
   },
   {
     "id": 90,
-    "coding": "ensembl:ensg00000097007",
+    "coding_id": "ensembl:ensg00000097007",
     "relation": "exactMatch"
   },
   {
     "id": 91,
-    "coding": "ncbi:25",
+    "coding_id": "ncbi:25",
     "relation": "exactMatch"
   },
   {
     "id": 92,
-    "coding": "refseq:NM_005157.6",
+    "coding_id": "refseq:NM_005157.6",
     "relation": "relatedMatch"
   },
   {
     "id": 93,
-    "coding": "hgnc:391",
+    "coding_id": "hgnc:391",
     "relation": "exactMatch"
   },
   {
     "id": 94,
-    "coding": "ensembl:ensg00000142208",
+    "coding_id": "ensembl:ensg00000142208",
     "relation": "exactMatch"
   },
   {
     "id": 95,
-    "coding": "ncbi:207",
+    "coding_id": "ncbi:207",
     "relation": "exactMatch"
   },
   {
     "id": 96,
-    "coding": "refseq:NM_001382430.1",
+    "coding_id": "refseq:NM_001382430.1",
     "relation": "relatedMatch"
   },
   {
     "id": 97,
-    "coding": "hgnc:427",
+    "coding_id": "hgnc:427",
     "relation": "exactMatch"
   },
   {
     "id": 98,
-    "coding": "ensembl:ensg00000171094",
+    "coding_id": "ensembl:ensg00000171094",
     "relation": "exactMatch"
   },
   {
     "id": 99,
-    "coding": "ncbi:238",
+    "coding_id": "ncbi:238",
     "relation": "exactMatch"
   },
   {
     "id": 100,
-    "coding": "refseq:NM_004304.5",
+    "coding_id": "refseq:NM_004304.5",
     "relation": "relatedMatch"
   },
   {
     "id": 101,
-    "coding": "hgnc:795",
+    "coding_id": "hgnc:795",
     "relation": "exactMatch"
   },
   {
     "id": 102,
-    "coding": "ensembl:ensg00000149311",
+    "coding_id": "ensembl:ensg00000149311",
     "relation": "exactMatch"
   },
   {
     "id": 103,
-    "coding": "ncbi:472",
+    "coding_id": "ncbi:472",
     "relation": "exactMatch"
   },
   {
     "id": 104,
-    "coding": "refseq:NM_000051.4",
+    "coding_id": "refseq:NM_000051.4",
     "relation": "relatedMatch"
   },
   {
     "id": 105,
-    "coding": "hgnc:21649",
+    "coding_id": "hgnc:21649",
     "relation": "exactMatch"
   },
   {
     "id": 106,
-    "coding": "ensembl:ensg00000006453",
+    "coding_id": "ensembl:ensg00000006453",
     "relation": "exactMatch"
   },
   {
     "id": 107,
-    "coding": "ncbi:55971",
+    "coding_id": "ncbi:55971",
     "relation": "exactMatch"
   },
   {
     "id": 108,
-    "coding": "refseq:NM_018842.5",
+    "coding_id": "refseq:NM_018842.5",
     "relation": "relatedMatch"
   },
   {
     "id": 109,
-    "coding": "hgnc:952",
+    "coding_id": "hgnc:952",
     "relation": "exactMatch"
   },
   {
     "id": 110,
-    "coding": "ensembl:ensg00000138376",
+    "coding_id": "ensembl:ensg00000138376",
     "relation": "exactMatch"
   },
   {
     "id": 111,
-    "coding": "ncbi:580",
+    "coding_id": "ncbi:580",
     "relation": "exactMatch"
   },
   {
     "id": 112,
-    "coding": "refseq:NM_000465.4",
+    "coding_id": "refseq:NM_000465.4",
     "relation": "relatedMatch"
   },
   {
     "id": 113,
-    "coding": "hgnc:1014",
+    "coding_id": "hgnc:1014",
     "relation": "exactMatch"
   },
   {
     "id": 114,
-    "coding": "ensembl:ensg00000186716",
+    "coding_id": "ensembl:ensg00000186716",
     "relation": "exactMatch"
   },
   {
     "id": 115,
-    "coding": "ncbi:613",
+    "coding_id": "ncbi:613",
     "relation": "exactMatch"
   },
   {
     "id": 116,
-    "coding": "refseq:NM_004327.4",
+    "coding_id": "refseq:NM_004327.4",
     "relation": "relatedMatch"
   },
   {
     "id": 117,
-    "coding": "hgnc:19351",
+    "coding_id": "hgnc:19351",
     "relation": "exactMatch"
   },
   {
     "id": 118,
-    "coding": "ensembl:ensg00000122870",
+    "coding_id": "ensembl:ensg00000122870",
     "relation": "exactMatch"
   },
   {
     "id": 119,
-    "coding": "ncbi:80114",
+    "coding_id": "ncbi:80114",
     "relation": "exactMatch"
   },
   {
     "id": 120,
-    "coding": "refseq:NM_001080512.3",
+    "coding_id": "refseq:NM_001080512.3",
     "relation": "relatedMatch"
   },
   {
     "id": 121,
-    "coding": "hgnc:1097",
+    "coding_id": "hgnc:1097",
     "relation": "exactMatch"
   },
   {
     "id": 122,
-    "coding": "ensembl:ensg00000157764",
+    "coding_id": "ensembl:ensg00000157764",
     "relation": "exactMatch"
   },
   {
     "id": 123,
-    "coding": "ncbi:673",
+    "coding_id": "ncbi:673",
     "relation": "exactMatch"
   },
   {
     "id": 124,
-    "coding": "refseq:NM_004333.6",
+    "coding_id": "refseq:NM_004333.6",
     "relation": "relatedMatch"
   },
   {
     "id": 125,
-    "coding": "hgnc:1100",
+    "coding_id": "hgnc:1100",
     "relation": "exactMatch"
   },
   {
     "id": 126,
-    "coding": "ensembl:ensg00000012048",
+    "coding_id": "ensembl:ensg00000012048",
     "relation": "exactMatch"
   },
   {
     "id": 127,
-    "coding": "ncbi:672",
+    "coding_id": "ncbi:672",
     "relation": "exactMatch"
   },
   {
     "id": 128,
-    "coding": "refseq:NM_007294.4",
+    "coding_id": "refseq:NM_007294.4",
     "relation": "relatedMatch"
   },
   {
     "id": 129,
-    "coding": "hgnc:1101",
+    "coding_id": "hgnc:1101",
     "relation": "exactMatch"
   },
   {
     "id": 130,
-    "coding": "ensembl:ensg00000139618",
+    "coding_id": "ensembl:ensg00000139618",
     "relation": "exactMatch"
   },
   {
     "id": 131,
-    "coding": "ncbi:675",
+    "coding_id": "ncbi:675",
     "relation": "exactMatch"
   },
   {
     "id": 132,
-    "coding": "refseq:NM_000059.4",
+    "coding_id": "refseq:NM_000059.4",
     "relation": "relatedMatch"
   },
   {
     "id": 133,
-    "coding": "hgnc:20473",
+    "coding_id": "hgnc:20473",
     "relation": "exactMatch"
   },
   {
     "id": 134,
-    "coding": "ensembl:ensg00000136492",
+    "coding_id": "ensembl:ensg00000136492",
     "relation": "exactMatch"
   },
   {
     "id": 135,
-    "coding": "ncbi:83990",
+    "coding_id": "ncbi:83990",
     "relation": "exactMatch"
   },
   {
     "id": 136,
-    "coding": "refseq:NM_032043.3",
+    "coding_id": "refseq:NM_032043.3",
     "relation": "relatedMatch"
   },
   {
     "id": 137,
-    "coding": "hgnc:1508",
+    "coding_id": "hgnc:1508",
     "relation": "exactMatch"
   },
   {
     "id": 138,
-    "coding": "ensembl:ensg00000165806",
+    "coding_id": "ensembl:ensg00000165806",
     "relation": "exactMatch"
   },
   {
     "id": 139,
-    "coding": "ncbi:840",
+    "coding_id": "ncbi:840",
     "relation": "exactMatch"
   },
   {
     "id": 140,
-    "coding": "refseq:NM_001227.5",
+    "coding_id": "refseq:NM_001227.5",
     "relation": "relatedMatch"
   },
   {
     "id": 141,
-    "coding": "hgnc:17635",
+    "coding_id": "hgnc:17635",
     "relation": "exactMatch"
   },
   {
     "id": 142,
-    "coding": "ensembl:ensg00000120217",
+    "coding_id": "ensembl:ensg00000120217",
     "relation": "exactMatch"
   },
   {
     "id": 143,
-    "coding": "ncbi:29126",
+    "coding_id": "ncbi:29126",
     "relation": "exactMatch"
   },
   {
     "id": 144,
-    "coding": "refseq:NM_014143.4",
+    "coding_id": "refseq:NM_014143.4",
     "relation": "relatedMatch"
   },
   {
     "id": 145,
-    "coding": "hgnc:24224",
+    "coding_id": "hgnc:24224",
     "relation": "exactMatch"
   },
   {
     "id": 146,
-    "coding": "ensembl:ensg00000167258",
+    "coding_id": "ensembl:ensg00000167258",
     "relation": "exactMatch"
   },
   {
     "id": 147,
-    "coding": "ncbi:51755",
+    "coding_id": "ncbi:51755",
     "relation": "exactMatch"
   },
   {
     "id": 148,
-    "coding": "refseq:NM_016507.4",
+    "coding_id": "refseq:NM_016507.4",
     "relation": "relatedMatch"
   },
   {
     "id": 149,
-    "coding": "hgnc:1925",
+    "coding_id": "hgnc:1925",
     "relation": "exactMatch"
   },
   {
     "id": 150,
-    "coding": "ensembl:ensg00000149554",
+    "coding_id": "ensembl:ensg00000149554",
     "relation": "exactMatch"
   },
   {
     "id": 151,
-    "coding": "ncbi:1111",
+    "coding_id": "ncbi:1111",
     "relation": "exactMatch"
   },
   {
     "id": 152,
-    "coding": "refseq:NM_001114122.3",
+    "coding_id": "refseq:NM_001114122.3",
     "relation": "relatedMatch"
   },
   {
     "id": 153,
-    "coding": "hgnc:16627",
+    "coding_id": "hgnc:16627",
     "relation": "exactMatch"
   },
   {
     "id": 154,
-    "coding": "ensembl:ensg00000183765",
+    "coding_id": "ensembl:ensg00000183765",
     "relation": "exactMatch"
   },
   {
     "id": 155,
-    "coding": "ncbi:11200",
+    "coding_id": "ncbi:11200",
     "relation": "exactMatch"
   },
   {
     "id": 156,
-    "coding": "refseq:NM_007194.4",
+    "coding_id": "refseq:NM_007194.4",
     "relation": "relatedMatch"
   },
   {
     "id": 157,
-    "coding": "hgnc:3236",
+    "coding_id": "hgnc:3236",
     "relation": "exactMatch"
   },
   {
     "id": 158,
-    "coding": "ensembl:ensg00000146648",
+    "coding_id": "ensembl:ensg00000146648",
     "relation": "exactMatch"
   },
   {
     "id": 159,
-    "coding": "ncbi:1956",
+    "coding_id": "ncbi:1956",
     "relation": "exactMatch"
   },
   {
     "id": 160,
-    "coding": "refseq:NM_005228.5",
+    "coding_id": "refseq:NM_005228.5",
     "relation": "relatedMatch"
   },
   {
     "id": 161,
-    "coding": "hgnc:3430",
+    "coding_id": "hgnc:3430",
     "relation": "exactMatch"
   },
   {
     "id": 162,
-    "coding": "ensembl:ensg00000141736",
+    "coding_id": "ensembl:ensg00000141736",
     "relation": "exactMatch"
   },
   {
     "id": 163,
-    "coding": "ncbi:2064",
+    "coding_id": "ncbi:2064",
     "relation": "exactMatch"
   },
   {
     "id": 164,
-    "coding": "refseq:NM_004448.4",
+    "coding_id": "refseq:NM_004448.4",
     "relation": "relatedMatch"
   },
   {
     "id": 165,
-    "coding": "hgnc:3467",
+    "coding_id": "hgnc:3467",
     "relation": "exactMatch"
   },
   {
     "id": 166,
-    "coding": "ensembl:ensg00000091831",
+    "coding_id": "ensembl:ensg00000091831",
     "relation": "exactMatch"
   },
   {
     "id": 167,
-    "coding": "ncbi:2099",
+    "coding_id": "ncbi:2099",
     "relation": "exactMatch"
   },
   {
     "id": 168,
-    "coding": "refseq:NM_000125.4",
+    "coding_id": "refseq:NM_000125.4",
     "relation": "relatedMatch"
   },
   {
     "id": 169,
-    "coding": "hgnc:3527",
+    "coding_id": "hgnc:3527",
     "relation": "exactMatch"
   },
   {
     "id": 170,
-    "coding": "ensembl:ensg00000106462",
+    "coding_id": "ensembl:ensg00000106462",
     "relation": "exactMatch"
   },
   {
     "id": 171,
-    "coding": "ncbi:2146",
+    "coding_id": "ncbi:2146",
     "relation": "exactMatch"
   },
   {
     "id": 172,
-    "coding": "refseq:NM_004456.5",
+    "coding_id": "refseq:NM_004456.5",
     "relation": "relatedMatch"
   },
   {
     "id": 173,
-    "coding": "hgnc:20748",
+    "coding_id": "hgnc:20748",
     "relation": "exactMatch"
   },
   {
     "id": 174,
-    "coding": "ensembl:ensg00000115392",
+    "coding_id": "ensembl:ensg00000115392",
     "relation": "exactMatch"
   },
   {
     "id": 175,
-    "coding": "ncbi:55120",
+    "coding_id": "ncbi:55120",
     "relation": "exactMatch"
   },
   {
     "id": 176,
-    "coding": "refseq:NM_018062.4",
+    "coding_id": "refseq:NM_018062.4",
     "relation": "relatedMatch"
   },
   {
     "id": 177,
-    "coding": "hgnc:3688",
+    "coding_id": "hgnc:3688",
     "relation": "exactMatch"
   },
   {
     "id": 178,
-    "coding": "ensembl:ensg00000077782",
+    "coding_id": "ensembl:ensg00000077782",
     "relation": "exactMatch"
   },
   {
     "id": 179,
-    "coding": "ncbi:2260",
+    "coding_id": "ncbi:2260",
     "relation": "exactMatch"
   },
   {
     "id": 180,
-    "coding": "refseq:NM_023110.3",
+    "coding_id": "refseq:NM_023110.3",
     "relation": "relatedMatch"
   },
   {
     "id": 181,
-    "coding": "hgnc:3689",
+    "coding_id": "hgnc:3689",
     "relation": "exactMatch"
   },
   {
     "id": 182,
-    "coding": "ensembl:ensg00000066468",
+    "coding_id": "ensembl:ensg00000066468",
     "relation": "exactMatch"
   },
   {
     "id": 183,
-    "coding": "ncbi:2263",
+    "coding_id": "ncbi:2263",
     "relation": "exactMatch"
   },
   {
     "id": 184,
-    "coding": "refseq:NM_000141.5",
+    "coding_id": "refseq:NM_000141.5",
     "relation": "relatedMatch"
   },
   {
     "id": 185,
-    "coding": "hgnc:3690",
+    "coding_id": "hgnc:3690",
     "relation": "exactMatch"
   },
   {
     "id": 186,
-    "coding": "ensembl:ensg00000068078",
+    "coding_id": "ensembl:ensg00000068078",
     "relation": "exactMatch"
   },
   {
     "id": 187,
-    "coding": "ncbi:2261",
+    "coding_id": "ncbi:2261",
     "relation": "exactMatch"
   },
   {
     "id": 188,
-    "coding": "refseq:NM_000142.5",
+    "coding_id": "refseq:NM_000142.5",
     "relation": "relatedMatch"
   },
   {
     "id": 189,
-    "coding": "hgnc:19124",
+    "coding_id": "hgnc:19124",
     "relation": "exactMatch"
   },
   {
     "id": 190,
-    "coding": "ensembl:ensg00000145216",
+    "coding_id": "ensembl:ensg00000145216",
     "relation": "exactMatch"
   },
   {
     "id": 191,
-    "coding": "ncbi:81608",
+    "coding_id": "ncbi:81608",
     "relation": "exactMatch"
   },
   {
     "id": 192,
-    "coding": "refseq:NM_030917.4",
+    "coding_id": "refseq:NM_030917.4",
     "relation": "relatedMatch"
   },
   {
     "id": 193,
-    "coding": "hgnc:3765",
+    "coding_id": "hgnc:3765",
     "relation": "exactMatch"
   },
   {
     "id": 194,
-    "coding": "ensembl:ensg00000122025",
+    "coding_id": "ensembl:ensg00000122025",
     "relation": "exactMatch"
   },
   {
     "id": 195,
-    "coding": "ncbi:2322",
+    "coding_id": "ncbi:2322",
     "relation": "exactMatch"
   },
   {
     "id": 196,
-    "coding": "refseq:NM_004119.3",
+    "coding_id": "refseq:NM_004119.3",
     "relation": "relatedMatch"
   },
   {
     "id": 197,
-    "coding": "hgnc:5173",
+    "coding_id": "hgnc:5173",
     "relation": "exactMatch"
   },
   {
     "id": 198,
-    "coding": "ensembl:ensg00000174775",
+    "coding_id": "ensembl:ensg00000174775",
     "relation": "exactMatch"
   },
   {
     "id": 199,
-    "coding": "ncbi:3265",
+    "coding_id": "ncbi:3265",
     "relation": "exactMatch"
   },
   {
     "id": 200,
-    "coding": "refseq:NM_005343.4",
+    "coding_id": "refseq:NM_005343.4",
     "relation": "relatedMatch"
   },
   {
     "id": 201,
-    "coding": "hgnc:5382",
+    "coding_id": "hgnc:5382",
     "relation": "exactMatch"
   },
   {
     "id": 202,
-    "coding": "ensembl:ensg00000138413",
+    "coding_id": "ensembl:ensg00000138413",
     "relation": "exactMatch"
   },
   {
     "id": 203,
-    "coding": "ncbi:3417",
+    "coding_id": "ncbi:3417",
     "relation": "exactMatch"
   },
   {
     "id": 204,
-    "coding": "refseq:NM_005896.4",
+    "coding_id": "refseq:NM_005896.4",
     "relation": "relatedMatch"
   },
   {
     "id": 205,
-    "coding": "hgnc:5383",
+    "coding_id": "hgnc:5383",
     "relation": "exactMatch"
   },
   {
     "id": 206,
-    "coding": "ensembl:ensg00000182054",
+    "coding_id": "ensembl:ensg00000182054",
     "relation": "exactMatch"
   },
   {
     "id": 207,
-    "coding": "ncbi:3418",
+    "coding_id": "ncbi:3418",
     "relation": "exactMatch"
   },
   {
     "id": 208,
-    "coding": "refseq:NM_002168.4",
+    "coding_id": "refseq:NM_002168.4",
     "relation": "relatedMatch"
   },
   {
     "id": 209,
-    "coding": "hgnc:6342",
+    "coding_id": "hgnc:6342",
     "relation": "exactMatch"
   },
   {
     "id": 210,
-    "coding": "ensembl:ensg00000157404",
+    "coding_id": "ensembl:ensg00000157404",
     "relation": "exactMatch"
   },
   {
     "id": 211,
-    "coding": "ncbi:3815",
+    "coding_id": "ncbi:3815",
     "relation": "exactMatch"
   },
   {
     "id": 212,
-    "coding": "refseq:NM_000222.3",
+    "coding_id": "refseq:NM_000222.3",
     "relation": "relatedMatch"
   },
   {
     "id": 213,
-    "coding": "hgnc:6407",
+    "coding_id": "hgnc:6407",
     "relation": "exactMatch"
   },
   {
     "id": 214,
-    "coding": "ensembl:ensg00000133703",
+    "coding_id": "ensembl:ensg00000133703",
     "relation": "exactMatch"
   },
   {
     "id": 215,
-    "coding": "ncbi:3845",
+    "coding_id": "ncbi:3845",
     "relation": "exactMatch"
   },
   {
     "id": 216,
-    "coding": "refseq:NM_004985.5",
+    "coding_id": "refseq:NM_004985.5",
     "relation": "relatedMatch"
   },
   {
     "id": 217,
-    "coding": "hgnc:7029",
+    "coding_id": "hgnc:7029",
     "relation": "exactMatch"
   },
   {
     "id": 218,
-    "coding": "ensembl:ensg00000105976",
+    "coding_id": "ensembl:ensg00000105976",
     "relation": "exactMatch"
   },
   {
     "id": 219,
-    "coding": "ncbi:4233",
+    "coding_id": "ncbi:4233",
     "relation": "exactMatch"
   },
   {
     "id": 220,
-    "coding": "refseq:NM_000245.4",
+    "coding_id": "refseq:NM_000245.4",
     "relation": "relatedMatch"
   },
   {
     "id": 221,
-    "coding": "hgnc:7989",
+    "coding_id": "hgnc:7989",
     "relation": "exactMatch"
   },
   {
     "id": 222,
-    "coding": "ensembl:ensg00000213281",
+    "coding_id": "ensembl:ensg00000213281",
     "relation": "exactMatch"
   },
   {
     "id": 223,
-    "coding": "ncbi:4893",
+    "coding_id": "ncbi:4893",
     "relation": "exactMatch"
   },
   {
     "id": 224,
-    "coding": "refseq:NM_002524.5",
+    "coding_id": "refseq:NM_002524.5",
     "relation": "relatedMatch"
   },
   {
     "id": 225,
-    "coding": "hgnc:7997",
+    "coding_id": "hgnc:7997",
     "relation": "exactMatch"
   },
   {
     "id": 226,
-    "coding": "ensembl:ensg00000157168",
+    "coding_id": "ensembl:ensg00000157168",
     "relation": "exactMatch"
   },
   {
     "id": 227,
-    "coding": "ncbi:3084",
+    "coding_id": "ncbi:3084",
     "relation": "exactMatch"
   },
   {
     "id": 228,
-    "coding": "refseq:NM_013964.5",
+    "coding_id": "refseq:NM_013964.5",
     "relation": "relatedMatch"
   },
   {
     "id": 229,
-    "coding": "hgnc:8031",
+    "coding_id": "hgnc:8031",
     "relation": "exactMatch"
   },
   {
     "id": 230,
-    "coding": "ensembl:ensg00000198400",
+    "coding_id": "ensembl:ensg00000198400",
     "relation": "exactMatch"
   },
   {
     "id": 231,
-    "coding": "ncbi:4914",
+    "coding_id": "ncbi:4914",
     "relation": "exactMatch"
   },
   {
     "id": 232,
-    "coding": "refseq:NM_002529.4",
+    "coding_id": "refseq:NM_002529.4",
     "relation": "relatedMatch"
   },
   {
     "id": 233,
-    "coding": "hgnc:8032",
+    "coding_id": "hgnc:8032",
     "relation": "exactMatch"
   },
   {
     "id": 234,
-    "coding": "ensembl:ensg00000148053",
+    "coding_id": "ensembl:ensg00000148053",
     "relation": "exactMatch"
   },
   {
     "id": 235,
-    "coding": "ncbi:4915",
+    "coding_id": "ncbi:4915",
     "relation": "exactMatch"
   },
   {
     "id": 236,
-    "coding": "refseq:NM_006180.6",
+    "coding_id": "refseq:NM_006180.6",
     "relation": "relatedMatch"
   },
   {
     "id": 237,
-    "coding": "hgnc:8033",
+    "coding_id": "hgnc:8033",
     "relation": "exactMatch"
   },
   {
     "id": 238,
-    "coding": "ensembl:ensg00000140538",
+    "coding_id": "ensembl:ensg00000140538",
     "relation": "exactMatch"
   },
   {
     "id": 239,
-    "coding": "ncbi:4916",
+    "coding_id": "ncbi:4916",
     "relation": "exactMatch"
   },
   {
     "id": 240,
-    "coding": "refseq:NM_001012338.3",
+    "coding_id": "refseq:NM_001012338.3",
     "relation": "relatedMatch"
   },
   {
     "id": 241,
-    "coding": "hgnc:26144",
+    "coding_id": "hgnc:26144",
     "relation": "exactMatch"
   },
   {
     "id": 242,
-    "coding": "ensembl:ensg00000083093",
+    "coding_id": "ensembl:ensg00000083093",
     "relation": "exactMatch"
   },
   {
     "id": 243,
-    "coding": "ncbi:79728",
+    "coding_id": "ncbi:79728",
     "relation": "exactMatch"
   },
   {
     "id": 244,
-    "coding": "refseq:NM_024675.4",
+    "coding_id": "refseq:NM_024675.4",
     "relation": "relatedMatch"
   },
   {
     "id": 245,
-    "coding": "hgnc:8803",
+    "coding_id": "hgnc:8803",
     "relation": "exactMatch"
   },
   {
     "id": 246,
-    "coding": "ensembl:ensg00000134853",
+    "coding_id": "ensembl:ensg00000134853",
     "relation": "exactMatch"
   },
   {
     "id": 247,
-    "coding": "ncbi:5156",
+    "coding_id": "ncbi:5156",
     "relation": "exactMatch"
   },
   {
     "id": 248,
-    "coding": "refseq:NM_006206.6",
+    "coding_id": "refseq:NM_006206.6",
     "relation": "relatedMatch"
   },
   {
     "id": 249,
-    "coding": "hgnc:8804",
+    "coding_id": "hgnc:8804",
     "relation": "exactMatch"
   },
   {
     "id": 250,
-    "coding": "ensembl:ensg00000113721",
+    "coding_id": "ensembl:ensg00000113721",
     "relation": "exactMatch"
   },
   {
     "id": 251,
-    "coding": "ncbi:5159",
+    "coding_id": "ncbi:5159",
     "relation": "exactMatch"
   },
   {
     "id": 252,
-    "coding": "refseq:NM_002609.4",
+    "coding_id": "refseq:NM_002609.4",
     "relation": "relatedMatch"
   },
   {
     "id": 253,
-    "coding": "hgnc:8975",
+    "coding_id": "hgnc:8975",
     "relation": "exactMatch"
   },
   {
     "id": 254,
-    "coding": "ensembl:ensg00000121879",
+    "coding_id": "ensembl:ensg00000121879",
     "relation": "exactMatch"
   },
   {
     "id": 255,
-    "coding": "ncbi:5290",
+    "coding_id": "ncbi:5290",
     "relation": "exactMatch"
   },
   {
     "id": 256,
-    "coding": "refseq:NM_006218.4",
+    "coding_id": "refseq:NM_006218.4",
     "relation": "relatedMatch"
   },
   {
     "id": 257,
-    "coding": "hgnc:9113",
+    "coding_id": "hgnc:9113",
     "relation": "exactMatch"
   },
   {
     "id": 258,
-    "coding": "ensembl:ensg00000140464",
+    "coding_id": "ensembl:ensg00000140464",
     "relation": "exactMatch"
   },
   {
     "id": 259,
-    "coding": "ncbi:5371",
+    "coding_id": "ncbi:5371",
     "relation": "exactMatch"
   },
   {
     "id": 260,
-    "coding": "refseq:NM_033238.3",
+    "coding_id": "refseq:NM_033238.3",
     "relation": "relatedMatch"
   },
   {
     "id": 261,
-    "coding": "hgnc:9588",
+    "coding_id": "hgnc:9588",
     "relation": "exactMatch"
   },
   {
     "id": 262,
-    "coding": "ensembl:ensg00000171862",
+    "coding_id": "ensembl:ensg00000171862",
     "relation": "exactMatch"
   },
   {
     "id": 263,
-    "coding": "ncbi:5728",
+    "coding_id": "ncbi:5728",
     "relation": "exactMatch"
   },
   {
     "id": 264,
-    "coding": "refseq:NM_000314.8",
+    "coding_id": "refseq:NM_000314.8",
     "relation": "relatedMatch"
   },
   {
     "id": 265,
-    "coding": "hgnc:9822",
+    "coding_id": "hgnc:9822",
     "relation": "exactMatch"
   },
   {
     "id": 266,
-    "coding": "ensembl:ensg00000182185",
+    "coding_id": "ensembl:ensg00000182185",
     "relation": "exactMatch"
   },
   {
     "id": 267,
-    "coding": "ncbi:5890",
+    "coding_id": "ncbi:5890",
     "relation": "exactMatch"
   },
   {
     "id": 268,
-    "coding": "refseq:NM_133510.4",
+    "coding_id": "refseq:NM_133510.4",
     "relation": "relatedMatch"
   },
   {
     "id": 269,
-    "coding": "hgnc:9820",
+    "coding_id": "hgnc:9820",
     "relation": "exactMatch"
   },
   {
     "id": 270,
-    "coding": "ensembl:ensg00000108384",
+    "coding_id": "ensembl:ensg00000108384",
     "relation": "exactMatch"
   },
   {
     "id": 271,
-    "coding": "ncbi:5889",
+    "coding_id": "ncbi:5889",
     "relation": "exactMatch"
   },
   {
     "id": 272,
-    "coding": "refseq:NM_058216.3",
+    "coding_id": "refseq:NM_058216.3",
     "relation": "relatedMatch"
   },
   {
     "id": 273,
-    "coding": "hgnc:9823",
+    "coding_id": "hgnc:9823",
     "relation": "exactMatch"
   },
   {
     "id": 274,
-    "coding": "ensembl:ensg00000185379",
+    "coding_id": "ensembl:ensg00000185379",
     "relation": "exactMatch"
   },
   {
     "id": 275,
-    "coding": "ncbi:5892",
+    "coding_id": "ncbi:5892",
     "relation": "exactMatch"
   },
   {
     "id": 276,
-    "coding": "refseq:NM_002878.4",
+    "coding_id": "refseq:NM_002878.4",
     "relation": "relatedMatch"
   },
   {
     "id": 277,
-    "coding": "hgnc:9826",
+    "coding_id": "hgnc:9826",
     "relation": "exactMatch"
   },
   {
     "id": 278,
-    "coding": "ensembl:ensg00000085999",
+    "coding_id": "ensembl:ensg00000085999",
     "relation": "exactMatch"
   },
   {
     "id": 279,
-    "coding": "ncbi:8438",
+    "coding_id": "ncbi:8438",
     "relation": "exactMatch"
   },
   {
     "id": 280,
-    "coding": "refseq:NM_003579.4",
+    "coding_id": "refseq:NM_003579.4",
     "relation": "relatedMatch"
   },
   {
     "id": 281,
-    "coding": "hgnc:9864",
+    "coding_id": "hgnc:9864",
     "relation": "exactMatch"
   },
   {
     "id": 282,
-    "coding": "ensembl:ensg00000131759",
+    "coding_id": "ensembl:ensg00000131759",
     "relation": "exactMatch"
   },
   {
     "id": 283,
-    "coding": "ncbi:5914",
+    "coding_id": "ncbi:5914",
     "relation": "exactMatch"
   },
   {
     "id": 284,
-    "coding": "refseq:NM_000964.4",
+    "coding_id": "refseq:NM_000964.4",
     "relation": "relatedMatch"
   },
   {
     "id": 285,
-    "coding": "hgnc:9967",
+    "coding_id": "hgnc:9967",
     "relation": "exactMatch"
   },
   {
     "id": 286,
-    "coding": "ensembl:ensg00000165731",
+    "coding_id": "ensembl:ensg00000165731",
     "relation": "exactMatch"
   },
   {
     "id": 287,
-    "coding": "ncbi:5979",
+    "coding_id": "ncbi:5979",
     "relation": "exactMatch"
   },
   {
     "id": 288,
-    "coding": "refseq:NM_020975.6",
+    "coding_id": "refseq:NM_020975.6",
     "relation": "relatedMatch"
   },
   {
     "id": 289,
-    "coding": "hgnc:10261",
+    "coding_id": "hgnc:10261",
     "relation": "exactMatch"
   },
   {
     "id": 290,
-    "coding": "ensembl:ensg00000047936",
+    "coding_id": "ensembl:ensg00000047936",
     "relation": "exactMatch"
   },
   {
     "id": 291,
-    "coding": "ncbi:6098",
+    "coding_id": "ncbi:6098",
     "relation": "exactMatch"
   },
   {
     "id": 292,
-    "coding": "refseq:NM_001378902.1",
+    "coding_id": "refseq:NM_001378902.1",
     "relation": "relatedMatch"
   },
   {
     "id": 293,
-    "coding": "hgnc:11524",
+    "coding_id": "hgnc:11524",
     "relation": "exactMatch"
   },
   {
     "id": 294,
-    "coding": "ensembl:ensg00000013810",
+    "coding_id": "ensembl:ensg00000013810",
     "relation": "exactMatch"
   },
   {
     "id": 295,
-    "coding": "ncbi:10460",
+    "coding_id": "ncbi:10460",
     "relation": "exactMatch"
   },
   {
     "id": 296,
-    "coding": "refseq:NM_006342.3",
+    "coding_id": "refseq:NM_006342.3",
     "relation": "relatedMatch"
   },
   {
     "id": 297,
-    "coding": "hgnc:11998",
+    "coding_id": "hgnc:11998",
     "relation": "exactMatch"
   },
   {
     "id": 298,
-    "coding": "ensembl:ensg00000141510",
+    "coding_id": "ensembl:ensg00000141510",
     "relation": "exactMatch"
   },
   {
     "id": 299,
-    "coding": "ncbi:7157",
+    "coding_id": "ncbi:7157",
     "relation": "exactMatch"
   },
   {
     "id": 300,
-    "coding": "refseq:NM_000546.6",
+    "coding_id": "refseq:NM_000546.6",
     "relation": "relatedMatch"
   },
   {
     "id": 301,
-    "coding": "hgnc:7131",
+    "coding_id": "hgnc:7131",
     "relation": "exactMatch"
   },
   {
     "id": 302,
-    "coding": "ensembl:ensg00000118058",
+    "coding_id": "ensembl:ensg00000118058",
     "relation": "exactMatch"
   },
   {
     "id": 303,
-    "coding": "ncbi:4297",
+    "coding_id": "ncbi:4297",
     "relation": "exactMatch"
   },
   {
     "id": 304,
-    "coding": "hgnc:12362",
+    "coding_id": "hgnc:12362",
     "relation": "exactMatch"
   },
   {
     "id": 305,
-    "coding": "ensembl:ENSG00000165699",
+    "coding_id": "ensembl:ENSG00000165699",
     "relation": "exactMatch"
   },
   {
     "id": 306,
-    "coding": "ncbi:7248",
+    "coding_id": "ncbi:7248",
     "relation": "exactMatch"
   },
   {
     "id": 307,
-    "coding": "hgnc:12363",
+    "coding_id": "hgnc:12363",
     "relation": "exactMatch"
   },
   {
     "id": 308,
-    "coding": "ensembl:ENSG00000103197",
+    "coding_id": "ensembl:ENSG00000103197",
     "relation": "exactMatch"
   },
   {
     "id": 309,
-    "coding": "ncbi:7249",
+    "coding_id": "ncbi:7249",
     "relation": "exactMatch"
   },
   {
     "id": 310,
-    "coding": "hgnc:882",
+    "coding_id": "hgnc:882",
     "relation": "exactMatch"
   },
   {
     "id": 311,
-    "coding": "ensembl:ENSG00000175054",
+    "coding_id": "ensembl:ENSG00000175054",
     "relation": "exactMatch"
   },
   {
     "id": 312,
-    "coding": "ncbi:545",
+    "coding_id": "ncbi:545",
     "relation": "exactMatch"
   },
   {
     "id": 313,
-    "coding": "hgnc:3582",
+    "coding_id": "hgnc:3582",
     "relation": "exactMatch"
   },
   {
     "id": 314,
-    "coding": "ensembl:ENSG00000187741",
+    "coding_id": "ensembl:ENSG00000187741",
     "relation": "exactMatch"
   },
   {
     "id": 315,
-    "coding": "ncbi:2175",
+    "coding_id": "ncbi:2175",
     "relation": "exactMatch"
   },
   {
     "id": 316,
-    "coding": "hgnc:7127",
+    "coding_id": "hgnc:7127",
     "relation": "exactMatch"
   },
   {
     "id": 317,
-    "coding": "ensembl:ENSG00000076242",
+    "coding_id": "ensembl:ENSG00000076242",
     "relation": "exactMatch"
   },
   {
     "id": 318,
-    "coding": "ncbi:4292",
+    "coding_id": "ncbi:4292",
     "relation": "exactMatch"
   },
   {
     "id": 319,
-    "coding": "hgnc:7230",
+    "coding_id": "hgnc:7230",
     "relation": "exactMatch"
   },
   {
     "id": 320,
-    "coding": "ensembl:ENSG00000020922",
+    "coding_id": "ensembl:ENSG00000020922",
     "relation": "exactMatch"
   },
   {
     "id": 321,
-    "coding": "ncbi:4361",
+    "coding_id": "ncbi:4361",
     "relation": "exactMatch"
   },
   {
     "id": 322,
-    "coding": "hgnc:7652",
+    "coding_id": "hgnc:7652",
     "relation": "exactMatch"
   },
   {
     "id": 323,
-    "coding": "ensembl:ENSG00000104320",
+    "coding_id": "ensembl:ENSG00000104320",
     "relation": "exactMatch"
   },
   {
     "id": 324,
-    "coding": "ncbi:4683",
+    "coding_id": "ncbi:4683",
     "relation": "exactMatch"
   },
   {
     "id": 325,
-    "coding": "ncit:C25425",
+    "coding_id": "ncit:C25425",
     "relation": "exactMatch"
   },
   {
     "id": 326,
-    "coding": "ncit:C66944",
+    "coding_id": "ncit:C66944",
     "relation": "exactMatch"
   },
   {
     "id": 327,
-    "coding": "ncit:C411",
+    "coding_id": "ncit:C411",
     "relation": "exactMatch"
   },
   {
     "id": 328,
-    "coding": "ncit:C456",
+    "coding_id": "ncit:C456",
     "relation": "exactMatch"
   },
   {
     "id": 329,
-    "coding": "ncit:",
+    "coding_id": "ncit:",
     "relation": "exactMatch"
   },
   {
     "id": 330,
-    "coding": "ncit:C48387",
+    "coding_id": "ncit:C48387",
     "relation": "exactMatch"
   },
   {
     "id": 331,
-    "coding": "ncit:C1097",
+    "coding_id": "ncit:C1097",
     "relation": "exactMatch"
   },
   {
     "id": 332,
-    "coding": "ncit:C80059",
+    "coding_id": "ncit:C80059",
     "relation": "exactMatch"
   },
   {
     "id": 333,
-    "coding": "ncit:C68845",
+    "coding_id": "ncit:C68845",
     "relation": "exactMatch"
   },
   {
     "id": 334,
-    "coding": "ncit:C769",
+    "coding_id": "ncit:C769",
     "relation": "exactMatch"
   },
   {
     "id": 335,
-    "coding": "ncit:C101790",
+    "coding_id": "ncit:C101790",
     "relation": "exactMatch"
   },
   {
     "id": 336,
-    "coding": "ncit:C98831",
+    "coding_id": "ncit:C98831",
     "relation": "exactMatch"
   },
   {
     "id": 337,
-    "coding": "ncit:C2039",
+    "coding_id": "ncit:C2039",
     "relation": "exactMatch"
   },
   {
     "id": 338,
-    "coding": "ncit:C65530",
+    "coding_id": "ncit:C65530",
     "relation": "exactMatch"
   },
   {
     "id": 339,
-    "coding": "ncit:C123827",
+    "coding_id": "ncit:C123827",
     "relation": "exactMatch"
   },
   {
     "id": 340,
-    "coding": "ncit:C71542",
+    "coding_id": "ncit:C71542",
     "relation": "exactMatch"
   },
   {
     "id": 341,
-    "coding": "ncit:C62528",
+    "coding_id": "ncit:C62528",
     "relation": "exactMatch"
   },
   {
     "id": 342,
-    "coding": "ncit:C60809",
+    "coding_id": "ncit:C60809",
     "relation": "exactMatch"
   },
   {
     "id": 343,
-    "coding": "ncit:C84865",
+    "coding_id": "ncit:C84865",
     "relation": "exactMatch"
   },
   {
     "id": 344,
-    "coding": "ncit:C98283",
+    "coding_id": "ncit:C98283",
     "relation": "exactMatch"
   },
   {
     "id": 345,
-    "coding": "ncit:C1723",
+    "coding_id": "ncit:C1723",
     "relation": "exactMatch"
   },
   {
     "id": 346,
-    "coding": "ncit:C2737",
+    "coding_id": "ncit:C2737",
     "relation": "exactMatch"
   },
   {
     "id": 347,
-    "coding": "ncit:C68923",
+    "coding_id": "ncit:C68923",
     "relation": "exactMatch"
   },
   {
     "id": 348,
-    "coding": "ncit:C64768",
+    "coding_id": "ncit:C64768",
     "relation": "exactMatch"
   },
   {
     "id": 349,
-    "coding": "ncit:C70792",
+    "coding_id": "ncit:C70792",
     "relation": "exactMatch"
   },
   {
     "id": 350,
-    "coding": "ncit:C1526",
+    "coding_id": "ncit:C1526",
     "relation": "exactMatch"
   },
   {
     "id": 351,
-    "coding": "ncit:C1647",
+    "coding_id": "ncit:C1647",
     "relation": "exactMatch"
   },
   {
     "id": 352,
-    "coding": "ncit:C128799",
+    "coding_id": "ncit:C128799",
     "relation": "exactMatch"
   },
   {
     "id": 353,
-    "coding": "ncit:C62040",
+    "coding_id": "ncit:C62040",
     "relation": "exactMatch"
   },
   {
     "id": 354,
-    "coding": "ncit:C1181",
+    "coding_id": "ncit:C1181",
     "relation": "exactMatch"
   },
   {
     "id": 355,
-    "coding": "ncit:C505",
+    "coding_id": "ncit:C505",
     "relation": "exactMatch"
   },
   {
     "id": 356,
-    "coding": "ncit:C1379",
+    "coding_id": "ncit:C1379",
     "relation": "exactMatch"
   },
   {
     "id": 357,
-    "coding": "ncit:C49176",
+    "coding_id": "ncit:C49176",
     "relation": "exactMatch"
   },
   {
     "id": 358,
-    "coding": "ncit:C132295",
+    "coding_id": "ncit:C132295",
     "relation": "exactMatch"
   },
   {
     "id": 359,
-    "coding": "ncit:C1855",
+    "coding_id": "ncit:C1855",
     "relation": "exactMatch"
   },
   {
     "id": 360,
-    "coding": "ncit:C66940",
+    "coding_id": "ncit:C66940",
     "relation": "exactMatch"
   },
   {
     "id": 361,
-    "coding": "ncit:C1411",
+    "coding_id": "ncit:C1411",
     "relation": "exactMatch"
   },
   {
     "id": 362,
-    "coding": "ncit:C1607",
+    "coding_id": "ncit:C1607",
     "relation": "exactMatch"
   },
   {
     "id": 363,
-    "coding": "ncit:C1282",
+    "coding_id": "ncit:C1282",
     "relation": "exactMatch"
   },
   {
     "id": 364,
-    "coding": "ncit:C1794",
+    "coding_id": "ncit:C1794",
     "relation": "exactMatch"
   },
   {
     "id": 365,
-    "coding": "ncit:C376",
+    "coding_id": "ncit:C376",
     "relation": "exactMatch"
   },
   {
     "id": 366,
-    "coding": "ncit:C1527",
+    "coding_id": "ncit:C1527",
     "relation": "exactMatch"
   },
   {
     "id": 367,
-    "coding": "ncit:C62035",
+    "coding_id": "ncit:C62035",
     "relation": "exactMatch"
   },
   {
     "id": 368,
-    "coding": "ncit:",
+    "coding_id": "ncit:",
     "relation": "exactMatch"
   },
   {
     "id": 369,
-    "coding": "ncit:C95777",
+    "coding_id": "ncit:C95777",
     "relation": "exactMatch"
   },
   {
     "id": 370,
-    "coding": "ncit:C103194",
+    "coding_id": "ncit:C103194",
     "relation": "exactMatch"
   },
   {
     "id": 371,
-    "coding": "ncit:C49085",
+    "coding_id": "ncit:C49085",
     "relation": "exactMatch"
   },
   {
     "id": 372,
-    "coding": "ncit:C71721",
+    "coding_id": "ncit:C71721",
     "relation": "exactMatch"
   },
   {
     "id": 373,
-    "coding": "ncit:C126799",
+    "coding_id": "ncit:C126799",
     "relation": "exactMatch"
   },
   {
     "id": 374,
-    "coding": "ncit:C106432",
+    "coding_id": "ncit:C106432",
     "relation": "exactMatch"
   },
   {
     "id": 375,
-    "coding": "ncit:C61614",
+    "coding_id": "ncit:C61614",
     "relation": "exactMatch"
   },
   {
     "id": 376,
-    "coding": "ncit:C66876",
+    "coding_id": "ncit:C66876",
     "relation": "exactMatch"
   },
   {
     "id": 377,
-    "coding": "ncit:C2688",
+    "coding_id": "ncit:C2688",
     "relation": "exactMatch"
   },
   {
     "id": 378,
-    "coding": "ncit:C82492",
+    "coding_id": "ncit:C82492",
     "relation": "exactMatch"
   },
   {
     "id": 379,
-    "coding": "ncit:C95701",
+    "coding_id": "ncit:C95701",
     "relation": "exactMatch"
   },
   {
     "id": 380,
-    "coding": "ncit:C157493",
+    "coding_id": "ncit:C157493",
     "relation": "exactMatch"
   },
   {
     "id": 381,
-    "coding": "ncit:C121540",
+    "coding_id": "ncit:C121540",
     "relation": "exactMatch"
   },
   {
     "id": 382,
-    "coding": "ncit:C113655",
+    "coding_id": "ncit:C113655",
     "relation": "exactMatch"
   },
   {
     "id": 383,
-    "coding": "ncit:C154287",
+    "coding_id": "ncit:C154287",
     "relation": "exactMatch"
   },
   {
     "id": 384,
-    "coding": "ncit:C114283",
+    "coding_id": "ncit:C114283",
     "relation": "exactMatch"
   },
   {
     "id": 385,
-    "coding": "ncit:C405",
+    "coding_id": "ncit:C405",
     "relation": "exactMatch"
   },
   {
     "id": 386,
-    "coding": "ncit:C1702",
+    "coding_id": "ncit:C1702",
     "relation": "exactMatch"
   },
   {
     "id": 387,
-    "coding": "ncit:C933",
+    "coding_id": "ncit:C933",
     "relation": "exactMatch"
   },
   {
     "id": 388,
-    "coding": "ncit:C2322",
+    "coding_id": "ncit:C2322",
     "relation": "exactMatch"
   },
   {
     "id": 389,
-    "coding": "ncit:C408",
+    "coding_id": "ncit:C408",
     "relation": "exactMatch"
   },
   {
     "id": 390,
-    "coding": "ncit:C491",
+    "coding_id": "ncit:C491",
     "relation": "exactMatch"
   },
   {
     "id": 391,
-    "coding": "ncit:C642",
+    "coding_id": "ncit:C642",
     "relation": "exactMatch"
   },
   {
     "id": 392,
-    "coding": "ncit:C77908",
+    "coding_id": "ncit:C77908",
     "relation": "exactMatch"
   },
   {
     "id": 393,
-    "coding": "ncit:C82386",
+    "coding_id": "ncit:C82386",
     "relation": "exactMatch"
   },
   {
     "id": 394,
-    "coding": "ncit:C62091",
+    "coding_id": "ncit:C62091",
     "relation": "exactMatch"
   },
   {
     "id": 395,
-    "coding": "ncit:C1806",
+    "coding_id": "ncit:C1806",
     "relation": "exactMatch"
   },
   {
     "id": 396,
-    "coding": "ncit:C49094",
+    "coding_id": "ncit:C49094",
     "relation": "exactMatch"
   },
   {
     "id": 397,
-    "coding": "ncit:C2654",
+    "coding_id": "ncit:C2654",
     "relation": "exactMatch"
   },
   {
     "id": 398,
-    "coding": "ncit:C68814",
+    "coding_id": "ncit:C68814",
     "relation": "exactMatch"
   },
   {
     "id": 399,
-    "coding": "ncit:C111999",
+    "coding_id": "ncit:C111999",
     "relation": "exactMatch"
   },
   {
     "id": 400,
-    "coding": "ncit:C120211",
+    "coding_id": "ncit:C120211",
     "relation": "exactMatch"
   },
   {
     "id": 401,
-    "coding": "ncit:C38692",
+    "coding_id": "ncit:C38692",
     "relation": "exactMatch"
   },
   {
     "id": 402,
-    "coding": "ncit:C62028",
+    "coding_id": "ncit:C62028",
     "relation": "exactMatch"
   },
   {
     "id": 403,
-    "coding": "ncit:C94214",
+    "coding_id": "ncit:C94214",
     "relation": "exactMatch"
   },
   {
     "id": 404,
-    "coding": "ncit:C134987",
+    "coding_id": "ncit:C134987",
     "relation": "exactMatch"
   },
   {
     "id": 405,
-    "coding": "ncit:C2668",
+    "coding_id": "ncit:C2668",
     "relation": "exactMatch"
   },
   {
     "id": 406,
-    "coding": "ncit:C114984",
+    "coding_id": "ncit:C114984",
     "relation": "exactMatch"
   },
   {
     "id": 407,
-    "coding": "ncit:",
+    "coding_id": "ncit:",
     "relation": "exactMatch"
   },
   {
     "id": 408,
-    "coding": "ncit:C1872",
+    "coding_id": "ncit:C1872",
     "relation": "exactMatch"
   },
   {
     "id": 409,
-    "coding": "ncit:C114494",
+    "coding_id": "ncit:C114494",
     "relation": "exactMatch"
   },
   {
     "id": 410,
-    "coding": "ncit:C38713",
+    "coding_id": "ncit:C38713",
     "relation": "exactMatch"
   },
   {
     "id": 411,
-    "coding": "ncit:C90564",
+    "coding_id": "ncit:C90564",
     "relation": "exactMatch"
   },
   {
     "id": 412,
-    "coding": "ncit:C116377",
+    "coding_id": "ncit:C116377",
     "relation": "exactMatch"
   },
   {
     "id": 413,
-    "coding": "ncit:C95733",
+    "coding_id": "ncit:C95733",
     "relation": "exactMatch"
   },
   {
     "id": 414,
-    "coding": "ncit:C48375",
+    "coding_id": "ncit:C48375",
     "relation": "exactMatch"
   },
   {
     "id": 415,
-    "coding": "ncit:C106250",
+    "coding_id": "ncit:C106250",
     "relation": "exactMatch"
   },
   {
     "id": 416,
-    "coding": "ncit:C88314",
+    "coding_id": "ncit:C88314",
     "relation": "exactMatch"
   },
   {
     "id": 417,
-    "coding": "ncit:C288",
+    "coding_id": "ncit:C288",
     "relation": "exactMatch"
   },
   {
     "id": 418,
-    "coding": "ncit:C114383",
+    "coding_id": "ncit:C114383",
     "relation": "exactMatch"
   },
   {
     "id": 419,
-    "coding": "ncit:C1005",
+    "coding_id": "ncit:C1005",
     "relation": "exactMatch"
   },
   {
     "id": 420,
-    "coding": "ncit:C102783",
+    "coding_id": "ncit:C102783",
     "relation": "exactMatch"
   },
   {
     "id": 421,
-    "coding": "ncit:C77896",
+    "coding_id": "ncit:C77896",
     "relation": "exactMatch"
   },
   {
     "id": 422,
-    "coding": "ncit:C26653",
+    "coding_id": "ncit:C26653",
     "relation": "exactMatch"
   },
   {
     "id": 423,
-    "coding": "ncit:C1857",
+    "coding_id": "ncit:C1857",
     "relation": "exactMatch"
   },
   {
     "id": 424,
-    "coding": "ncit:C103147",
+    "coding_id": "ncit:C103147",
     "relation": "exactMatch"
   },
   {
     "id": 425,
-    "coding": "ncit:C97660",
+    "coding_id": "ncit:C97660",
     "relation": "exactMatch"
   },
   {
     "id": 426,
-    "coding": "ncit:C115977",
+    "coding_id": "ncit:C115977",
     "relation": "exactMatch"
   },
   {
     "id": 427,
-    "coding": "ncit:C53398",
+    "coding_id": "ncit:C53398",
     "relation": "exactMatch"
   },
   {
     "id": 428,
-    "coding": "ncit:C74061",
+    "coding_id": "ncit:C74061",
     "relation": "exactMatch"
   },
   {
     "id": 429,
-    "coding": "ncit:",
+    "coding_id": "ncit:",
     "relation": "exactMatch"
   },
   {
     "id": 430,
-    "coding": "ncit:C116722",
+    "coding_id": "ncit:C116722",
     "relation": "exactMatch"
   },
   {
     "id": 431,
-    "coding": "ncit:C78825",
+    "coding_id": "ncit:C78825",
     "relation": "exactMatch"
   },
   {
     "id": 432,
-    "coding": "ncit:C115112",
+    "coding_id": "ncit:C115112",
     "relation": "exactMatch"
   },
   {
     "id": 433,
-    "coding": "ncit:C121775",
+    "coding_id": "ncit:C121775",
     "relation": "exactMatch"
   },
   {
     "id": 434,
-    "coding": "ncit:C124993",
+    "coding_id": "ncit:C124993",
     "relation": "exactMatch"
   },
   {
     "id": 435,
-    "coding": "ncit:C102564",
+    "coding_id": "ncit:C102564",
     "relation": "exactMatch"
   },
   {
     "id": 436,
-    "coding": "ncit:C103273",
+    "coding_id": "ncit:C103273",
     "relation": "exactMatch"
   },
   {
     "id": 437,
-    "coding": "ncit:C85475",
+    "coding_id": "ncit:C85475",
     "relation": "exactMatch"
   },
   {
     "id": 438,
-    "coding": "ncit:C49094",
+    "coding_id": "ncit:C49094",
     "relation": "exactMatch"
   },
   {
     "id": 439,
-    "coding": "ncit:C141428",
+    "coding_id": "ncit:C141428",
     "relation": "exactMatch"
   },
   {
     "id": 440,
-    "coding": "ncit:C113442",
+    "coding_id": "ncit:C113442",
     "relation": "exactMatch"
   },
   {
     "id": 441,
-    "coding": "ncit:C81934",
+    "coding_id": "ncit:C81934",
     "relation": "exactMatch"
   },
   {
     "id": 442,
-    "coding": "ncit:C564",
+    "coding_id": "ncit:C564",
     "relation": "exactMatch"
   },
   {
     "id": 443,
-    "coding": "ncit:C1275",
+    "coding_id": "ncit:C1275",
     "relation": "exactMatch"
   },
   {
     "id": 444,
-    "coding": "ncit:",
+    "coding_id": "ncit:",
     "relation": "exactMatch"
   },
   {
     "id": 445,
-    "coding": "ncit:C62078",
+    "coding_id": "ncit:C62078",
     "relation": "exactMatch"
   },
   {
     "id": 446,
-    "coding": "ncit:C66952",
+    "coding_id": "ncit:C66952",
     "relation": "exactMatch"
   },
   {
     "id": 447,
-    "coding": "ncit:C73261",
+    "coding_id": "ncit:C73261",
     "relation": "exactMatch"
   },
   {
     "id": 448,
-    "coding": "ncit:C770",
+    "coding_id": "ncit:C770",
     "relation": "exactMatch"
   },
   {
     "id": 449,
-    "coding": "ncit:C362",
+    "coding_id": "ncit:C362",
     "relation": "exactMatch"
   },
   {
     "id": 450,
-    "coding": "ncit:C62050",
+    "coding_id": "ncit:C62050",
     "relation": "exactMatch"
   },
   {
     "id": 451,
-    "coding": "ncit:C20494",
+    "coding_id": "ncit:C20494",
     "relation": "exactMatch"
   },
   {
     "id": 452,
-    "coding": "ncit:C111573",
+    "coding_id": "ncit:C111573",
     "relation": "exactMatch"
   },
   {
     "id": 453,
-    "coding": "ncit:C88302",
+    "coding_id": "ncit:C88302",
     "relation": "exactMatch"
   },
   {
     "id": 454,
-    "coding": "ncit:C91733",
+    "coding_id": "ncit:C91733",
     "relation": "exactMatch"
   },
   {
     "id": 455,
-    "coding": "ncit:C96748",
+    "coding_id": "ncit:C96748",
     "relation": "exactMatch"
   },
   {
     "id": 456,
-    "coding": "ncit:C126752",
+    "coding_id": "ncit:C126752",
     "relation": "exactMatch"
   },
   {
     "id": 457,
-    "coding": "ncit:C129687",
+    "coding_id": "ncit:C129687",
     "relation": "exactMatch"
   },
   {
     "id": 458,
-    "coding": "ncit:C95124",
+    "coding_id": "ncit:C95124",
     "relation": "exactMatch"
   },
   {
     "id": 459,
-    "coding": "ncit:C121553",
+    "coding_id": "ncit:C121553",
     "relation": "exactMatch"
   },
   {
     "id": 460,
-    "coding": "ncit:C133821",
+    "coding_id": "ncit:C133821",
     "relation": "exactMatch"
   },
   {
     "id": 461,
-    "coding": "ncit:C1094",
+    "coding_id": "ncit:C1094",
     "relation": "exactMatch"
   },
   {
     "id": 462,
-    "coding": "ncit:C137800",
+    "coding_id": "ncit:C137800",
     "relation": "exactMatch"
   },
   {
     "id": 463,
-    "coding": "ncit:C107506",
+    "coding_id": "ncit:C107506",
     "relation": "exactMatch"
   },
   {
     "id": 464,
-    "coding": "ncit:C71744",
+    "coding_id": "ncit:C71744",
     "relation": "exactMatch"
   },
   {
     "id": 465,
-    "coding": "ncit:C148147",
+    "coding_id": "ncit:C148147",
     "relation": "exactMatch"
   },
   {
     "id": 466,
-    "coding": "ncit:C102566",
+    "coding_id": "ncit:C102566",
     "relation": "exactMatch"
   },
   {
     "id": 467,
-    "coding": "ncit:C106254",
+    "coding_id": "ncit:C106254",
     "relation": "exactMatch"
   },
   {
     "id": 468,
-    "coding": "ncit:C152914",
+    "coding_id": "ncit:C152914",
     "relation": "exactMatch"
   },
   {
     "id": 469,
-    "coding": "ncit:C1374",
+    "coding_id": "ncit:C1374",
     "relation": "exactMatch"
   },
   {
     "id": 470,
-    "coding": "ncit:C132166",
+    "coding_id": "ncit:C132166",
     "relation": "exactMatch"
   },
   {
     "id": 471,
-    "coding": "ncit:C130010",
+    "coding_id": "ncit:C130010",
     "relation": "exactMatch"
   },
   {
     "id": 472,
-    "coding": "ncit:C152948",
+    "coding_id": "ncit:C152948",
     "relation": "exactMatch"
   },
   {
     "id": 473,
-    "coding": "ncit:C102754",
+    "coding_id": "ncit:C102754",
     "relation": "exactMatch"
   },
   {
     "id": 474,
-    "coding": "ncit:C165776",
+    "coding_id": "ncit:C165776",
     "relation": "exactMatch"
   }
 ]

--- a/referenced/propositions.json
+++ b/referenced/propositions.json
@@ -7789,7 +7789,7 @@
     ],
     "conditionQualifier_id": 9,
     "subjectVariant": {},
-    "therapy_id": 112,
+    "therapy_id": 70,
     "therapy_group_id": null
   },
   {
@@ -7802,7 +7802,7 @@
     ],
     "conditionQualifier_id": 9,
     "subjectVariant": {},
-    "therapy_id": 112,
+    "therapy_id": 70,
     "therapy_group_id": null
   },
   {
@@ -7815,7 +7815,7 @@
     ],
     "conditionQualifier_id": 9,
     "subjectVariant": {},
-    "therapy_id": 112,
+    "therapy_id": 70,
     "therapy_group_id": null
   },
   {
@@ -7829,7 +7829,7 @@
     ],
     "conditionQualifier_id": 9,
     "subjectVariant": {},
-    "therapy_id": 112,
+    "therapy_id": 70,
     "therapy_group_id": null
   },
   {
@@ -7842,7 +7842,7 @@
     ],
     "conditionQualifier_id": 9,
     "subjectVariant": {},
-    "therapy_id": 112,
+    "therapy_id": 70,
     "therapy_group_id": null
   },
   {
@@ -7855,7 +7855,7 @@
     ],
     "conditionQualifier_id": 9,
     "subjectVariant": {},
-    "therapy_id": 112,
+    "therapy_id": 70,
     "therapy_group_id": null
   },
   {

--- a/referenced/strengths.json
+++ b/referenced/strengths.json
@@ -1,20 +1,11 @@
 [
   {
     "id": 0,
-    "conceptType": "Evidence strength",
-    "primaryCode": "ncit:C25425",
+    "conceptType": "Evidence",
     "name": "Approval",
+    "primaryCoding": "ncit:C25425",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C25425",
-          "code": "C25425",
-          "name": "Approval",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      325
     ]
   }
 ]

--- a/referenced/strengths.json
+++ b/referenced/strengths.json
@@ -3,7 +3,7 @@
     "id": 0,
     "conceptType": "Evidence",
     "name": "Approval",
-    "primaryCoding": "ncit:C25425",
+    "primary_coding_id": "ncit:C25425",
     "mappings": []
   }
 ]

--- a/referenced/strengths.json
+++ b/referenced/strengths.json
@@ -4,8 +4,6 @@
     "conceptType": "Evidence",
     "name": "Approval",
     "primaryCoding": "ncit:C25425",
-    "mappings": [
-      325
-    ]
+    "mappings": []
   }
 ]

--- a/referenced/therapies.json
+++ b/referenced/therapies.json
@@ -4,9 +4,7 @@
     "conceptType": "Drug",
     "name": "Brentuximab Vedotin",
     "primaryCoding": "ncit:C66944",
-    "mappings": [
-      326
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -27,9 +25,7 @@
     "conceptType": "Drug",
     "name": "Dacarbazine",
     "primaryCoding": "ncit:C411",
-    "mappings": [
-      327
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -50,9 +46,7 @@
     "conceptType": "Drug",
     "name": "Doxorubicin",
     "primaryCoding": "ncit:C456",
-    "mappings": [
-      328
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -94,9 +88,7 @@
     "conceptType": "Drug",
     "name": "Everolimus",
     "primaryCoding": "ncit:C48387",
-    "mappings": [
-      330
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -117,9 +109,7 @@
     "conceptType": "Drug",
     "name": "Exemestane",
     "primaryCoding": "ncit:C1097",
-    "mappings": [
-      331
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -140,9 +130,7 @@
     "conceptType": "Drug",
     "name": "Niraparib",
     "primaryCoding": "ncit:C80059",
-    "mappings": [
-      332
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -163,9 +151,7 @@
     "conceptType": "Drug",
     "name": "Abiraterone acetate",
     "primaryCoding": "ncit:C68845",
-    "mappings": [
-      333
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -186,9 +172,7 @@
     "conceptType": "Drug",
     "name": "Prednisolone",
     "primaryCoding": "ncit:C769",
-    "mappings": [
-      334
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -209,9 +193,7 @@
     "conceptType": "Drug",
     "name": "Alectinib",
     "primaryCoding": "ncit:C101790",
-    "mappings": [
-      335
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -232,9 +214,7 @@
     "conceptType": "Drug",
     "name": "Brigatinib",
     "primaryCoding": "ncit:C98831",
-    "mappings": [
-      336
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -255,9 +235,7 @@
     "conceptType": "Drug",
     "name": "Bevacizumab",
     "primaryCoding": "ncit:C2039",
-    "mappings": [
-      337
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -278,9 +256,7 @@
     "conceptType": "Drug",
     "name": "Erlotinib",
     "primaryCoding": "ncit:C65530",
-    "mappings": [
-      338
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -301,9 +277,7 @@
     "conceptType": "Drug",
     "name": "Avapritinib",
     "primaryCoding": "ncit:C123827",
-    "mappings": [
-      339
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -324,9 +298,7 @@
     "conceptType": "Drug",
     "name": "Inotuzumab ozogamicin",
     "primaryCoding": "ncit:C71542",
-    "mappings": [
-      340
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -347,9 +319,7 @@
     "conceptType": "Drug",
     "name": "Blinatumomab",
     "primaryCoding": "ncit:C62528",
-    "mappings": [
-      341
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -370,9 +340,7 @@
     "conceptType": "Drug",
     "name": "Bosutinib",
     "primaryCoding": "ncit:C60809",
-    "mappings": [
-      342
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -393,9 +361,7 @@
     "conceptType": "Drug",
     "name": "Binimetinib",
     "primaryCoding": "ncit:C84865",
-    "mappings": [
-      343
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -416,9 +382,7 @@
     "conceptType": "Drug",
     "name": "Encorafenib",
     "primaryCoding": "ncit:C98283",
-    "mappings": [
-      344
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -439,9 +403,7 @@
     "conceptType": "Drug",
     "name": "Cetuximab",
     "primaryCoding": "ncit:C1723",
-    "mappings": [
-      345
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -462,9 +424,7 @@
     "conceptType": "Drug",
     "name": "Vandetanib",
     "primaryCoding": "ncit:C2737",
-    "mappings": [
-      346
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -485,9 +445,7 @@
     "conceptType": "Drug",
     "name": "Cobimetinib",
     "primaryCoding": "ncit:C68923",
-    "mappings": [
-      347
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -508,9 +466,7 @@
     "conceptType": "Drug",
     "name": "Vemurafenib",
     "primaryCoding": "ncit:C64768",
-    "mappings": [
-      348
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -531,9 +487,7 @@
     "conceptType": "Drug",
     "name": "Ramucirumab",
     "primaryCoding": "ncit:C70792",
-    "mappings": [
-      349
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -554,9 +508,7 @@
     "conceptType": "Drug",
     "name": "Docetaxel",
     "primaryCoding": "ncit:C1526",
-    "mappings": [
-      350
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -577,9 +529,7 @@
     "conceptType": "Drug",
     "name": "Trastuzumab",
     "primaryCoding": "ncit:C1647",
-    "mappings": [
-      351
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -600,9 +550,7 @@
     "conceptType": "Drug",
     "name": "Trastuzumab deruxtecan",
     "primaryCoding": "ncit:C128799",
-    "mappings": [
-      352
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -623,9 +571,7 @@
     "conceptType": "Drug",
     "name": "Irinotecan",
     "primaryCoding": "ncit:C62040",
-    "mappings": [
-      353
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -646,9 +592,7 @@
     "conceptType": "Drug",
     "name": "Oxaliplatin",
     "primaryCoding": "ncit:C1181",
-    "mappings": [
-      354
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -669,9 +613,7 @@
     "conceptType": "Drug",
     "name": "Fluorouracil",
     "primaryCoding": "ncit:C505",
-    "mappings": [
-      355
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -692,9 +634,7 @@
     "conceptType": "Drug",
     "name": "Fulvestrant",
     "primaryCoding": "ncit:C1379",
-    "mappings": [
-      356
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -715,9 +655,7 @@
     "conceptType": "Drug",
     "name": "Palbociclib",
     "primaryCoding": "ncit:C49176",
-    "mappings": [
-      357
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -738,9 +676,7 @@
     "conceptType": "Drug",
     "name": "Pralsetinib",
     "primaryCoding": "ncit:C132295",
-    "mappings": [
-      358
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -761,9 +697,7 @@
     "conceptType": "Drug",
     "name": "Gefitinib",
     "primaryCoding": "ncit:C1855",
-    "mappings": [
-      359
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -784,9 +718,7 @@
     "conceptType": "Drug",
     "name": "Afatinib",
     "primaryCoding": "ncit:C66940",
-    "mappings": [
-      360
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -807,9 +739,7 @@
     "conceptType": "Drug",
     "name": "Paclitaxel",
     "primaryCoding": "ncit:C1411",
-    "mappings": [
-      361
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -830,9 +760,7 @@
     "conceptType": "Drug",
     "name": "Anastrozole",
     "primaryCoding": "ncit:C1607",
-    "mappings": [
-      362
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -853,9 +781,7 @@
     "conceptType": "Drug",
     "name": "Carboplatin",
     "primaryCoding": "ncit:C1282",
-    "mappings": [
-      363
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -876,9 +802,7 @@
     "conceptType": "Drug",
     "name": "Capecitabine",
     "primaryCoding": "ncit:C1794",
-    "mappings": [
-      364
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -899,9 +823,7 @@
     "conceptType": "Drug",
     "name": "Cisplatin",
     "primaryCoding": "ncit:C376",
-    "mappings": [
-      365
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -922,9 +844,7 @@
     "conceptType": "Drug",
     "name": "Letrozole",
     "primaryCoding": "ncit:C1527",
-    "mappings": [
-      366
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -945,9 +865,7 @@
     "conceptType": "Drug",
     "name": "Imatinib",
     "primaryCoding": "ncit:C62035",
-    "mappings": [
-      367
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -970,9 +888,7 @@
     "conceptType": "Drug",
     "name": "Ponatinib",
     "primaryCoding": "ncit:C95777",
-    "mappings": [
-      369
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -993,9 +909,7 @@
     "conceptType": "Drug",
     "name": "Durvalumab",
     "primaryCoding": "ncit:C103194",
-    "mappings": [
-      370
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -1016,9 +930,7 @@
     "conceptType": "Drug",
     "name": "Tremelimumab",
     "primaryCoding": "ncit:C49085",
-    "mappings": [
-      371
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -1039,9 +951,7 @@
     "conceptType": "Drug",
     "name": "Olaparib",
     "primaryCoding": "ncit:C71721",
-    "mappings": [
-      372
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -1062,9 +972,7 @@
     "conceptType": "Drug",
     "name": "Dostarlimab",
     "primaryCoding": "ncit:C126799",
-    "mappings": [
-      373
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -1085,9 +993,7 @@
     "conceptType": "Drug",
     "name": "Pembrolizumab",
     "primaryCoding": "ncit:C106432",
-    "mappings": [
-      374
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -1108,9 +1014,7 @@
     "conceptType": "Drug",
     "name": "Pemetrexed",
     "primaryCoding": "ncit:C61614",
-    "mappings": [
-      375
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -1131,9 +1035,7 @@
     "conceptType": "Drug",
     "name": "Gemcitabine",
     "primaryCoding": "ncit:C66876",
-    "mappings": [
-      376
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -1154,9 +1056,7 @@
     "conceptType": "Drug",
     "name": "Nab-paclitaxel",
     "primaryCoding": "ncit:C2688",
-    "mappings": [
-      377
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -1177,9 +1077,7 @@
     "conceptType": "Drug",
     "name": "Trastuzumab emtansine",
     "primaryCoding": "ncit:C82492",
-    "mappings": [
-      378
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -1200,9 +1098,7 @@
     "conceptType": "Drug",
     "name": "Ribociclib",
     "primaryCoding": "ncit:C95701",
-    "mappings": [
-      379
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -1223,9 +1119,7 @@
     "conceptType": "Drug",
     "name": "Adagrasib",
     "primaryCoding": "ncit:C157493",
-    "mappings": [
-      380
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -1246,9 +1140,7 @@
     "conceptType": "Drug",
     "name": "Cemiplimab",
     "primaryCoding": "ncit:C121540",
-    "mappings": [
-      381
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -1269,9 +1161,7 @@
     "conceptType": "Drug",
     "name": "Lorlatinib",
     "primaryCoding": "ncit:C113655",
-    "mappings": [
-      382
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -1292,9 +1182,7 @@
     "conceptType": "Drug",
     "name": "Sotorasib",
     "primaryCoding": "ncit:C154287",
-    "mappings": [
-      383
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -1315,9 +1203,7 @@
     "conceptType": "Drug",
     "name": "Futibatinib",
     "primaryCoding": "ncit:C114283",
-    "mappings": [
-      384
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -1338,9 +1224,7 @@
     "conceptType": "Drug",
     "name": "Cyclophosphamide",
     "primaryCoding": "ncit:C405",
-    "mappings": [
-      385
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -1361,9 +1245,7 @@
     "conceptType": "Drug",
     "name": "Rituximab",
     "primaryCoding": "ncit:C1702",
-    "mappings": [
-      386
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -1384,9 +1266,7 @@
     "conceptType": "Drug",
     "name": "Vincristine",
     "primaryCoding": "ncit:C933",
-    "mappings": [
-      387
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -1407,9 +1287,7 @@
     "conceptType": "Drug",
     "name": "Corticosteroid",
     "primaryCoding": "ncit:C2322",
-    "mappings": [
-      388
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -1430,9 +1308,7 @@
     "conceptType": "Drug",
     "name": "Cytarabine",
     "primaryCoding": "ncit:C408",
-    "mappings": [
-      389
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -1453,9 +1329,7 @@
     "conceptType": "Drug",
     "name": "Etoposide",
     "primaryCoding": "ncit:C491",
-    "mappings": [
-      390
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -1476,9 +1350,7 @@
     "conceptType": "Drug",
     "name": "Methotrexate",
     "primaryCoding": "ncit:C642",
-    "mappings": [
-      391
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -1499,9 +1371,7 @@
     "conceptType": "Drug",
     "name": "Trametinib",
     "primaryCoding": "ncit:C77908",
-    "mappings": [
-      392
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -1522,9 +1392,7 @@
     "conceptType": "Drug",
     "name": "Dabrafenib",
     "primaryCoding": "ncit:C82386",
-    "mappings": [
-      393
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -1545,9 +1413,7 @@
     "conceptType": "Drug",
     "name": "Daunorubicin",
     "primaryCoding": "ncit:C62091",
-    "mappings": [
-      394
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -1568,9 +1434,7 @@
     "conceptType": "Drug",
     "name": "Gemtuzumab ozogamicin",
     "primaryCoding": "ncit:C1806",
-    "mappings": [
-      395
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -1612,9 +1476,7 @@
     "conceptType": "Drug",
     "name": "Ipilimumab",
     "primaryCoding": "ncit:C2654",
-    "mappings": [
-      397
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -1635,9 +1497,7 @@
     "conceptType": "Drug",
     "name": "Nivolumab",
     "primaryCoding": "ncit:C68814",
-    "mappings": [
-      398
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -1658,9 +1518,7 @@
     "conceptType": "Drug",
     "name": "Relatlimab",
     "primaryCoding": "ncit:C111999",
-    "mappings": [
-      399
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -1681,9 +1539,7 @@
     "conceptType": "Drug",
     "name": "Elacestrant",
     "primaryCoding": "ncit:C120211",
-    "mappings": [
-      400
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -1704,9 +1560,7 @@
     "conceptType": "Drug",
     "name": "Pertuzumab",
     "primaryCoding": "ncit:C38692",
-    "mappings": [
-      401
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -1727,9 +1581,7 @@
     "conceptType": "Drug",
     "name": "Epirubicin",
     "primaryCoding": "ncit:C62028",
-    "mappings": [
-      402
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -1750,9 +1602,7 @@
     "conceptType": "Drug",
     "name": "Alpelisib",
     "primaryCoding": "ncit:C94214",
-    "mappings": [
-      403
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -1773,9 +1623,7 @@
     "conceptType": "Drug",
     "name": "Selpercatinib",
     "primaryCoding": "ncit:C134987",
-    "mappings": [
-      404
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -1796,9 +1644,7 @@
     "conceptType": "Drug",
     "name": "Lenalidomide",
     "primaryCoding": "ncit:C2668",
-    "mappings": [
-      405
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -1819,9 +1665,7 @@
     "conceptType": "Drug",
     "name": "Entrectinib",
     "primaryCoding": "ncit:C114984",
-    "mappings": [
-      406
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -1844,9 +1688,7 @@
     "conceptType": "Drug",
     "name": "Midostaurin",
     "primaryCoding": "ncit:C1872",
-    "mappings": [
-      408
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -1867,9 +1709,7 @@
     "conceptType": "Drug",
     "name": "Asciminib",
     "primaryCoding": "ncit:C114494",
-    "mappings": [
-      409
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -1890,9 +1730,7 @@
     "conceptType": "Drug",
     "name": "Dasatinib",
     "primaryCoding": "ncit:C38713",
-    "mappings": [
-      410
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -1913,9 +1751,7 @@
     "conceptType": "Drug",
     "name": "Capmatinib",
     "primaryCoding": "ncit:C90564",
-    "mappings": [
-      411
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -1936,9 +1772,7 @@
     "conceptType": "Drug",
     "name": "Osimertinib",
     "primaryCoding": "ncit:C116377",
-    "mappings": [
-      412
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -1959,9 +1793,7 @@
     "conceptType": "Drug",
     "name": "Talazoparib",
     "primaryCoding": "ncit:C95733",
-    "mappings": [
-      413
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -1982,9 +1814,7 @@
     "conceptType": "Drug",
     "name": "Nilotinib",
     "primaryCoding": "ncit:C48375",
-    "mappings": [
-      414
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -2005,9 +1835,7 @@
     "conceptType": "Drug",
     "name": "Atezolizumab",
     "primaryCoding": "ncit:C106250",
-    "mappings": [
-      415
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -2028,9 +1856,7 @@
     "conceptType": "Drug",
     "name": "Tepotinib",
     "primaryCoding": "ncit:C88314",
-    "mappings": [
-      416
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -2051,9 +1877,7 @@
     "conceptType": "Drug",
     "name": "Azacitidine",
     "primaryCoding": "ncit:C288",
-    "mappings": [
-      417
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -2074,9 +1898,7 @@
     "conceptType": "Drug",
     "name": "Ivosidenib",
     "primaryCoding": "ncit:C114383",
-    "mappings": [
-      418
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -2097,9 +1919,7 @@
     "conceptType": "Drug",
     "name": "Arsenic trioxide",
     "primaryCoding": "ncit:C1005",
-    "mappings": [
-      419
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -2120,9 +1940,7 @@
     "conceptType": "Drug",
     "name": "Sacituzumab govitecan",
     "primaryCoding": "ncit:C102783",
-    "mappings": [
-      420
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -2143,9 +1961,7 @@
     "conceptType": "Drug",
     "name": "Tucatinib",
     "primaryCoding": "ncit:C77896",
-    "mappings": [
-      421
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -2166,9 +1982,7 @@
     "conceptType": "Drug",
     "name": "Lapatinib",
     "primaryCoding": "ncit:C26653",
-    "mappings": [
-      422
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -2189,9 +2003,7 @@
     "conceptType": "Drug",
     "name": "Panitumumab",
     "primaryCoding": "ncit:C1857",
-    "mappings": [
-      423
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -2212,9 +2024,7 @@
     "conceptType": "Drug",
     "name": "Venetoclax",
     "primaryCoding": "ncit:C103147",
-    "mappings": [
-      424
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -2235,9 +2045,7 @@
     "conceptType": "Drug",
     "name": "Abemaciclib",
     "primaryCoding": "ncit:C97660",
-    "mappings": [
-      425
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -2258,9 +2066,7 @@
     "conceptType": "Drug",
     "name": "Larotrectinib",
     "primaryCoding": "ncit:C115977",
-    "mappings": [
-      426
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -2281,9 +2087,7 @@
     "conceptType": "Drug",
     "name": "Dacomitinib",
     "primaryCoding": "ncit:C53398",
-    "mappings": [
-      427
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -2304,9 +2108,7 @@
     "conceptType": "Drug",
     "name": "Crizotinib",
     "primaryCoding": "ncit:C74061",
-    "mappings": [
-      428
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -2329,9 +2131,7 @@
     "conceptType": "Drug",
     "name": "Gilteritinib",
     "primaryCoding": "ncit:C116722",
-    "mappings": [
-      430
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -2352,9 +2152,7 @@
     "conceptType": "Drug",
     "name": "Idelalisib",
     "primaryCoding": "ncit:C78825",
-    "mappings": [
-      431
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -2375,9 +2173,7 @@
     "conceptType": "Drug",
     "name": "Ceritinib",
     "primaryCoding": "ncit:C115112",
-    "mappings": [
-      432
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -2398,9 +2194,7 @@
     "conceptType": "Drug",
     "name": "Tislelizumab",
     "primaryCoding": "ncit:C121775",
-    "mappings": [
-      433
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -2421,9 +2215,7 @@
     "conceptType": "Drug",
     "name": "Amivantamab",
     "primaryCoding": "ncit:C124993",
-    "mappings": [
-      434
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -2444,9 +2236,7 @@
     "conceptType": "Drug",
     "name": "Capivasertib",
     "primaryCoding": "ncit:C102564",
-    "mappings": [
-      435
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -2467,9 +2257,7 @@
     "conceptType": "Drug",
     "name": "Erdafitinib",
     "primaryCoding": "ncit:C103273",
-    "mappings": [
-      436
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -2490,9 +2278,7 @@
     "conceptType": "Drug",
     "name": "Zolbetuximab",
     "primaryCoding": "ncit:C85475",
-    "mappings": [
-      437
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -2513,9 +2299,7 @@
     "conceptType": "Drug",
     "name": "Zanubrutinib",
     "primaryCoding": "ncit:C141428",
-    "mappings": [
-      439
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -2536,9 +2320,7 @@
     "conceptType": "Drug",
     "name": "Acalabrutinib",
     "primaryCoding": "ncit:C113442",
-    "mappings": [
-      440
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -2559,9 +2341,7 @@
     "conceptType": "Drug",
     "name": "Ibrutinib",
     "primaryCoding": "ncit:C81934",
-    "mappings": [
-      441
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -2582,9 +2362,7 @@
     "conceptType": "Drug",
     "name": "Ifosfamide",
     "primaryCoding": "ncit:C564",
-    "mappings": [
-      442
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -2605,9 +2383,7 @@
     "conceptType": "Drug",
     "name": "Vinorelbine",
     "primaryCoding": "ncit:C1275",
-    "mappings": [
-      443
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -2628,9 +2404,7 @@
     "conceptType": "Drug",
     "name": "Tamoxifen",
     "primaryCoding": "ncit:C62078",
-    "mappings": [
-      445
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -2651,9 +2425,7 @@
     "conceptType": "Drug",
     "name": "Ofatumumab",
     "primaryCoding": "ncit:C66952",
-    "mappings": [
-      446
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -2674,9 +2446,7 @@
     "conceptType": "Drug",
     "name": "Bendamustine",
     "primaryCoding": "ncit:C73261",
-    "mappings": [
-      447
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -2697,9 +2467,7 @@
     "conceptType": "Drug",
     "name": "Prednisone",
     "primaryCoding": "ncit:C770",
-    "mappings": [
-      448
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -2720,9 +2488,7 @@
     "conceptType": "Drug",
     "name": "Chlorambucil",
     "primaryCoding": "ncit:C362",
-    "mappings": [
-      449
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -2743,9 +2509,7 @@
     "conceptType": "Drug",
     "name": "Mitoxantrone",
     "primaryCoding": "ncit:C62050",
-    "mappings": [
-      450
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -2766,9 +2530,7 @@
     "conceptType": "Drug",
     "name": "Interferon Alpha",
     "primaryCoding": "ncit:C20494",
-    "mappings": [
-      451
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -2789,9 +2551,7 @@
     "conceptType": "Drug",
     "name": "Enasidenib",
     "primaryCoding": "ncit:C111573",
-    "mappings": [
-      452
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -2812,9 +2572,7 @@
     "conceptType": "Drug",
     "name": "Infigratinib",
     "primaryCoding": "ncit:C88302",
-    "mappings": [
-      453
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -2856,9 +2614,7 @@
     "conceptType": "Drug",
     "name": "Eribulin",
     "primaryCoding": "ncit:C96748",
-    "mappings": [
-      455
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -2879,9 +2635,7 @@
     "conceptType": "Drug",
     "name": "Mobocertinib",
     "primaryCoding": "ncit:C126752",
-    "mappings": [
-      456
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -2902,9 +2656,7 @@
     "conceptType": "Drug",
     "name": "Olutasidenib",
     "primaryCoding": "ncit:C129687",
-    "mappings": [
-      457
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -2925,9 +2677,7 @@
     "conceptType": "Drug",
     "name": "Lenvatinib",
     "primaryCoding": "ncit:C95124",
-    "mappings": [
-      458
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -2948,9 +2698,7 @@
     "conceptType": "Drug",
     "name": "Pemigatinib",
     "primaryCoding": "ncit:C121553",
-    "mappings": [
-      459
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -2971,9 +2719,7 @@
     "conceptType": "Drug",
     "name": "Repotrectinib",
     "primaryCoding": "ncit:C133821",
-    "mappings": [
-      460
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -2994,9 +2740,7 @@
     "conceptType": "Drug",
     "name": "Fludarabine",
     "primaryCoding": "ncit:C1094",
-    "mappings": [
-      461
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -3017,9 +2761,7 @@
     "conceptType": "Drug",
     "name": "Rucaparib",
     "primaryCoding": "ncit:C137800",
-    "mappings": [
-      462
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -3040,9 +2782,7 @@
     "conceptType": "Drug",
     "name": "Tazemetostat",
     "primaryCoding": "ncit:C107506",
-    "mappings": [
-      463
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -3063,9 +2803,7 @@
     "conceptType": "Drug",
     "name": "Enzalutamide",
     "primaryCoding": "ncit:C71744",
-    "mappings": [
-      464
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -3086,9 +2824,7 @@
     "conceptType": "Drug",
     "name": "Lazertinib",
     "primaryCoding": "ncit:C148147",
-    "mappings": [
-      465
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -3109,9 +2845,7 @@
     "conceptType": "Drug",
     "name": "Mirvetuximab soravtansine",
     "primaryCoding": "ncit:C102566",
-    "mappings": [
-      466
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -3132,9 +2866,7 @@
     "conceptType": "Drug",
     "name": "Tovorafenib",
     "primaryCoding": "ncit:C106254",
-    "mappings": [
-      467
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -3155,9 +2887,7 @@
     "conceptType": "Drug",
     "name": "Vorasidenib",
     "primaryCoding": "ncit:C152914",
-    "mappings": [
-      468
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -3178,9 +2908,7 @@
     "conceptType": "Drug",
     "name": "Goserelin",
     "primaryCoding": "ncit:C1374",
-    "mappings": [
-      469
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -3201,9 +2929,7 @@
     "conceptType": "Drug",
     "name": "Inavolisib",
     "primaryCoding": "ncit:C132166",
-    "mappings": [
-      470
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -3224,9 +2950,7 @@
     "conceptType": "Drug",
     "name": "Zanidatamab",
     "primaryCoding": "ncit:C130010",
-    "mappings": [
-      471
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -3247,9 +2971,7 @@
     "conceptType": "Drug",
     "name": "Zenocutuzumab",
     "primaryCoding": "ncit:C152948",
-    "mappings": [
-      472
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -3270,9 +2992,7 @@
     "conceptType": "Drug",
     "name": "Ensartinib",
     "primaryCoding": "ncit:C102754",
-    "mappings": [
-      473
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -3293,9 +3013,7 @@
     "conceptType": "Drug",
     "name": "Revumenib",
     "primaryCoding": "ncit:C165776",
-    "mappings": [
-      474
-    ],
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",

--- a/referenced/therapies.json
+++ b/referenced/therapies.json
@@ -966,27 +966,6 @@
     ]
   },
   {
-    "id": 42,
-    "conceptType": "Drug",
-    "name": "",
-    "primaryCoding": "ncit:",
-    "mappings": [],
-    "extensions": [
-      {
-        "name": "therapy_strategy",
-        "value": [
-          ""
-        ],
-        "description": "Associated therapeutic strategy or mechanism of action of the therapy."
-      },
-      {
-        "name": "therapy_type",
-        "value": "",
-        "description": "Type of cancer treatment from cancer.gov: https://www.cancer.gov/about-cancer/treatment/types"
-      }
-    ]
-  },
-  {
     "id": 43,
     "conceptType": "Drug",
     "name": "Ponatinib",
@@ -1861,27 +1840,6 @@
     ]
   },
   {
-    "id": 81,
-    "conceptType": "Drug",
-    "name": "",
-    "primaryCoding": "ncit:",
-    "mappings": [],
-    "extensions": [
-      {
-        "name": "therapy_strategy",
-        "value": [
-          ""
-        ],
-        "description": "Associated therapeutic strategy or mechanism of action of the therapy."
-      },
-      {
-        "name": "therapy_type",
-        "value": "",
-        "description": "Type of cancer treatment from cancer.gov: https://www.cancer.gov/about-cancer/treatment/types"
-      }
-    ]
-  },
-  {
     "id": 82,
     "conceptType": "Drug",
     "name": "Midostaurin",
@@ -2367,27 +2325,6 @@
     ]
   },
   {
-    "id": 103,
-    "conceptType": "Drug",
-    "name": "",
-    "primaryCoding": "ncit:",
-    "mappings": [],
-    "extensions": [
-      {
-        "name": "therapy_strategy",
-        "value": [
-          ""
-        ],
-        "description": "Associated therapeutic strategy or mechanism of action of the therapy."
-      },
-      {
-        "name": "therapy_type",
-        "value": "",
-        "description": "Type of cancer treatment from cancer.gov: https://www.cancer.gov/about-cancer/treatment/types"
-      }
-    ]
-  },
-  {
     "id": 104,
     "conceptType": "Drug",
     "name": "Gilteritinib",
@@ -2572,27 +2509,6 @@
     ]
   },
   {
-    "id": 112,
-    "conceptType": "Drug",
-    "name": "Neratinib",
-    "primaryCoding": "ncit:C49094",
-    "mappings": [],
-    "extensions": [
-      {
-        "name": "therapy_strategy",
-        "value": [
-          "ER Signaling inhibition"
-        ],
-        "description": "Associated therapeutic strategy or mechanism of action of the therapy."
-      },
-      {
-        "name": "therapy_type",
-        "value": "Targeted therapy",
-        "description": "Type of cancer treatment from cancer.gov: https://www.cancer.gov/about-cancer/treatment/types"
-      }
-    ]
-  },
-  {
     "id": 113,
     "conceptType": "Drug",
     "name": "Zanubrutinib",
@@ -2703,25 +2619,6 @@
       {
         "name": "therapy_type",
         "value": "Chemotherapy",
-        "description": "Type of cancer treatment from cancer.gov: https://www.cancer.gov/about-cancer/treatment/types"
-      }
-    ]
-  },
-  {
-    "id": 118,
-    "conceptType": "Drug",
-    "name": "",
-    "primaryCoding": "ncit:",
-    "mappings": [],
-    "extensions": [
-      {
-        "name": "therapy_strategy",
-        "value": [],
-        "description": "Associated therapeutic strategy or mechanism of action of the therapy."
-      },
-      {
-        "name": "therapy_type",
-        "value": "",
         "description": "Type of cancer treatment from cancer.gov: https://www.cancer.gov/about-cancer/treatment/types"
       }
     ]

--- a/referenced/therapies.json
+++ b/referenced/therapies.json
@@ -3,7 +3,7 @@
     "id": 0,
     "conceptType": "Drug",
     "name": "Brentuximab Vedotin",
-    "primaryCoding": "ncit:C66944",
+    "primary_coding_id": "ncit:C66944",
     "mappings": [],
     "extensions": [
       {
@@ -24,7 +24,7 @@
     "id": 1,
     "conceptType": "Drug",
     "name": "Dacarbazine",
-    "primaryCoding": "ncit:C411",
+    "primary_coding_id": "ncit:C411",
     "mappings": [],
     "extensions": [
       {
@@ -45,7 +45,7 @@
     "id": 2,
     "conceptType": "Drug",
     "name": "Doxorubicin",
-    "primaryCoding": "ncit:C456",
+    "primary_coding_id": "ncit:C456",
     "mappings": [],
     "extensions": [
       {
@@ -66,7 +66,7 @@
     "id": 3,
     "conceptType": "Drug",
     "name": "Vinblastine",
-    "primaryCoding": "ncit:C930",
+    "primary_coding_id": "ncit:C930",
     "mappings": [],
     "extensions": [
       {
@@ -87,7 +87,7 @@
     "id": 4,
     "conceptType": "Drug",
     "name": "Everolimus",
-    "primaryCoding": "ncit:C48387",
+    "primary_coding_id": "ncit:C48387",
     "mappings": [],
     "extensions": [
       {
@@ -108,7 +108,7 @@
     "id": 5,
     "conceptType": "Drug",
     "name": "Exemestane",
-    "primaryCoding": "ncit:C1097",
+    "primary_coding_id": "ncit:C1097",
     "mappings": [],
     "extensions": [
       {
@@ -129,7 +129,7 @@
     "id": 6,
     "conceptType": "Drug",
     "name": "Niraparib",
-    "primaryCoding": "ncit:C80059",
+    "primary_coding_id": "ncit:C80059",
     "mappings": [],
     "extensions": [
       {
@@ -150,7 +150,7 @@
     "id": 7,
     "conceptType": "Drug",
     "name": "Abiraterone acetate",
-    "primaryCoding": "ncit:C68845",
+    "primary_coding_id": "ncit:C68845",
     "mappings": [],
     "extensions": [
       {
@@ -171,7 +171,7 @@
     "id": 8,
     "conceptType": "Drug",
     "name": "Prednisolone",
-    "primaryCoding": "ncit:C769",
+    "primary_coding_id": "ncit:C769",
     "mappings": [],
     "extensions": [
       {
@@ -192,7 +192,7 @@
     "id": 9,
     "conceptType": "Drug",
     "name": "Alectinib",
-    "primaryCoding": "ncit:C101790",
+    "primary_coding_id": "ncit:C101790",
     "mappings": [],
     "extensions": [
       {
@@ -213,7 +213,7 @@
     "id": 10,
     "conceptType": "Drug",
     "name": "Brigatinib",
-    "primaryCoding": "ncit:C98831",
+    "primary_coding_id": "ncit:C98831",
     "mappings": [],
     "extensions": [
       {
@@ -234,7 +234,7 @@
     "id": 11,
     "conceptType": "Drug",
     "name": "Bevacizumab",
-    "primaryCoding": "ncit:C2039",
+    "primary_coding_id": "ncit:C2039",
     "mappings": [],
     "extensions": [
       {
@@ -255,7 +255,7 @@
     "id": 12,
     "conceptType": "Drug",
     "name": "Erlotinib",
-    "primaryCoding": "ncit:C65530",
+    "primary_coding_id": "ncit:C65530",
     "mappings": [],
     "extensions": [
       {
@@ -276,7 +276,7 @@
     "id": 13,
     "conceptType": "Drug",
     "name": "Avapritinib",
-    "primaryCoding": "ncit:C123827",
+    "primary_coding_id": "ncit:C123827",
     "mappings": [],
     "extensions": [
       {
@@ -297,7 +297,7 @@
     "id": 14,
     "conceptType": "Drug",
     "name": "Inotuzumab ozogamicin",
-    "primaryCoding": "ncit:C71542",
+    "primary_coding_id": "ncit:C71542",
     "mappings": [],
     "extensions": [
       {
@@ -318,7 +318,7 @@
     "id": 15,
     "conceptType": "Drug",
     "name": "Blinatumomab",
-    "primaryCoding": "ncit:C62528",
+    "primary_coding_id": "ncit:C62528",
     "mappings": [],
     "extensions": [
       {
@@ -339,7 +339,7 @@
     "id": 16,
     "conceptType": "Drug",
     "name": "Bosutinib",
-    "primaryCoding": "ncit:C60809",
+    "primary_coding_id": "ncit:C60809",
     "mappings": [],
     "extensions": [
       {
@@ -360,7 +360,7 @@
     "id": 17,
     "conceptType": "Drug",
     "name": "Binimetinib",
-    "primaryCoding": "ncit:C84865",
+    "primary_coding_id": "ncit:C84865",
     "mappings": [],
     "extensions": [
       {
@@ -381,7 +381,7 @@
     "id": 18,
     "conceptType": "Drug",
     "name": "Encorafenib",
-    "primaryCoding": "ncit:C98283",
+    "primary_coding_id": "ncit:C98283",
     "mappings": [],
     "extensions": [
       {
@@ -402,7 +402,7 @@
     "id": 19,
     "conceptType": "Drug",
     "name": "Cetuximab",
-    "primaryCoding": "ncit:C1723",
+    "primary_coding_id": "ncit:C1723",
     "mappings": [],
     "extensions": [
       {
@@ -423,7 +423,7 @@
     "id": 20,
     "conceptType": "Drug",
     "name": "Vandetanib",
-    "primaryCoding": "ncit:C2737",
+    "primary_coding_id": "ncit:C2737",
     "mappings": [],
     "extensions": [
       {
@@ -444,7 +444,7 @@
     "id": 21,
     "conceptType": "Drug",
     "name": "Cobimetinib",
-    "primaryCoding": "ncit:C68923",
+    "primary_coding_id": "ncit:C68923",
     "mappings": [],
     "extensions": [
       {
@@ -465,7 +465,7 @@
     "id": 22,
     "conceptType": "Drug",
     "name": "Vemurafenib",
-    "primaryCoding": "ncit:C64768",
+    "primary_coding_id": "ncit:C64768",
     "mappings": [],
     "extensions": [
       {
@@ -486,7 +486,7 @@
     "id": 23,
     "conceptType": "Drug",
     "name": "Ramucirumab",
-    "primaryCoding": "ncit:C70792",
+    "primary_coding_id": "ncit:C70792",
     "mappings": [],
     "extensions": [
       {
@@ -507,7 +507,7 @@
     "id": 24,
     "conceptType": "Drug",
     "name": "Docetaxel",
-    "primaryCoding": "ncit:C1526",
+    "primary_coding_id": "ncit:C1526",
     "mappings": [],
     "extensions": [
       {
@@ -528,7 +528,7 @@
     "id": 25,
     "conceptType": "Drug",
     "name": "Trastuzumab",
-    "primaryCoding": "ncit:C1647",
+    "primary_coding_id": "ncit:C1647",
     "mappings": [],
     "extensions": [
       {
@@ -549,7 +549,7 @@
     "id": 26,
     "conceptType": "Drug",
     "name": "Trastuzumab deruxtecan",
-    "primaryCoding": "ncit:C128799",
+    "primary_coding_id": "ncit:C128799",
     "mappings": [],
     "extensions": [
       {
@@ -570,7 +570,7 @@
     "id": 27,
     "conceptType": "Drug",
     "name": "Irinotecan",
-    "primaryCoding": "ncit:C62040",
+    "primary_coding_id": "ncit:C62040",
     "mappings": [],
     "extensions": [
       {
@@ -591,7 +591,7 @@
     "id": 28,
     "conceptType": "Drug",
     "name": "Oxaliplatin",
-    "primaryCoding": "ncit:C1181",
+    "primary_coding_id": "ncit:C1181",
     "mappings": [],
     "extensions": [
       {
@@ -612,7 +612,7 @@
     "id": 29,
     "conceptType": "Drug",
     "name": "Fluorouracil",
-    "primaryCoding": "ncit:C505",
+    "primary_coding_id": "ncit:C505",
     "mappings": [],
     "extensions": [
       {
@@ -633,7 +633,7 @@
     "id": 30,
     "conceptType": "Drug",
     "name": "Fulvestrant",
-    "primaryCoding": "ncit:C1379",
+    "primary_coding_id": "ncit:C1379",
     "mappings": [],
     "extensions": [
       {
@@ -654,7 +654,7 @@
     "id": 31,
     "conceptType": "Drug",
     "name": "Palbociclib",
-    "primaryCoding": "ncit:C49176",
+    "primary_coding_id": "ncit:C49176",
     "mappings": [],
     "extensions": [
       {
@@ -675,7 +675,7 @@
     "id": 32,
     "conceptType": "Drug",
     "name": "Pralsetinib",
-    "primaryCoding": "ncit:C132295",
+    "primary_coding_id": "ncit:C132295",
     "mappings": [],
     "extensions": [
       {
@@ -696,7 +696,7 @@
     "id": 33,
     "conceptType": "Drug",
     "name": "Gefitinib",
-    "primaryCoding": "ncit:C1855",
+    "primary_coding_id": "ncit:C1855",
     "mappings": [],
     "extensions": [
       {
@@ -717,7 +717,7 @@
     "id": 34,
     "conceptType": "Drug",
     "name": "Afatinib",
-    "primaryCoding": "ncit:C66940",
+    "primary_coding_id": "ncit:C66940",
     "mappings": [],
     "extensions": [
       {
@@ -738,7 +738,7 @@
     "id": 35,
     "conceptType": "Drug",
     "name": "Paclitaxel",
-    "primaryCoding": "ncit:C1411",
+    "primary_coding_id": "ncit:C1411",
     "mappings": [],
     "extensions": [
       {
@@ -759,7 +759,7 @@
     "id": 36,
     "conceptType": "Drug",
     "name": "Anastrozole",
-    "primaryCoding": "ncit:C1607",
+    "primary_coding_id": "ncit:C1607",
     "mappings": [],
     "extensions": [
       {
@@ -780,7 +780,7 @@
     "id": 37,
     "conceptType": "Drug",
     "name": "Carboplatin",
-    "primaryCoding": "ncit:C1282",
+    "primary_coding_id": "ncit:C1282",
     "mappings": [],
     "extensions": [
       {
@@ -801,7 +801,7 @@
     "id": 38,
     "conceptType": "Drug",
     "name": "Capecitabine",
-    "primaryCoding": "ncit:C1794",
+    "primary_coding_id": "ncit:C1794",
     "mappings": [],
     "extensions": [
       {
@@ -822,7 +822,7 @@
     "id": 39,
     "conceptType": "Drug",
     "name": "Cisplatin",
-    "primaryCoding": "ncit:C376",
+    "primary_coding_id": "ncit:C376",
     "mappings": [],
     "extensions": [
       {
@@ -843,7 +843,7 @@
     "id": 40,
     "conceptType": "Drug",
     "name": "Letrozole",
-    "primaryCoding": "ncit:C1527",
+    "primary_coding_id": "ncit:C1527",
     "mappings": [],
     "extensions": [
       {
@@ -864,7 +864,7 @@
     "id": 41,
     "conceptType": "Drug",
     "name": "Imatinib",
-    "primaryCoding": "ncit:C62035",
+    "primary_coding_id": "ncit:C62035",
     "mappings": [],
     "extensions": [
       {
@@ -887,7 +887,7 @@
     "id": 43,
     "conceptType": "Drug",
     "name": "Ponatinib",
-    "primaryCoding": "ncit:C95777",
+    "primary_coding_id": "ncit:C95777",
     "mappings": [],
     "extensions": [
       {
@@ -908,7 +908,7 @@
     "id": 44,
     "conceptType": "Drug",
     "name": "Durvalumab",
-    "primaryCoding": "ncit:C103194",
+    "primary_coding_id": "ncit:C103194",
     "mappings": [],
     "extensions": [
       {
@@ -929,7 +929,7 @@
     "id": 45,
     "conceptType": "Drug",
     "name": "Tremelimumab",
-    "primaryCoding": "ncit:C49085",
+    "primary_coding_id": "ncit:C49085",
     "mappings": [],
     "extensions": [
       {
@@ -950,7 +950,7 @@
     "id": 46,
     "conceptType": "Drug",
     "name": "Olaparib",
-    "primaryCoding": "ncit:C71721",
+    "primary_coding_id": "ncit:C71721",
     "mappings": [],
     "extensions": [
       {
@@ -971,7 +971,7 @@
     "id": 47,
     "conceptType": "Drug",
     "name": "Dostarlimab",
-    "primaryCoding": "ncit:C126799",
+    "primary_coding_id": "ncit:C126799",
     "mappings": [],
     "extensions": [
       {
@@ -992,7 +992,7 @@
     "id": 48,
     "conceptType": "Drug",
     "name": "Pembrolizumab",
-    "primaryCoding": "ncit:C106432",
+    "primary_coding_id": "ncit:C106432",
     "mappings": [],
     "extensions": [
       {
@@ -1013,7 +1013,7 @@
     "id": 49,
     "conceptType": "Drug",
     "name": "Pemetrexed",
-    "primaryCoding": "ncit:C61614",
+    "primary_coding_id": "ncit:C61614",
     "mappings": [],
     "extensions": [
       {
@@ -1034,7 +1034,7 @@
     "id": 50,
     "conceptType": "Drug",
     "name": "Gemcitabine",
-    "primaryCoding": "ncit:C66876",
+    "primary_coding_id": "ncit:C66876",
     "mappings": [],
     "extensions": [
       {
@@ -1055,7 +1055,7 @@
     "id": 51,
     "conceptType": "Drug",
     "name": "Nab-paclitaxel",
-    "primaryCoding": "ncit:C2688",
+    "primary_coding_id": "ncit:C2688",
     "mappings": [],
     "extensions": [
       {
@@ -1076,7 +1076,7 @@
     "id": 52,
     "conceptType": "Drug",
     "name": "Trastuzumab emtansine",
-    "primaryCoding": "ncit:C82492",
+    "primary_coding_id": "ncit:C82492",
     "mappings": [],
     "extensions": [
       {
@@ -1097,7 +1097,7 @@
     "id": 53,
     "conceptType": "Drug",
     "name": "Ribociclib",
-    "primaryCoding": "ncit:C95701",
+    "primary_coding_id": "ncit:C95701",
     "mappings": [],
     "extensions": [
       {
@@ -1118,7 +1118,7 @@
     "id": 54,
     "conceptType": "Drug",
     "name": "Adagrasib",
-    "primaryCoding": "ncit:C157493",
+    "primary_coding_id": "ncit:C157493",
     "mappings": [],
     "extensions": [
       {
@@ -1139,7 +1139,7 @@
     "id": 55,
     "conceptType": "Drug",
     "name": "Cemiplimab",
-    "primaryCoding": "ncit:C121540",
+    "primary_coding_id": "ncit:C121540",
     "mappings": [],
     "extensions": [
       {
@@ -1160,7 +1160,7 @@
     "id": 56,
     "conceptType": "Drug",
     "name": "Lorlatinib",
-    "primaryCoding": "ncit:C113655",
+    "primary_coding_id": "ncit:C113655",
     "mappings": [],
     "extensions": [
       {
@@ -1181,7 +1181,7 @@
     "id": 57,
     "conceptType": "Drug",
     "name": "Sotorasib",
-    "primaryCoding": "ncit:C154287",
+    "primary_coding_id": "ncit:C154287",
     "mappings": [],
     "extensions": [
       {
@@ -1202,7 +1202,7 @@
     "id": 58,
     "conceptType": "Drug",
     "name": "Futibatinib",
-    "primaryCoding": "ncit:C114283",
+    "primary_coding_id": "ncit:C114283",
     "mappings": [],
     "extensions": [
       {
@@ -1223,7 +1223,7 @@
     "id": 59,
     "conceptType": "Drug",
     "name": "Cyclophosphamide",
-    "primaryCoding": "ncit:C405",
+    "primary_coding_id": "ncit:C405",
     "mappings": [],
     "extensions": [
       {
@@ -1244,7 +1244,7 @@
     "id": 60,
     "conceptType": "Drug",
     "name": "Rituximab",
-    "primaryCoding": "ncit:C1702",
+    "primary_coding_id": "ncit:C1702",
     "mappings": [],
     "extensions": [
       {
@@ -1265,7 +1265,7 @@
     "id": 61,
     "conceptType": "Drug",
     "name": "Vincristine",
-    "primaryCoding": "ncit:C933",
+    "primary_coding_id": "ncit:C933",
     "mappings": [],
     "extensions": [
       {
@@ -1286,7 +1286,7 @@
     "id": 62,
     "conceptType": "Drug",
     "name": "Corticosteroid",
-    "primaryCoding": "ncit:C2322",
+    "primary_coding_id": "ncit:C2322",
     "mappings": [],
     "extensions": [
       {
@@ -1307,7 +1307,7 @@
     "id": 63,
     "conceptType": "Drug",
     "name": "Cytarabine",
-    "primaryCoding": "ncit:C408",
+    "primary_coding_id": "ncit:C408",
     "mappings": [],
     "extensions": [
       {
@@ -1328,7 +1328,7 @@
     "id": 64,
     "conceptType": "Drug",
     "name": "Etoposide",
-    "primaryCoding": "ncit:C491",
+    "primary_coding_id": "ncit:C491",
     "mappings": [],
     "extensions": [
       {
@@ -1349,7 +1349,7 @@
     "id": 65,
     "conceptType": "Drug",
     "name": "Methotrexate",
-    "primaryCoding": "ncit:C642",
+    "primary_coding_id": "ncit:C642",
     "mappings": [],
     "extensions": [
       {
@@ -1370,7 +1370,7 @@
     "id": 66,
     "conceptType": "Drug",
     "name": "Trametinib",
-    "primaryCoding": "ncit:C77908",
+    "primary_coding_id": "ncit:C77908",
     "mappings": [],
     "extensions": [
       {
@@ -1391,7 +1391,7 @@
     "id": 67,
     "conceptType": "Drug",
     "name": "Dabrafenib",
-    "primaryCoding": "ncit:C82386",
+    "primary_coding_id": "ncit:C82386",
     "mappings": [],
     "extensions": [
       {
@@ -1412,7 +1412,7 @@
     "id": 68,
     "conceptType": "Drug",
     "name": "Daunorubicin",
-    "primaryCoding": "ncit:C62091",
+    "primary_coding_id": "ncit:C62091",
     "mappings": [],
     "extensions": [
       {
@@ -1433,7 +1433,7 @@
     "id": 69,
     "conceptType": "Drug",
     "name": "Gemtuzumab ozogamicin",
-    "primaryCoding": "ncit:C1806",
+    "primary_coding_id": "ncit:C1806",
     "mappings": [],
     "extensions": [
       {
@@ -1454,7 +1454,7 @@
     "id": 70,
     "conceptType": "Drug",
     "name": "Neratinib",
-    "primaryCoding": "ncit:C49094",
+    "primary_coding_id": "ncit:C49094",
     "mappings": [],
     "extensions": [
       {
@@ -1475,7 +1475,7 @@
     "id": 71,
     "conceptType": "Drug",
     "name": "Ipilimumab",
-    "primaryCoding": "ncit:C2654",
+    "primary_coding_id": "ncit:C2654",
     "mappings": [],
     "extensions": [
       {
@@ -1496,7 +1496,7 @@
     "id": 72,
     "conceptType": "Drug",
     "name": "Nivolumab",
-    "primaryCoding": "ncit:C68814",
+    "primary_coding_id": "ncit:C68814",
     "mappings": [],
     "extensions": [
       {
@@ -1517,7 +1517,7 @@
     "id": 73,
     "conceptType": "Drug",
     "name": "Relatlimab",
-    "primaryCoding": "ncit:C111999",
+    "primary_coding_id": "ncit:C111999",
     "mappings": [],
     "extensions": [
       {
@@ -1538,7 +1538,7 @@
     "id": 74,
     "conceptType": "Drug",
     "name": "Elacestrant",
-    "primaryCoding": "ncit:C120211",
+    "primary_coding_id": "ncit:C120211",
     "mappings": [],
     "extensions": [
       {
@@ -1559,7 +1559,7 @@
     "id": 75,
     "conceptType": "Drug",
     "name": "Pertuzumab",
-    "primaryCoding": "ncit:C38692",
+    "primary_coding_id": "ncit:C38692",
     "mappings": [],
     "extensions": [
       {
@@ -1580,7 +1580,7 @@
     "id": 76,
     "conceptType": "Drug",
     "name": "Epirubicin",
-    "primaryCoding": "ncit:C62028",
+    "primary_coding_id": "ncit:C62028",
     "mappings": [],
     "extensions": [
       {
@@ -1601,7 +1601,7 @@
     "id": 77,
     "conceptType": "Drug",
     "name": "Alpelisib",
-    "primaryCoding": "ncit:C94214",
+    "primary_coding_id": "ncit:C94214",
     "mappings": [],
     "extensions": [
       {
@@ -1622,7 +1622,7 @@
     "id": 78,
     "conceptType": "Drug",
     "name": "Selpercatinib",
-    "primaryCoding": "ncit:C134987",
+    "primary_coding_id": "ncit:C134987",
     "mappings": [],
     "extensions": [
       {
@@ -1643,7 +1643,7 @@
     "id": 79,
     "conceptType": "Drug",
     "name": "Lenalidomide",
-    "primaryCoding": "ncit:C2668",
+    "primary_coding_id": "ncit:C2668",
     "mappings": [],
     "extensions": [
       {
@@ -1664,7 +1664,7 @@
     "id": 80,
     "conceptType": "Drug",
     "name": "Entrectinib",
-    "primaryCoding": "ncit:C114984",
+    "primary_coding_id": "ncit:C114984",
     "mappings": [],
     "extensions": [
       {
@@ -1687,7 +1687,7 @@
     "id": 82,
     "conceptType": "Drug",
     "name": "Midostaurin",
-    "primaryCoding": "ncit:C1872",
+    "primary_coding_id": "ncit:C1872",
     "mappings": [],
     "extensions": [
       {
@@ -1708,7 +1708,7 @@
     "id": 83,
     "conceptType": "Drug",
     "name": "Asciminib",
-    "primaryCoding": "ncit:C114494",
+    "primary_coding_id": "ncit:C114494",
     "mappings": [],
     "extensions": [
       {
@@ -1729,7 +1729,7 @@
     "id": 84,
     "conceptType": "Drug",
     "name": "Dasatinib",
-    "primaryCoding": "ncit:C38713",
+    "primary_coding_id": "ncit:C38713",
     "mappings": [],
     "extensions": [
       {
@@ -1750,7 +1750,7 @@
     "id": 85,
     "conceptType": "Drug",
     "name": "Capmatinib",
-    "primaryCoding": "ncit:C90564",
+    "primary_coding_id": "ncit:C90564",
     "mappings": [],
     "extensions": [
       {
@@ -1771,7 +1771,7 @@
     "id": 86,
     "conceptType": "Drug",
     "name": "Osimertinib",
-    "primaryCoding": "ncit:C116377",
+    "primary_coding_id": "ncit:C116377",
     "mappings": [],
     "extensions": [
       {
@@ -1792,7 +1792,7 @@
     "id": 87,
     "conceptType": "Drug",
     "name": "Talazoparib",
-    "primaryCoding": "ncit:C95733",
+    "primary_coding_id": "ncit:C95733",
     "mappings": [],
     "extensions": [
       {
@@ -1813,7 +1813,7 @@
     "id": 88,
     "conceptType": "Drug",
     "name": "Nilotinib",
-    "primaryCoding": "ncit:C48375",
+    "primary_coding_id": "ncit:C48375",
     "mappings": [],
     "extensions": [
       {
@@ -1834,7 +1834,7 @@
     "id": 89,
     "conceptType": "Drug",
     "name": "Atezolizumab",
-    "primaryCoding": "ncit:C106250",
+    "primary_coding_id": "ncit:C106250",
     "mappings": [],
     "extensions": [
       {
@@ -1855,7 +1855,7 @@
     "id": 90,
     "conceptType": "Drug",
     "name": "Tepotinib",
-    "primaryCoding": "ncit:C88314",
+    "primary_coding_id": "ncit:C88314",
     "mappings": [],
     "extensions": [
       {
@@ -1876,7 +1876,7 @@
     "id": 91,
     "conceptType": "Drug",
     "name": "Azacitidine",
-    "primaryCoding": "ncit:C288",
+    "primary_coding_id": "ncit:C288",
     "mappings": [],
     "extensions": [
       {
@@ -1897,7 +1897,7 @@
     "id": 92,
     "conceptType": "Drug",
     "name": "Ivosidenib",
-    "primaryCoding": "ncit:C114383",
+    "primary_coding_id": "ncit:C114383",
     "mappings": [],
     "extensions": [
       {
@@ -1918,7 +1918,7 @@
     "id": 93,
     "conceptType": "Drug",
     "name": "Arsenic trioxide",
-    "primaryCoding": "ncit:C1005",
+    "primary_coding_id": "ncit:C1005",
     "mappings": [],
     "extensions": [
       {
@@ -1939,7 +1939,7 @@
     "id": 94,
     "conceptType": "Drug",
     "name": "Sacituzumab govitecan",
-    "primaryCoding": "ncit:C102783",
+    "primary_coding_id": "ncit:C102783",
     "mappings": [],
     "extensions": [
       {
@@ -1960,7 +1960,7 @@
     "id": 95,
     "conceptType": "Drug",
     "name": "Tucatinib",
-    "primaryCoding": "ncit:C77896",
+    "primary_coding_id": "ncit:C77896",
     "mappings": [],
     "extensions": [
       {
@@ -1981,7 +1981,7 @@
     "id": 96,
     "conceptType": "Drug",
     "name": "Lapatinib",
-    "primaryCoding": "ncit:C26653",
+    "primary_coding_id": "ncit:C26653",
     "mappings": [],
     "extensions": [
       {
@@ -2002,7 +2002,7 @@
     "id": 97,
     "conceptType": "Drug",
     "name": "Panitumumab",
-    "primaryCoding": "ncit:C1857",
+    "primary_coding_id": "ncit:C1857",
     "mappings": [],
     "extensions": [
       {
@@ -2023,7 +2023,7 @@
     "id": 98,
     "conceptType": "Drug",
     "name": "Venetoclax",
-    "primaryCoding": "ncit:C103147",
+    "primary_coding_id": "ncit:C103147",
     "mappings": [],
     "extensions": [
       {
@@ -2044,7 +2044,7 @@
     "id": 99,
     "conceptType": "Drug",
     "name": "Abemaciclib",
-    "primaryCoding": "ncit:C97660",
+    "primary_coding_id": "ncit:C97660",
     "mappings": [],
     "extensions": [
       {
@@ -2065,7 +2065,7 @@
     "id": 100,
     "conceptType": "Drug",
     "name": "Larotrectinib",
-    "primaryCoding": "ncit:C115977",
+    "primary_coding_id": "ncit:C115977",
     "mappings": [],
     "extensions": [
       {
@@ -2086,7 +2086,7 @@
     "id": 101,
     "conceptType": "Drug",
     "name": "Dacomitinib",
-    "primaryCoding": "ncit:C53398",
+    "primary_coding_id": "ncit:C53398",
     "mappings": [],
     "extensions": [
       {
@@ -2107,7 +2107,7 @@
     "id": 102,
     "conceptType": "Drug",
     "name": "Crizotinib",
-    "primaryCoding": "ncit:C74061",
+    "primary_coding_id": "ncit:C74061",
     "mappings": [],
     "extensions": [
       {
@@ -2130,7 +2130,7 @@
     "id": 104,
     "conceptType": "Drug",
     "name": "Gilteritinib",
-    "primaryCoding": "ncit:C116722",
+    "primary_coding_id": "ncit:C116722",
     "mappings": [],
     "extensions": [
       {
@@ -2151,7 +2151,7 @@
     "id": 105,
     "conceptType": "Drug",
     "name": "Idelalisib",
-    "primaryCoding": "ncit:C78825",
+    "primary_coding_id": "ncit:C78825",
     "mappings": [],
     "extensions": [
       {
@@ -2172,7 +2172,7 @@
     "id": 106,
     "conceptType": "Drug",
     "name": "Ceritinib",
-    "primaryCoding": "ncit:C115112",
+    "primary_coding_id": "ncit:C115112",
     "mappings": [],
     "extensions": [
       {
@@ -2193,7 +2193,7 @@
     "id": 107,
     "conceptType": "Drug",
     "name": "Tislelizumab",
-    "primaryCoding": "ncit:C121775",
+    "primary_coding_id": "ncit:C121775",
     "mappings": [],
     "extensions": [
       {
@@ -2214,7 +2214,7 @@
     "id": 108,
     "conceptType": "Drug",
     "name": "Amivantamab",
-    "primaryCoding": "ncit:C124993",
+    "primary_coding_id": "ncit:C124993",
     "mappings": [],
     "extensions": [
       {
@@ -2235,7 +2235,7 @@
     "id": 109,
     "conceptType": "Drug",
     "name": "Capivasertib",
-    "primaryCoding": "ncit:C102564",
+    "primary_coding_id": "ncit:C102564",
     "mappings": [],
     "extensions": [
       {
@@ -2256,7 +2256,7 @@
     "id": 110,
     "conceptType": "Drug",
     "name": "Erdafitinib",
-    "primaryCoding": "ncit:C103273",
+    "primary_coding_id": "ncit:C103273",
     "mappings": [],
     "extensions": [
       {
@@ -2277,7 +2277,7 @@
     "id": 111,
     "conceptType": "Drug",
     "name": "Zolbetuximab",
-    "primaryCoding": "ncit:C85475",
+    "primary_coding_id": "ncit:C85475",
     "mappings": [],
     "extensions": [
       {
@@ -2298,7 +2298,7 @@
     "id": 113,
     "conceptType": "Drug",
     "name": "Zanubrutinib",
-    "primaryCoding": "ncit:C141428",
+    "primary_coding_id": "ncit:C141428",
     "mappings": [],
     "extensions": [
       {
@@ -2319,7 +2319,7 @@
     "id": 114,
     "conceptType": "Drug",
     "name": "Acalabrutinib",
-    "primaryCoding": "ncit:C113442",
+    "primary_coding_id": "ncit:C113442",
     "mappings": [],
     "extensions": [
       {
@@ -2340,7 +2340,7 @@
     "id": 115,
     "conceptType": "Drug",
     "name": "Ibrutinib",
-    "primaryCoding": "ncit:C81934",
+    "primary_coding_id": "ncit:C81934",
     "mappings": [],
     "extensions": [
       {
@@ -2361,7 +2361,7 @@
     "id": 116,
     "conceptType": "Drug",
     "name": "Ifosfamide",
-    "primaryCoding": "ncit:C564",
+    "primary_coding_id": "ncit:C564",
     "mappings": [],
     "extensions": [
       {
@@ -2382,7 +2382,7 @@
     "id": 117,
     "conceptType": "Drug",
     "name": "Vinorelbine",
-    "primaryCoding": "ncit:C1275",
+    "primary_coding_id": "ncit:C1275",
     "mappings": [],
     "extensions": [
       {
@@ -2403,7 +2403,7 @@
     "id": 119,
     "conceptType": "Drug",
     "name": "Tamoxifen",
-    "primaryCoding": "ncit:C62078",
+    "primary_coding_id": "ncit:C62078",
     "mappings": [],
     "extensions": [
       {
@@ -2424,7 +2424,7 @@
     "id": 120,
     "conceptType": "Drug",
     "name": "Ofatumumab",
-    "primaryCoding": "ncit:C66952",
+    "primary_coding_id": "ncit:C66952",
     "mappings": [],
     "extensions": [
       {
@@ -2445,7 +2445,7 @@
     "id": 121,
     "conceptType": "Drug",
     "name": "Bendamustine",
-    "primaryCoding": "ncit:C73261",
+    "primary_coding_id": "ncit:C73261",
     "mappings": [],
     "extensions": [
       {
@@ -2466,7 +2466,7 @@
     "id": 122,
     "conceptType": "Drug",
     "name": "Prednisone",
-    "primaryCoding": "ncit:C770",
+    "primary_coding_id": "ncit:C770",
     "mappings": [],
     "extensions": [
       {
@@ -2487,7 +2487,7 @@
     "id": 123,
     "conceptType": "Drug",
     "name": "Chlorambucil",
-    "primaryCoding": "ncit:C362",
+    "primary_coding_id": "ncit:C362",
     "mappings": [],
     "extensions": [
       {
@@ -2508,7 +2508,7 @@
     "id": 124,
     "conceptType": "Drug",
     "name": "Mitoxantrone",
-    "primaryCoding": "ncit:C62050",
+    "primary_coding_id": "ncit:C62050",
     "mappings": [],
     "extensions": [
       {
@@ -2529,7 +2529,7 @@
     "id": 125,
     "conceptType": "Drug",
     "name": "Interferon Alpha",
-    "primaryCoding": "ncit:C20494",
+    "primary_coding_id": "ncit:C20494",
     "mappings": [],
     "extensions": [
       {
@@ -2550,7 +2550,7 @@
     "id": 126,
     "conceptType": "Drug",
     "name": "Enasidenib",
-    "primaryCoding": "ncit:C111573",
+    "primary_coding_id": "ncit:C111573",
     "mappings": [],
     "extensions": [
       {
@@ -2571,7 +2571,7 @@
     "id": 127,
     "conceptType": "Drug",
     "name": "Infigratinib",
-    "primaryCoding": "ncit:C88302",
+    "primary_coding_id": "ncit:C88302",
     "mappings": [],
     "extensions": [
       {
@@ -2592,7 +2592,7 @@
     "id": 128,
     "conceptType": "Drug",
     "name": "Margetuximab",
-    "primaryCoding": "ncit:C91733",
+    "primary_coding_id": "ncit:C91733",
     "mappings": [],
     "extensions": [
       {
@@ -2613,7 +2613,7 @@
     "id": 129,
     "conceptType": "Drug",
     "name": "Eribulin",
-    "primaryCoding": "ncit:C96748",
+    "primary_coding_id": "ncit:C96748",
     "mappings": [],
     "extensions": [
       {
@@ -2634,7 +2634,7 @@
     "id": 130,
     "conceptType": "Drug",
     "name": "Mobocertinib",
-    "primaryCoding": "ncit:C126752",
+    "primary_coding_id": "ncit:C126752",
     "mappings": [],
     "extensions": [
       {
@@ -2655,7 +2655,7 @@
     "id": 131,
     "conceptType": "Drug",
     "name": "Olutasidenib",
-    "primaryCoding": "ncit:C129687",
+    "primary_coding_id": "ncit:C129687",
     "mappings": [],
     "extensions": [
       {
@@ -2676,7 +2676,7 @@
     "id": 132,
     "conceptType": "Drug",
     "name": "Lenvatinib",
-    "primaryCoding": "ncit:C95124",
+    "primary_coding_id": "ncit:C95124",
     "mappings": [],
     "extensions": [
       {
@@ -2697,7 +2697,7 @@
     "id": 133,
     "conceptType": "Drug",
     "name": "Pemigatinib",
-    "primaryCoding": "ncit:C121553",
+    "primary_coding_id": "ncit:C121553",
     "mappings": [],
     "extensions": [
       {
@@ -2718,7 +2718,7 @@
     "id": 134,
     "conceptType": "Drug",
     "name": "Repotrectinib",
-    "primaryCoding": "ncit:C133821",
+    "primary_coding_id": "ncit:C133821",
     "mappings": [],
     "extensions": [
       {
@@ -2739,7 +2739,7 @@
     "id": 135,
     "conceptType": "Drug",
     "name": "Fludarabine",
-    "primaryCoding": "ncit:C1094",
+    "primary_coding_id": "ncit:C1094",
     "mappings": [],
     "extensions": [
       {
@@ -2760,7 +2760,7 @@
     "id": 136,
     "conceptType": "Drug",
     "name": "Rucaparib",
-    "primaryCoding": "ncit:C137800",
+    "primary_coding_id": "ncit:C137800",
     "mappings": [],
     "extensions": [
       {
@@ -2781,7 +2781,7 @@
     "id": 137,
     "conceptType": "Drug",
     "name": "Tazemetostat",
-    "primaryCoding": "ncit:C107506",
+    "primary_coding_id": "ncit:C107506",
     "mappings": [],
     "extensions": [
       {
@@ -2802,7 +2802,7 @@
     "id": 138,
     "conceptType": "Drug",
     "name": "Enzalutamide",
-    "primaryCoding": "ncit:C71744",
+    "primary_coding_id": "ncit:C71744",
     "mappings": [],
     "extensions": [
       {
@@ -2823,7 +2823,7 @@
     "id": 139,
     "conceptType": "Drug",
     "name": "Lazertinib",
-    "primaryCoding": "ncit:C148147",
+    "primary_coding_id": "ncit:C148147",
     "mappings": [],
     "extensions": [
       {
@@ -2844,7 +2844,7 @@
     "id": 140,
     "conceptType": "Drug",
     "name": "Mirvetuximab soravtansine",
-    "primaryCoding": "ncit:C102566",
+    "primary_coding_id": "ncit:C102566",
     "mappings": [],
     "extensions": [
       {
@@ -2865,7 +2865,7 @@
     "id": 141,
     "conceptType": "Drug",
     "name": "Tovorafenib",
-    "primaryCoding": "ncit:C106254",
+    "primary_coding_id": "ncit:C106254",
     "mappings": [],
     "extensions": [
       {
@@ -2886,7 +2886,7 @@
     "id": 142,
     "conceptType": "Drug",
     "name": "Vorasidenib",
-    "primaryCoding": "ncit:C152914",
+    "primary_coding_id": "ncit:C152914",
     "mappings": [],
     "extensions": [
       {
@@ -2907,7 +2907,7 @@
     "id": 143,
     "conceptType": "Drug",
     "name": "Goserelin",
-    "primaryCoding": "ncit:C1374",
+    "primary_coding_id": "ncit:C1374",
     "mappings": [],
     "extensions": [
       {
@@ -2928,7 +2928,7 @@
     "id": 144,
     "conceptType": "Drug",
     "name": "Inavolisib",
-    "primaryCoding": "ncit:C132166",
+    "primary_coding_id": "ncit:C132166",
     "mappings": [],
     "extensions": [
       {
@@ -2949,7 +2949,7 @@
     "id": 145,
     "conceptType": "Drug",
     "name": "Zanidatamab",
-    "primaryCoding": "ncit:C130010",
+    "primary_coding_id": "ncit:C130010",
     "mappings": [],
     "extensions": [
       {
@@ -2970,7 +2970,7 @@
     "id": 146,
     "conceptType": "Drug",
     "name": "Zenocutuzumab",
-    "primaryCoding": "ncit:C152948",
+    "primary_coding_id": "ncit:C152948",
     "mappings": [],
     "extensions": [
       {
@@ -2991,7 +2991,7 @@
     "id": 147,
     "conceptType": "Drug",
     "name": "Ensartinib",
-    "primaryCoding": "ncit:C102754",
+    "primary_coding_id": "ncit:C102754",
     "mappings": [],
     "extensions": [
       {
@@ -3012,7 +3012,7 @@
     "id": 148,
     "conceptType": "Drug",
     "name": "Revumenib",
-    "primaryCoding": "ncit:C165776",
+    "primary_coding_id": "ncit:C165776",
     "mappings": [],
     "extensions": [
       {

--- a/referenced/therapies.json
+++ b/referenced/therapies.json
@@ -2834,15 +2834,13 @@
     "id": 128,
     "conceptType": "Drug",
     "name": "Margetuximab",
-    "primaryCoding": "ncit:",
-    "mappings": [
-      454
-    ],
+    "primaryCoding": "ncit:C91733",
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
         "value": [
-          "ER signaling inhibition"
+          "HER2 inhibition"
         ],
         "description": "Associated therapeutic strategy or mechanism of action of the therapy."
       },

--- a/referenced/therapies.json
+++ b/referenced/therapies.json
@@ -3,18 +3,9 @@
     "id": 0,
     "conceptType": "Drug",
     "name": "Brentuximab Vedotin",
-    "primaryCode": "ncit:C66944",
+    "primaryCoding": "ncit:C66944",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C66944",
-          "code": "C66944",
-          "name": "Brentuximab Vedotin",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      326
     ],
     "extensions": [
       {
@@ -35,18 +26,9 @@
     "id": 1,
     "conceptType": "Drug",
     "name": "Dacarbazine",
-    "primaryCode": "ncit:C411",
+    "primaryCoding": "ncit:C411",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C411",
-          "code": "C411",
-          "name": "Dacarbazine",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      327
     ],
     "extensions": [
       {
@@ -67,18 +49,9 @@
     "id": 2,
     "conceptType": "Drug",
     "name": "Doxorubicin",
-    "primaryCode": "ncit:C456",
+    "primaryCoding": "ncit:C456",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C456",
-          "code": "C456",
-          "name": "Doxorubicin",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      328
     ],
     "extensions": [
       {
@@ -99,19 +72,8 @@
     "id": 3,
     "conceptType": "Drug",
     "name": "Vinblastine",
-    "primaryCode": "ncit:C930",
-    "mappings": [
-      {
-        "coding": {
-          "id": "ncit:",
-          "code": "C930",
-          "name": "Vinblastine",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
-    ],
+    "primaryCoding": "ncit:C930",
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -131,18 +93,9 @@
     "id": 4,
     "conceptType": "Drug",
     "name": "Everolimus",
-    "primaryCode": "ncit:C48387",
+    "primaryCoding": "ncit:C48387",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C48387",
-          "code": "C48387",
-          "name": "Everolimus",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      330
     ],
     "extensions": [
       {
@@ -163,18 +116,9 @@
     "id": 5,
     "conceptType": "Drug",
     "name": "Exemestane",
-    "primaryCode": "ncit:C1097",
+    "primaryCoding": "ncit:C1097",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C1097",
-          "code": "C1097",
-          "name": "Exemestane",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      331
     ],
     "extensions": [
       {
@@ -195,18 +139,9 @@
     "id": 6,
     "conceptType": "Drug",
     "name": "Niraparib",
-    "primaryCode": "ncit:C80059",
+    "primaryCoding": "ncit:C80059",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C80059",
-          "code": "C80059",
-          "name": "Niraparib",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      332
     ],
     "extensions": [
       {
@@ -227,18 +162,9 @@
     "id": 7,
     "conceptType": "Drug",
     "name": "Abiraterone acetate",
-    "primaryCode": "ncit:C68845",
+    "primaryCoding": "ncit:C68845",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C68845",
-          "code": "C68845",
-          "name": "Abiraterone Acetate",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      333
     ],
     "extensions": [
       {
@@ -259,18 +185,9 @@
     "id": 8,
     "conceptType": "Drug",
     "name": "Prednisolone",
-    "primaryCode": "ncit:C769",
+    "primaryCoding": "ncit:C769",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C769",
-          "code": "C769",
-          "name": "Prednisolone",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      334
     ],
     "extensions": [
       {
@@ -291,18 +208,9 @@
     "id": 9,
     "conceptType": "Drug",
     "name": "Alectinib",
-    "primaryCode": "ncit:C101790",
+    "primaryCoding": "ncit:C101790",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C101790",
-          "code": "C101790",
-          "name": "Alectinib",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      335
     ],
     "extensions": [
       {
@@ -323,18 +231,9 @@
     "id": 10,
     "conceptType": "Drug",
     "name": "Brigatinib",
-    "primaryCode": "ncit:C98831",
+    "primaryCoding": "ncit:C98831",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C98831",
-          "code": "C98831",
-          "name": "Brigatinib",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      336
     ],
     "extensions": [
       {
@@ -355,18 +254,9 @@
     "id": 11,
     "conceptType": "Drug",
     "name": "Bevacizumab",
-    "primaryCode": "ncit:C2039",
+    "primaryCoding": "ncit:C2039",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C2039",
-          "code": "C2039",
-          "name": "Bevacizumab",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      337
     ],
     "extensions": [
       {
@@ -387,18 +277,9 @@
     "id": 12,
     "conceptType": "Drug",
     "name": "Erlotinib",
-    "primaryCode": "ncit:C65530",
+    "primaryCoding": "ncit:C65530",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C65530",
-          "code": "C65530",
-          "name": "Erlotinib",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      338
     ],
     "extensions": [
       {
@@ -419,18 +300,9 @@
     "id": 13,
     "conceptType": "Drug",
     "name": "Avapritinib",
-    "primaryCode": "ncit:C123827",
+    "primaryCoding": "ncit:C123827",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C123827",
-          "code": "C123827",
-          "name": "Avapritinib",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      339
     ],
     "extensions": [
       {
@@ -451,18 +323,9 @@
     "id": 14,
     "conceptType": "Drug",
     "name": "Inotuzumab ozogamicin",
-    "primaryCode": "ncit:C71542",
+    "primaryCoding": "ncit:C71542",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C71542",
-          "code": "C71542",
-          "name": "Inotuzumab Ozogamicin",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      340
     ],
     "extensions": [
       {
@@ -483,18 +346,9 @@
     "id": 15,
     "conceptType": "Drug",
     "name": "Blinatumomab",
-    "primaryCode": "ncit:C62528",
+    "primaryCoding": "ncit:C62528",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C62528",
-          "code": "C62528",
-          "name": "Blinatumomab",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      341
     ],
     "extensions": [
       {
@@ -515,18 +369,9 @@
     "id": 16,
     "conceptType": "Drug",
     "name": "Bosutinib",
-    "primaryCode": "ncit:C60809",
+    "primaryCoding": "ncit:C60809",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C60809",
-          "code": "C60809",
-          "name": "Bosutinib",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      342
     ],
     "extensions": [
       {
@@ -547,18 +392,9 @@
     "id": 17,
     "conceptType": "Drug",
     "name": "Binimetinib",
-    "primaryCode": "ncit:C84865",
+    "primaryCoding": "ncit:C84865",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C84865",
-          "code": "C84865",
-          "name": "Binimetinib",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      343
     ],
     "extensions": [
       {
@@ -579,18 +415,9 @@
     "id": 18,
     "conceptType": "Drug",
     "name": "Encorafenib",
-    "primaryCode": "ncit:C98283",
+    "primaryCoding": "ncit:C98283",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C98283",
-          "code": "C98283",
-          "name": "Encorafenib",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      344
     ],
     "extensions": [
       {
@@ -611,18 +438,9 @@
     "id": 19,
     "conceptType": "Drug",
     "name": "Cetuximab",
-    "primaryCode": "ncit:C1723",
+    "primaryCoding": "ncit:C1723",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C1723",
-          "code": "C1723",
-          "name": "Cetuximab",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      345
     ],
     "extensions": [
       {
@@ -643,18 +461,9 @@
     "id": 20,
     "conceptType": "Drug",
     "name": "Vandetanib",
-    "primaryCode": "ncit:C2737",
+    "primaryCoding": "ncit:C2737",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C2737",
-          "code": "C2737",
-          "name": "Vandetanib",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      346
     ],
     "extensions": [
       {
@@ -675,18 +484,9 @@
     "id": 21,
     "conceptType": "Drug",
     "name": "Cobimetinib",
-    "primaryCode": "ncit:C68923",
+    "primaryCoding": "ncit:C68923",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C68923",
-          "code": "C68923",
-          "name": "Cobimetinib",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      347
     ],
     "extensions": [
       {
@@ -707,18 +507,9 @@
     "id": 22,
     "conceptType": "Drug",
     "name": "Vemurafenib",
-    "primaryCode": "ncit:C64768",
+    "primaryCoding": "ncit:C64768",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C64768",
-          "code": "C64768",
-          "name": "Vemurafenib",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      348
     ],
     "extensions": [
       {
@@ -739,18 +530,9 @@
     "id": 23,
     "conceptType": "Drug",
     "name": "Ramucirumab",
-    "primaryCode": "ncit:C70792",
+    "primaryCoding": "ncit:C70792",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C70792",
-          "code": "C70792",
-          "name": "Ramucirumab",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      349
     ],
     "extensions": [
       {
@@ -771,18 +553,9 @@
     "id": 24,
     "conceptType": "Drug",
     "name": "Docetaxel",
-    "primaryCode": "ncit:C1526",
+    "primaryCoding": "ncit:C1526",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C1526",
-          "code": "C1526",
-          "name": "Docetaxel",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      350
     ],
     "extensions": [
       {
@@ -803,18 +576,9 @@
     "id": 25,
     "conceptType": "Drug",
     "name": "Trastuzumab",
-    "primaryCode": "ncit:C1647",
+    "primaryCoding": "ncit:C1647",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C1647",
-          "code": "C1647",
-          "name": "Trastuzumab",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      351
     ],
     "extensions": [
       {
@@ -835,18 +599,9 @@
     "id": 26,
     "conceptType": "Drug",
     "name": "Trastuzumab deruxtecan",
-    "primaryCode": "ncit:C128799",
+    "primaryCoding": "ncit:C128799",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C128799",
-          "code": "C128799",
-          "name": "Trastuzumab Deruxtecan",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      352
     ],
     "extensions": [
       {
@@ -867,18 +622,9 @@
     "id": 27,
     "conceptType": "Drug",
     "name": "Irinotecan",
-    "primaryCode": "ncit:C62040",
+    "primaryCoding": "ncit:C62040",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C62040",
-          "code": "C62040",
-          "name": "Irinotecan",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      353
     ],
     "extensions": [
       {
@@ -899,18 +645,9 @@
     "id": 28,
     "conceptType": "Drug",
     "name": "Oxaliplatin",
-    "primaryCode": "ncit:C1181",
+    "primaryCoding": "ncit:C1181",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C1181",
-          "code": "C1181",
-          "name": "Oxaliplatin",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      354
     ],
     "extensions": [
       {
@@ -931,18 +668,9 @@
     "id": 29,
     "conceptType": "Drug",
     "name": "Fluorouracil",
-    "primaryCode": "ncit:C505",
+    "primaryCoding": "ncit:C505",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C505",
-          "code": "C505",
-          "name": "Fluorouracil",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      355
     ],
     "extensions": [
       {
@@ -963,18 +691,9 @@
     "id": 30,
     "conceptType": "Drug",
     "name": "Fulvestrant",
-    "primaryCode": "ncit:C1379",
+    "primaryCoding": "ncit:C1379",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C1379",
-          "code": "C1379",
-          "name": "Fulvestrant",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      356
     ],
     "extensions": [
       {
@@ -995,18 +714,9 @@
     "id": 31,
     "conceptType": "Drug",
     "name": "Palbociclib",
-    "primaryCode": "ncit:C49176",
+    "primaryCoding": "ncit:C49176",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C49176",
-          "code": "C49176",
-          "name": "Palbociclib",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      357
     ],
     "extensions": [
       {
@@ -1027,18 +737,9 @@
     "id": 32,
     "conceptType": "Drug",
     "name": "Pralsetinib",
-    "primaryCode": "ncit:C132295",
+    "primaryCoding": "ncit:C132295",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C132295",
-          "code": "C132295",
-          "name": "Pralsetinib",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      358
     ],
     "extensions": [
       {
@@ -1059,18 +760,9 @@
     "id": 33,
     "conceptType": "Drug",
     "name": "Gefitinib",
-    "primaryCode": "ncit:C1855",
+    "primaryCoding": "ncit:C1855",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C1855",
-          "code": "C1855",
-          "name": "Gefitinib",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      359
     ],
     "extensions": [
       {
@@ -1091,18 +783,9 @@
     "id": 34,
     "conceptType": "Drug",
     "name": "Afatinib",
-    "primaryCode": "ncit:C66940",
+    "primaryCoding": "ncit:C66940",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C66940",
-          "code": "C66940",
-          "name": "Afatinib",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      360
     ],
     "extensions": [
       {
@@ -1123,18 +806,9 @@
     "id": 35,
     "conceptType": "Drug",
     "name": "Paclitaxel",
-    "primaryCode": "ncit:C1411",
+    "primaryCoding": "ncit:C1411",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C1411",
-          "code": "C1411",
-          "name": "Paclitaxel",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      361
     ],
     "extensions": [
       {
@@ -1155,18 +829,9 @@
     "id": 36,
     "conceptType": "Drug",
     "name": "Anastrozole",
-    "primaryCode": "ncit:C1607",
+    "primaryCoding": "ncit:C1607",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C1607",
-          "code": "C1607",
-          "name": "Anastrozole",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      362
     ],
     "extensions": [
       {
@@ -1187,18 +852,9 @@
     "id": 37,
     "conceptType": "Drug",
     "name": "Carboplatin",
-    "primaryCode": "ncit:C1282",
+    "primaryCoding": "ncit:C1282",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C1282",
-          "code": "C1282",
-          "name": "Carboplatin",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      363
     ],
     "extensions": [
       {
@@ -1219,18 +875,9 @@
     "id": 38,
     "conceptType": "Drug",
     "name": "Capecitabine",
-    "primaryCode": "ncit:C1794",
+    "primaryCoding": "ncit:C1794",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C1794",
-          "code": "C1794",
-          "name": "Capecitabine",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      364
     ],
     "extensions": [
       {
@@ -1251,18 +898,9 @@
     "id": 39,
     "conceptType": "Drug",
     "name": "Cisplatin",
-    "primaryCode": "ncit:C376",
+    "primaryCoding": "ncit:C376",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C376",
-          "code": "C376",
-          "name": "Cisplatin",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      365
     ],
     "extensions": [
       {
@@ -1283,18 +921,9 @@
     "id": 40,
     "conceptType": "Drug",
     "name": "Letrozole",
-    "primaryCode": "ncit:C1527",
+    "primaryCoding": "ncit:C1527",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C1527",
-          "code": "C1527",
-          "name": "Letrozole",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      366
     ],
     "extensions": [
       {
@@ -1315,18 +944,9 @@
     "id": 41,
     "conceptType": "Drug",
     "name": "Imatinib",
-    "primaryCode": "ncit:C62035",
+    "primaryCoding": "ncit:C62035",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C62035",
-          "code": "C62035",
-          "name": "Imatinib",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      367
     ],
     "extensions": [
       {
@@ -1349,19 +969,8 @@
     "id": 42,
     "conceptType": "Drug",
     "name": "",
-    "primaryCode": "ncit:",
-    "mappings": [
-      {
-        "coding": {
-          "id": "ncit:",
-          "code": "",
-          "name": "",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
-    ],
+    "primaryCoding": "ncit:",
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -1381,18 +990,9 @@
     "id": 43,
     "conceptType": "Drug",
     "name": "Ponatinib",
-    "primaryCode": "ncit:C95777",
+    "primaryCoding": "ncit:C95777",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C95777",
-          "code": "C95777",
-          "name": "Ponatinib",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      369
     ],
     "extensions": [
       {
@@ -1413,18 +1013,9 @@
     "id": 44,
     "conceptType": "Drug",
     "name": "Durvalumab",
-    "primaryCode": "ncit:C103194",
+    "primaryCoding": "ncit:C103194",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C103194",
-          "code": "C103194",
-          "name": "Durvalumab",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      370
     ],
     "extensions": [
       {
@@ -1445,18 +1036,9 @@
     "id": 45,
     "conceptType": "Drug",
     "name": "Tremelimumab",
-    "primaryCode": "ncit:C49085",
+    "primaryCoding": "ncit:C49085",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C49085",
-          "code": "C49085",
-          "name": "Tremelimumab",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      371
     ],
     "extensions": [
       {
@@ -1477,18 +1059,9 @@
     "id": 46,
     "conceptType": "Drug",
     "name": "Olaparib",
-    "primaryCode": "ncit:C71721",
+    "primaryCoding": "ncit:C71721",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C71721",
-          "code": "C71721",
-          "name": "Olaparib",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      372
     ],
     "extensions": [
       {
@@ -1509,18 +1082,9 @@
     "id": 47,
     "conceptType": "Drug",
     "name": "Dostarlimab",
-    "primaryCode": "ncit:C126799",
+    "primaryCoding": "ncit:C126799",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C126799",
-          "code": "C126799",
-          "name": "Dostarlimab",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      373
     ],
     "extensions": [
       {
@@ -1541,18 +1105,9 @@
     "id": 48,
     "conceptType": "Drug",
     "name": "Pembrolizumab",
-    "primaryCode": "ncit:C106432",
+    "primaryCoding": "ncit:C106432",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C106432",
-          "code": "C106432",
-          "name": "Pembrolizumab",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      374
     ],
     "extensions": [
       {
@@ -1573,18 +1128,9 @@
     "id": 49,
     "conceptType": "Drug",
     "name": "Pemetrexed",
-    "primaryCode": "ncit:C61614",
+    "primaryCoding": "ncit:C61614",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C61614",
-          "code": "C61614",
-          "name": "Pemetrexed",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      375
     ],
     "extensions": [
       {
@@ -1605,18 +1151,9 @@
     "id": 50,
     "conceptType": "Drug",
     "name": "Gemcitabine",
-    "primaryCode": "ncit:C66876",
+    "primaryCoding": "ncit:C66876",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C66876",
-          "code": "C66876",
-          "name": "Gemcitabine",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      376
     ],
     "extensions": [
       {
@@ -1637,18 +1174,9 @@
     "id": 51,
     "conceptType": "Drug",
     "name": "Nab-paclitaxel",
-    "primaryCode": "ncit:C2688",
+    "primaryCoding": "ncit:C2688",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C2688",
-          "code": "C2688",
-          "name": "Nab-paclitaxel",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      377
     ],
     "extensions": [
       {
@@ -1669,18 +1197,9 @@
     "id": 52,
     "conceptType": "Drug",
     "name": "Trastuzumab emtansine",
-    "primaryCode": "ncit:C82492",
+    "primaryCoding": "ncit:C82492",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C82492",
-          "code": "C82492",
-          "name": "Trastuzumab Emtansine",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      378
     ],
     "extensions": [
       {
@@ -1701,18 +1220,9 @@
     "id": 53,
     "conceptType": "Drug",
     "name": "Ribociclib",
-    "primaryCode": "ncit:C95701",
+    "primaryCoding": "ncit:C95701",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C95701",
-          "code": "C95701",
-          "name": "Ribociclib",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      379
     ],
     "extensions": [
       {
@@ -1733,18 +1243,9 @@
     "id": 54,
     "conceptType": "Drug",
     "name": "Adagrasib",
-    "primaryCode": "ncit:C157493",
+    "primaryCoding": "ncit:C157493",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C157493",
-          "code": "C157493",
-          "name": "Adagrasib",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      380
     ],
     "extensions": [
       {
@@ -1765,18 +1266,9 @@
     "id": 55,
     "conceptType": "Drug",
     "name": "Cemiplimab",
-    "primaryCode": "ncit:C121540",
+    "primaryCoding": "ncit:C121540",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C121540",
-          "code": "C121540",
-          "name": "Cemiplimab",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      381
     ],
     "extensions": [
       {
@@ -1797,18 +1289,9 @@
     "id": 56,
     "conceptType": "Drug",
     "name": "Lorlatinib",
-    "primaryCode": "ncit:C113655",
+    "primaryCoding": "ncit:C113655",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C113655",
-          "code": "C113655",
-          "name": "Lorlatinib",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      382
     ],
     "extensions": [
       {
@@ -1829,18 +1312,9 @@
     "id": 57,
     "conceptType": "Drug",
     "name": "Sotorasib",
-    "primaryCode": "ncit:C154287",
+    "primaryCoding": "ncit:C154287",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C154287",
-          "code": "C154287",
-          "name": "Sotorasib",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      383
     ],
     "extensions": [
       {
@@ -1861,18 +1335,9 @@
     "id": 58,
     "conceptType": "Drug",
     "name": "Futibatinib",
-    "primaryCode": "ncit:C114283",
+    "primaryCoding": "ncit:C114283",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C114283",
-          "code": "C114283",
-          "name": "Futibatinib",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      384
     ],
     "extensions": [
       {
@@ -1893,18 +1358,9 @@
     "id": 59,
     "conceptType": "Drug",
     "name": "Cyclophosphamide",
-    "primaryCode": "ncit:C405",
+    "primaryCoding": "ncit:C405",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C405",
-          "code": "C405",
-          "name": "Cyclophosphamide",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      385
     ],
     "extensions": [
       {
@@ -1925,18 +1381,9 @@
     "id": 60,
     "conceptType": "Drug",
     "name": "Rituximab",
-    "primaryCode": "ncit:C1702",
+    "primaryCoding": "ncit:C1702",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C1702",
-          "code": "C1702",
-          "name": "Rituximab",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      386
     ],
     "extensions": [
       {
@@ -1957,18 +1404,9 @@
     "id": 61,
     "conceptType": "Drug",
     "name": "Vincristine",
-    "primaryCode": "ncit:C933",
+    "primaryCoding": "ncit:C933",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C933",
-          "code": "C933",
-          "name": "Vincristine",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      387
     ],
     "extensions": [
       {
@@ -1989,18 +1427,9 @@
     "id": 62,
     "conceptType": "Drug",
     "name": "Corticosteroid",
-    "primaryCode": "ncit:C2322",
+    "primaryCoding": "ncit:C2322",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C2322",
-          "code": "C2322",
-          "name": "Corticosteroid",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      388
     ],
     "extensions": [
       {
@@ -2021,18 +1450,9 @@
     "id": 63,
     "conceptType": "Drug",
     "name": "Cytarabine",
-    "primaryCode": "ncit:C408",
+    "primaryCoding": "ncit:C408",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C408",
-          "code": "C408",
-          "name": "Cytarabine",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      389
     ],
     "extensions": [
       {
@@ -2053,18 +1473,9 @@
     "id": 64,
     "conceptType": "Drug",
     "name": "Etoposide",
-    "primaryCode": "ncit:C491",
+    "primaryCoding": "ncit:C491",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C491",
-          "code": "C491",
-          "name": "Etoposide",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      390
     ],
     "extensions": [
       {
@@ -2085,18 +1496,9 @@
     "id": 65,
     "conceptType": "Drug",
     "name": "Methotrexate",
-    "primaryCode": "ncit:C642",
+    "primaryCoding": "ncit:C642",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C642",
-          "code": "C642",
-          "name": "Methotrexate",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      391
     ],
     "extensions": [
       {
@@ -2117,18 +1519,9 @@
     "id": 66,
     "conceptType": "Drug",
     "name": "Trametinib",
-    "primaryCode": "ncit:C77908",
+    "primaryCoding": "ncit:C77908",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C77908",
-          "code": "C77908",
-          "name": "Trametinib",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      392
     ],
     "extensions": [
       {
@@ -2149,18 +1542,9 @@
     "id": 67,
     "conceptType": "Drug",
     "name": "Dabrafenib",
-    "primaryCode": "ncit:C82386",
+    "primaryCoding": "ncit:C82386",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C82386",
-          "code": "C82386",
-          "name": "Dabrafenib",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      393
     ],
     "extensions": [
       {
@@ -2181,18 +1565,9 @@
     "id": 68,
     "conceptType": "Drug",
     "name": "Daunorubicin",
-    "primaryCode": "ncit:C62091",
+    "primaryCoding": "ncit:C62091",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C62091",
-          "code": "C62091",
-          "name": "Daunorubicin",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      394
     ],
     "extensions": [
       {
@@ -2213,18 +1588,9 @@
     "id": 69,
     "conceptType": "Drug",
     "name": "Gemtuzumab ozogamicin",
-    "primaryCode": "ncit:C1806",
+    "primaryCoding": "ncit:C1806",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C1806",
-          "code": "C1806",
-          "name": "Gemtuzumab Ozogamicin",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      395
     ],
     "extensions": [
       {
@@ -2245,19 +1611,8 @@
     "id": 70,
     "conceptType": "Drug",
     "name": "Neratinib",
-    "primaryCode": "ncit:C49094",
-    "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C49094",
-          "code": "C49094",
-          "name": "Neratinib",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
-    ],
+    "primaryCoding": "ncit:C49094",
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -2277,18 +1632,9 @@
     "id": 71,
     "conceptType": "Drug",
     "name": "Ipilimumab",
-    "primaryCode": "ncit:C2654",
+    "primaryCoding": "ncit:C2654",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C2654",
-          "code": "C2654",
-          "name": "Ipilimumab",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      397
     ],
     "extensions": [
       {
@@ -2309,18 +1655,9 @@
     "id": 72,
     "conceptType": "Drug",
     "name": "Nivolumab",
-    "primaryCode": "ncit:C68814",
+    "primaryCoding": "ncit:C68814",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C68814",
-          "code": "C68814",
-          "name": "Nivolumab",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      398
     ],
     "extensions": [
       {
@@ -2341,18 +1678,9 @@
     "id": 73,
     "conceptType": "Drug",
     "name": "Relatlimab",
-    "primaryCode": "ncit:C111999",
+    "primaryCoding": "ncit:C111999",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C111999",
-          "code": "C111999",
-          "name": "Relatlimab",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      399
     ],
     "extensions": [
       {
@@ -2373,18 +1701,9 @@
     "id": 74,
     "conceptType": "Drug",
     "name": "Elacestrant",
-    "primaryCode": "ncit:C120211",
+    "primaryCoding": "ncit:C120211",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C120211",
-          "code": "C120211",
-          "name": "Elacestrant",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      400
     ],
     "extensions": [
       {
@@ -2405,18 +1724,9 @@
     "id": 75,
     "conceptType": "Drug",
     "name": "Pertuzumab",
-    "primaryCode": "ncit:C38692",
+    "primaryCoding": "ncit:C38692",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C38692",
-          "code": "C38692",
-          "name": "Pertuzumab",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      401
     ],
     "extensions": [
       {
@@ -2437,18 +1747,9 @@
     "id": 76,
     "conceptType": "Drug",
     "name": "Epirubicin",
-    "primaryCode": "ncit:C62028",
+    "primaryCoding": "ncit:C62028",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C62028",
-          "code": "C62028",
-          "name": "Epirubicin",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      402
     ],
     "extensions": [
       {
@@ -2469,18 +1770,9 @@
     "id": 77,
     "conceptType": "Drug",
     "name": "Alpelisib",
-    "primaryCode": "ncit:C94214",
+    "primaryCoding": "ncit:C94214",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C94214",
-          "code": "C94214",
-          "name": "Alpelisib",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      403
     ],
     "extensions": [
       {
@@ -2501,18 +1793,9 @@
     "id": 78,
     "conceptType": "Drug",
     "name": "Selpercatinib",
-    "primaryCode": "ncit:C134987",
+    "primaryCoding": "ncit:C134987",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C134987",
-          "code": "C134987",
-          "name": "Selpercatinib",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      404
     ],
     "extensions": [
       {
@@ -2533,18 +1816,9 @@
     "id": 79,
     "conceptType": "Drug",
     "name": "Lenalidomide",
-    "primaryCode": "ncit:C2668",
+    "primaryCoding": "ncit:C2668",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C2668",
-          "code": "C2668",
-          "name": "Lenalidomide",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      405
     ],
     "extensions": [
       {
@@ -2565,18 +1839,9 @@
     "id": 80,
     "conceptType": "Drug",
     "name": "Entrectinib",
-    "primaryCode": "ncit:C114984",
+    "primaryCoding": "ncit:C114984",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C114984",
-          "code": "C114984",
-          "name": "Entrectinib",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      406
     ],
     "extensions": [
       {
@@ -2599,19 +1864,8 @@
     "id": 81,
     "conceptType": "Drug",
     "name": "",
-    "primaryCode": "ncit:",
-    "mappings": [
-      {
-        "coding": {
-          "id": "ncit:",
-          "code": "",
-          "name": "",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
-    ],
+    "primaryCoding": "ncit:",
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -2631,18 +1885,9 @@
     "id": 82,
     "conceptType": "Drug",
     "name": "Midostaurin",
-    "primaryCode": "ncit:C1872",
+    "primaryCoding": "ncit:C1872",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C1872",
-          "code": "C1872",
-          "name": "Midostaurin",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      408
     ],
     "extensions": [
       {
@@ -2663,18 +1908,9 @@
     "id": 83,
     "conceptType": "Drug",
     "name": "Asciminib",
-    "primaryCode": "ncit:C114494",
+    "primaryCoding": "ncit:C114494",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C114494",
-          "code": "C114494",
-          "name": "Asciminib",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      409
     ],
     "extensions": [
       {
@@ -2695,18 +1931,9 @@
     "id": 84,
     "conceptType": "Drug",
     "name": "Dasatinib",
-    "primaryCode": "ncit:C38713",
+    "primaryCoding": "ncit:C38713",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C38713",
-          "code": "C38713",
-          "name": "Dasatinib",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      410
     ],
     "extensions": [
       {
@@ -2727,18 +1954,9 @@
     "id": 85,
     "conceptType": "Drug",
     "name": "Capmatinib",
-    "primaryCode": "ncit:C90564",
+    "primaryCoding": "ncit:C90564",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C90564",
-          "code": "C90564",
-          "name": "Capmatinib",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      411
     ],
     "extensions": [
       {
@@ -2759,18 +1977,9 @@
     "id": 86,
     "conceptType": "Drug",
     "name": "Osimertinib",
-    "primaryCode": "ncit:C116377",
+    "primaryCoding": "ncit:C116377",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C116377",
-          "code": "C116377",
-          "name": "Osimertinib",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      412
     ],
     "extensions": [
       {
@@ -2791,18 +2000,9 @@
     "id": 87,
     "conceptType": "Drug",
     "name": "Talazoparib",
-    "primaryCode": "ncit:C95733",
+    "primaryCoding": "ncit:C95733",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C95733",
-          "code": "C95733",
-          "name": "Talazoparib",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      413
     ],
     "extensions": [
       {
@@ -2823,18 +2023,9 @@
     "id": 88,
     "conceptType": "Drug",
     "name": "Nilotinib",
-    "primaryCode": "ncit:C48375",
+    "primaryCoding": "ncit:C48375",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C48375",
-          "code": "C48375",
-          "name": "Nilotinib",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      414
     ],
     "extensions": [
       {
@@ -2855,18 +2046,9 @@
     "id": 89,
     "conceptType": "Drug",
     "name": "Atezolizumab",
-    "primaryCode": "ncit:C106250",
+    "primaryCoding": "ncit:C106250",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C106250",
-          "code": "C106250",
-          "name": "Atezolizumab",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      415
     ],
     "extensions": [
       {
@@ -2887,18 +2069,9 @@
     "id": 90,
     "conceptType": "Drug",
     "name": "Tepotinib",
-    "primaryCode": "ncit:C88314",
+    "primaryCoding": "ncit:C88314",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C88314",
-          "code": "C88314",
-          "name": "Tepotinib",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      416
     ],
     "extensions": [
       {
@@ -2919,18 +2092,9 @@
     "id": 91,
     "conceptType": "Drug",
     "name": "Azacitidine",
-    "primaryCode": "ncit:C288",
+    "primaryCoding": "ncit:C288",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C288",
-          "code": "C288",
-          "name": "Azacitidine",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      417
     ],
     "extensions": [
       {
@@ -2951,18 +2115,9 @@
     "id": 92,
     "conceptType": "Drug",
     "name": "Ivosidenib",
-    "primaryCode": "ncit:C114383",
+    "primaryCoding": "ncit:C114383",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C114383",
-          "code": "C114383",
-          "name": "Ivosidenib",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      418
     ],
     "extensions": [
       {
@@ -2983,18 +2138,9 @@
     "id": 93,
     "conceptType": "Drug",
     "name": "Arsenic trioxide",
-    "primaryCode": "ncit:C1005",
+    "primaryCoding": "ncit:C1005",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C1005",
-          "code": "C1005",
-          "name": "Arsenic Trioxide",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      419
     ],
     "extensions": [
       {
@@ -3015,18 +2161,9 @@
     "id": 94,
     "conceptType": "Drug",
     "name": "Sacituzumab govitecan",
-    "primaryCode": "ncit:C102783",
+    "primaryCoding": "ncit:C102783",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C102783",
-          "code": "C102783",
-          "name": "Sacituzumab Govitecan",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      420
     ],
     "extensions": [
       {
@@ -3047,18 +2184,9 @@
     "id": 95,
     "conceptType": "Drug",
     "name": "Tucatinib",
-    "primaryCode": "ncit:C77896",
+    "primaryCoding": "ncit:C77896",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C77896",
-          "code": "C77896",
-          "name": "Tucatinib",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      421
     ],
     "extensions": [
       {
@@ -3079,18 +2207,9 @@
     "id": 96,
     "conceptType": "Drug",
     "name": "Lapatinib",
-    "primaryCode": "ncit:C26653",
+    "primaryCoding": "ncit:C26653",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C26653",
-          "code": "C26653",
-          "name": "Lapatinib",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      422
     ],
     "extensions": [
       {
@@ -3111,18 +2230,9 @@
     "id": 97,
     "conceptType": "Drug",
     "name": "Panitumumab",
-    "primaryCode": "ncit:C1857",
+    "primaryCoding": "ncit:C1857",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C1857",
-          "code": "C1857",
-          "name": "Panitumumab",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      423
     ],
     "extensions": [
       {
@@ -3143,18 +2253,9 @@
     "id": 98,
     "conceptType": "Drug",
     "name": "Venetoclax",
-    "primaryCode": "ncit:C103147",
+    "primaryCoding": "ncit:C103147",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C103147",
-          "code": "C103147",
-          "name": "Venetoclax",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      424
     ],
     "extensions": [
       {
@@ -3175,18 +2276,9 @@
     "id": 99,
     "conceptType": "Drug",
     "name": "Abemaciclib",
-    "primaryCode": "ncit:C97660",
+    "primaryCoding": "ncit:C97660",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C97660",
-          "code": "C97660",
-          "name": "Abemaciclib",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      425
     ],
     "extensions": [
       {
@@ -3207,18 +2299,9 @@
     "id": 100,
     "conceptType": "Drug",
     "name": "Larotrectinib",
-    "primaryCode": "ncit:C115977",
+    "primaryCoding": "ncit:C115977",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C115977",
-          "code": "C115977",
-          "name": "Larotrectinib",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      426
     ],
     "extensions": [
       {
@@ -3239,18 +2322,9 @@
     "id": 101,
     "conceptType": "Drug",
     "name": "Dacomitinib",
-    "primaryCode": "ncit:C53398",
+    "primaryCoding": "ncit:C53398",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C53398",
-          "code": "C53398",
-          "name": "Dacomitinib",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      427
     ],
     "extensions": [
       {
@@ -3271,18 +2345,9 @@
     "id": 102,
     "conceptType": "Drug",
     "name": "Crizotinib",
-    "primaryCode": "ncit:C74061",
+    "primaryCoding": "ncit:C74061",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C74061",
-          "code": "C74061",
-          "name": "Crizotinib",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      428
     ],
     "extensions": [
       {
@@ -3305,19 +2370,8 @@
     "id": 103,
     "conceptType": "Drug",
     "name": "",
-    "primaryCode": "ncit:",
-    "mappings": [
-      {
-        "coding": {
-          "id": "ncit:",
-          "code": "",
-          "name": "",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
-    ],
+    "primaryCoding": "ncit:",
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -3337,18 +2391,9 @@
     "id": 104,
     "conceptType": "Drug",
     "name": "Gilteritinib",
-    "primaryCode": "ncit:C116722",
+    "primaryCoding": "ncit:C116722",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C116722",
-          "code": "C116722",
-          "name": "Gilteritinib",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      430
     ],
     "extensions": [
       {
@@ -3369,18 +2414,9 @@
     "id": 105,
     "conceptType": "Drug",
     "name": "Idelalisib",
-    "primaryCode": "ncit:C78825",
+    "primaryCoding": "ncit:C78825",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C78825",
-          "code": "C78825",
-          "name": "Idelalisib",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      431
     ],
     "extensions": [
       {
@@ -3401,18 +2437,9 @@
     "id": 106,
     "conceptType": "Drug",
     "name": "Ceritinib",
-    "primaryCode": "ncit:C115112",
+    "primaryCoding": "ncit:C115112",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C115112",
-          "code": "C115112",
-          "name": "Ceritinib",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      432
     ],
     "extensions": [
       {
@@ -3433,18 +2460,9 @@
     "id": 107,
     "conceptType": "Drug",
     "name": "Tislelizumab",
-    "primaryCode": "ncit:C121775",
+    "primaryCoding": "ncit:C121775",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C121775",
-          "code": "C121775",
-          "name": "Tislelizumab",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      433
     ],
     "extensions": [
       {
@@ -3465,18 +2483,9 @@
     "id": 108,
     "conceptType": "Drug",
     "name": "Amivantamab",
-    "primaryCode": "ncit:C124993",
+    "primaryCoding": "ncit:C124993",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C124993",
-          "code": "C124993",
-          "name": "Amivantamab",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      434
     ],
     "extensions": [
       {
@@ -3497,18 +2506,9 @@
     "id": 109,
     "conceptType": "Drug",
     "name": "Capivasertib",
-    "primaryCode": "ncit:C102564",
+    "primaryCoding": "ncit:C102564",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C102564",
-          "code": "C102564",
-          "name": "Capivasertib",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      435
     ],
     "extensions": [
       {
@@ -3529,18 +2529,9 @@
     "id": 110,
     "conceptType": "Drug",
     "name": "Erdafitinib",
-    "primaryCode": "ncit:C103273",
+    "primaryCoding": "ncit:C103273",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C103273",
-          "code": "C103273",
-          "name": "Erdafitinib",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      436
     ],
     "extensions": [
       {
@@ -3561,18 +2552,9 @@
     "id": 111,
     "conceptType": "Drug",
     "name": "Zolbetuximab",
-    "primaryCode": "ncit:C85475",
+    "primaryCoding": "ncit:C85475",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C85475",
-          "code": "C85475",
-          "name": "Zolbetuximab",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      437
     ],
     "extensions": [
       {
@@ -3593,19 +2575,8 @@
     "id": 112,
     "conceptType": "Drug",
     "name": "Neratinib",
-    "primaryCode": "ncit:C49094",
-    "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C49094",
-          "code": "C49094",
-          "name": "Neratinib",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
-    ],
+    "primaryCoding": "ncit:C49094",
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
@@ -3625,18 +2596,9 @@
     "id": 113,
     "conceptType": "Drug",
     "name": "Zanubrutinib",
-    "primaryCode": "ncit:C141428",
+    "primaryCoding": "ncit:C141428",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C141428",
-          "code": "C141428",
-          "name": "Zanubrutinib",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      439
     ],
     "extensions": [
       {
@@ -3657,18 +2619,9 @@
     "id": 114,
     "conceptType": "Drug",
     "name": "Acalabrutinib",
-    "primaryCode": "ncit:C113442",
+    "primaryCoding": "ncit:C113442",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C113442",
-          "code": "C113442",
-          "name": "Acalabrutinib",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      440
     ],
     "extensions": [
       {
@@ -3689,18 +2642,9 @@
     "id": 115,
     "conceptType": "Drug",
     "name": "Ibrutinib",
-    "primaryCode": "ncit:C81934",
+    "primaryCoding": "ncit:C81934",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C81934",
-          "code": "C81934",
-          "name": "Ibrutinib",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      441
     ],
     "extensions": [
       {
@@ -3721,18 +2665,9 @@
     "id": 116,
     "conceptType": "Drug",
     "name": "Ifosfamide",
-    "primaryCode": "ncit:C564",
+    "primaryCoding": "ncit:C564",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C564",
-          "code": "C564",
-          "name": "Ifosfamide",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      442
     ],
     "extensions": [
       {
@@ -3753,18 +2688,9 @@
     "id": 117,
     "conceptType": "Drug",
     "name": "Vinorelbine",
-    "primaryCode": "ncit:C1275",
+    "primaryCoding": "ncit:C1275",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C1275",
-          "code": "C1275",
-          "name": "Vinorelbine",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      443
     ],
     "extensions": [
       {
@@ -3785,25 +2711,12 @@
     "id": 118,
     "conceptType": "Drug",
     "name": "",
-    "primaryCode": "ncit:",
-    "mappings": [
-      {
-        "coding": {
-          "id": "ncit:",
-          "code": "",
-          "name": "",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
-    ],
+    "primaryCoding": "ncit:",
+    "mappings": [],
     "extensions": [
       {
         "name": "therapy_strategy",
-        "value": [
-
-        ],
+        "value": [],
         "description": "Associated therapeutic strategy or mechanism of action of the therapy."
       },
       {
@@ -3817,18 +2730,9 @@
     "id": 119,
     "conceptType": "Drug",
     "name": "Tamoxifen",
-    "primaryCode": "ncit:C62078",
+    "primaryCoding": "ncit:C62078",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C62078",
-          "code": "C62078",
-          "name": "Tamoxifen",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      445
     ],
     "extensions": [
       {
@@ -3849,18 +2753,9 @@
     "id": 120,
     "conceptType": "Drug",
     "name": "Ofatumumab",
-    "primaryCode": "ncit:C66952",
+    "primaryCoding": "ncit:C66952",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C66952",
-          "code": "C66952",
-          "name": "Ofatumumab",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      446
     ],
     "extensions": [
       {
@@ -3881,18 +2776,9 @@
     "id": 121,
     "conceptType": "Drug",
     "name": "Bendamustine",
-    "primaryCode": "ncit:C73261",
+    "primaryCoding": "ncit:C73261",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C73261",
-          "code": "C73261",
-          "name": "Bendamustine",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      447
     ],
     "extensions": [
       {
@@ -3913,18 +2799,9 @@
     "id": 122,
     "conceptType": "Drug",
     "name": "Prednisone",
-    "primaryCode": "ncit:C770",
+    "primaryCoding": "ncit:C770",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C770",
-          "code": "C770",
-          "name": "Prednisone",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      448
     ],
     "extensions": [
       {
@@ -3945,18 +2822,9 @@
     "id": 123,
     "conceptType": "Drug",
     "name": "Chlorambucil",
-    "primaryCode": "ncit:C362",
+    "primaryCoding": "ncit:C362",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C362",
-          "code": "C362",
-          "name": "Chlorambucil",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      449
     ],
     "extensions": [
       {
@@ -3977,18 +2845,9 @@
     "id": 124,
     "conceptType": "Drug",
     "name": "Mitoxantrone",
-    "primaryCode": "ncit:C62050",
+    "primaryCoding": "ncit:C62050",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C62050",
-          "code": "C62050",
-          "name": "Mitoxantrone",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      450
     ],
     "extensions": [
       {
@@ -4009,18 +2868,9 @@
     "id": 125,
     "conceptType": "Drug",
     "name": "Interferon Alpha",
-    "primaryCode": "ncit:C20494",
+    "primaryCoding": "ncit:C20494",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C20494",
-          "code": "C20494",
-          "name": "Interferon Alpha",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      451
     ],
     "extensions": [
       {
@@ -4041,18 +2891,9 @@
     "id": 126,
     "conceptType": "Drug",
     "name": "Enasidenib",
-    "primaryCode": "ncit:C111573",
+    "primaryCoding": "ncit:C111573",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C111573",
-          "code": "C111573",
-          "name": "Enasidenib",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      452
     ],
     "extensions": [
       {
@@ -4073,18 +2914,9 @@
     "id": 127,
     "conceptType": "Drug",
     "name": "Infigratinib",
-    "primaryCode": "ncit:C88302",
+    "primaryCoding": "ncit:C88302",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C88302",
-          "code": "C88302",
-          "name": "Infigratinib",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      453
     ],
     "extensions": [
       {
@@ -4105,18 +2937,9 @@
     "id": 128,
     "conceptType": "Drug",
     "name": "Margetuximab",
-    "primaryCode": "ncit:",
+    "primaryCoding": "ncit:",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C91733",
-          "code": "C91733",
-          "name": "Margetuximab",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      454
     ],
     "extensions": [
       {
@@ -4137,18 +2960,9 @@
     "id": 129,
     "conceptType": "Drug",
     "name": "Eribulin",
-    "primaryCode": "ncit:C96748",
+    "primaryCoding": "ncit:C96748",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C96748",
-          "code": "C96748",
-          "name": "Eribulin",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      455
     ],
     "extensions": [
       {
@@ -4169,18 +2983,9 @@
     "id": 130,
     "conceptType": "Drug",
     "name": "Mobocertinib",
-    "primaryCode": "ncit:C126752",
+    "primaryCoding": "ncit:C126752",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C126752",
-          "code": "C126752",
-          "name": "Mobocertinib",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      456
     ],
     "extensions": [
       {
@@ -4201,18 +3006,9 @@
     "id": 131,
     "conceptType": "Drug",
     "name": "Olutasidenib",
-    "primaryCode": "ncit:C129687",
+    "primaryCoding": "ncit:C129687",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C129687",
-          "code": "C129687",
-          "name": "Olutasidenib",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      457
     ],
     "extensions": [
       {
@@ -4233,18 +3029,9 @@
     "id": 132,
     "conceptType": "Drug",
     "name": "Lenvatinib",
-    "primaryCode": "ncit:C95124",
+    "primaryCoding": "ncit:C95124",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C95124",
-          "code": "C95124",
-          "name": "Lenvatinib",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      458
     ],
     "extensions": [
       {
@@ -4265,18 +3052,9 @@
     "id": 133,
     "conceptType": "Drug",
     "name": "Pemigatinib",
-    "primaryCode": "ncit:C121553",
+    "primaryCoding": "ncit:C121553",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C121553",
-          "code": "C121553",
-          "name": "Pemigatinib",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      459
     ],
     "extensions": [
       {
@@ -4297,18 +3075,9 @@
     "id": 134,
     "conceptType": "Drug",
     "name": "Repotrectinib",
-    "primaryCode": "ncit:C133821",
+    "primaryCoding": "ncit:C133821",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C133821",
-          "code": "C133821",
-          "name": "Repotrectinib",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      460
     ],
     "extensions": [
       {
@@ -4329,18 +3098,9 @@
     "id": 135,
     "conceptType": "Drug",
     "name": "Fludarabine",
-    "primaryCode": "ncit:C1094",
+    "primaryCoding": "ncit:C1094",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C1094",
-          "code": "C1094",
-          "name": "Fludarabine",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      461
     ],
     "extensions": [
       {
@@ -4361,18 +3121,9 @@
     "id": 136,
     "conceptType": "Drug",
     "name": "Rucaparib",
-    "primaryCode": "ncit:C137800",
+    "primaryCoding": "ncit:C137800",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C137800",
-          "code": "C137800",
-          "name": "Rucaparib",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      462
     ],
     "extensions": [
       {
@@ -4393,18 +3144,9 @@
     "id": 137,
     "conceptType": "Drug",
     "name": "Tazemetostat",
-    "primaryCode": "ncit:C107506",
+    "primaryCoding": "ncit:C107506",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C107506",
-          "code": "C107506",
-          "name": "Tazemetostat",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      463
     ],
     "extensions": [
       {
@@ -4425,18 +3167,9 @@
     "id": 138,
     "conceptType": "Drug",
     "name": "Enzalutamide",
-    "primaryCode": "ncit:C71744",
+    "primaryCoding": "ncit:C71744",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C71744",
-          "code": "C71744",
-          "name": "Enzalutamide",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      464
     ],
     "extensions": [
       {
@@ -4457,18 +3190,9 @@
     "id": 139,
     "conceptType": "Drug",
     "name": "Lazertinib",
-    "primaryCode": "ncit:C148147",
+    "primaryCoding": "ncit:C148147",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C148147",
-          "code": "C148147",
-          "name": "Lazertinib",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      465
     ],
     "extensions": [
       {
@@ -4489,18 +3213,9 @@
     "id": 140,
     "conceptType": "Drug",
     "name": "Mirvetuximab soravtansine",
-    "primaryCode": "ncit:C102566",
+    "primaryCoding": "ncit:C102566",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C102566",
-          "code": "C102566",
-          "name": "Mirvetuximab Soravtansine",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      466
     ],
     "extensions": [
       {
@@ -4521,18 +3236,9 @@
     "id": 141,
     "conceptType": "Drug",
     "name": "Tovorafenib",
-    "primaryCode": "ncit:C106254",
+    "primaryCoding": "ncit:C106254",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C106254",
-          "code": "C106254",
-          "name": "Tovorafenib",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      467
     ],
     "extensions": [
       {
@@ -4553,18 +3259,9 @@
     "id": 142,
     "conceptType": "Drug",
     "name": "Vorasidenib",
-    "primaryCode": "ncit:C152914",
+    "primaryCoding": "ncit:C152914",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C152914",
-          "code": "C152914",
-          "name": "Vorasidenib",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      468
     ],
     "extensions": [
       {
@@ -4585,18 +3282,9 @@
     "id": 143,
     "conceptType": "Drug",
     "name": "Goserelin",
-    "primaryCode": "ncit:C1374",
+    "primaryCoding": "ncit:C1374",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C1374",
-          "code": "C1374",
-          "name": "Goserelin",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      469
     ],
     "extensions": [
       {
@@ -4617,18 +3305,9 @@
     "id": 144,
     "conceptType": "Drug",
     "name": "Inavolisib",
-    "primaryCode": "ncit:C132166",
+    "primaryCoding": "ncit:C132166",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C132166",
-          "code": "C132166",
-          "name": "Inavolisib",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      470
     ],
     "extensions": [
       {
@@ -4649,18 +3328,9 @@
     "id": 145,
     "conceptType": "Drug",
     "name": "Zanidatamab",
-    "primaryCode": "ncit:C130010",
+    "primaryCoding": "ncit:C130010",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C130010",
-          "code": "C130010",
-          "name": "Zanidatamab",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      471
     ],
     "extensions": [
       {
@@ -4681,18 +3351,9 @@
     "id": 146,
     "conceptType": "Drug",
     "name": "Zenocutuzumab",
-    "primaryCode": "ncit:C152948",
+    "primaryCoding": "ncit:C152948",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C152948",
-          "code": "C152948",
-          "name": "Zenocutuzumab",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      472
     ],
     "extensions": [
       {
@@ -4713,18 +3374,9 @@
     "id": 147,
     "conceptType": "Drug",
     "name": "Ensartinib",
-    "primaryCode": "ncit:C102754",
+    "primaryCoding": "ncit:C102754",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C102754",
-          "code": "C102754",
-          "name": "Ensartinib",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      473
     ],
     "extensions": [
       {
@@ -4745,18 +3397,9 @@
     "id": 148,
     "conceptType": "Drug",
     "name": "Revumenib",
-    "primaryCode": "ncit:C165776",
+    "primaryCoding": "ncit:C165776",
     "mappings": [
-      {
-        "coding": {
-          "id": "ncit:C165776",
-          "code": "C165776",
-          "name": "Revumenib",
-          "system": "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/",
-          "systemVersion": "25.01d"
-        },
-        "relation": "exactMatch"
-      }
+      474
     ],
     "extensions": [
       {

--- a/utils/README.md
+++ b/utils/README.md
@@ -19,14 +19,17 @@ Optional arguments:
     --about           <string>    referenced JSON for database metadata. Default: referenced/about.json
     --agents          <string>    referenced JSON for agents contribution to database. Default: referenced/agents.json
     --biomarkers      <string>    referenced JSON for biomarkers. Default: referenced/biomarkers.json
+    --codings         <string>    referenced JSON for codings. Default: referenced/codings.json
     --contributions   <string>    referenced JSON for contributions to database. Default: referenced/contributions.json
     --diseases        <string>    referenced JSON for cancer types. Default: referenced/diseases.json
     --documents       <string>    referenced JSON for documents cited in the database. Default: referenced/documents.json
     --genes           <string>    referenced JSON for genes associated with biomarkers. Default: referenced/genes.json
     --indications     <string>    referenced JSON for regulatory approvals for use or reimbursement. Default: referenced/indications.json
+    --mappings        <string>    referenced JSON for mappings. Default: referenced/mappings.json
     --organizations   <string>    referenced JSON for organizations that publish documents cited within the database. Default: referenced/organizations.json
     --propositions    <string>    referenced JSON for propositions. Default: referenced/propositions.json
     --statements      <string>    referenced JSON for statements. Default: referenced/statements.json
+    --strengths       <string>    referenced JSON for strengths. Default: referenced/strengths.json
     --therapies       <string>    referenced JSON for therapies. Default: referenced/therapies.json
     --therapy-groups  <string>    referenced JSON for therapy groups. Default: referenced/therapy_groups.json
     --output          <string>    file path for dereferenced JSON output by this script. Default: moalmanac-draft.dereferenced.json
@@ -38,14 +41,17 @@ python dereference.py \
   --about referenced/about.json \
   --agents referenced/agents.json \
   --biomarkers referenced/biomarkers.json \
+  --codings referenced/codings.json \
   --contributions referenced/contributions.json \
   --diseases referenced/diseases.json \
   --documents referenced/documents.json \
   --genes referenced/genes.json \
   --indications referenced/indications.json \
+  --mappings referenced/mappings.json \
   --organizations referenced/organizations.json \
   --propositions referenced/propositions.json \
   --statements referenced/statements.json \
+  --strengths referenced/strengths.json \
   --therapies referenced/therapies.json \
   --therapy-groups referenced/therapy-groups.json \
   --output  moalmanac-draft.dereferenced.json

--- a/utils/dereference.py
+++ b/utils/dereference.py
@@ -131,8 +131,25 @@ class Biomarkers(BaseTable):
         records (list[dict]): A list of dictionaries representing the biomarker records.
     """
 
-    def dereference(self, genes: 'Genes') -> None:
-        """Dereference all keys for this table."""
+    def dereference(self, genes: 'Genes', resolve_dependencies=True, codings: 'Codings'=None, mappings: 'Mappings'=None) -> None:
+        """
+        Dereferences all referenced keys within the Genes table and optionally resolves dependencies
+        within these related tables.
+
+        Calls functions within this class to replace references with actual data from the referenced tables.
+        If `resolve_dependencies` is set to True and the dependent table(s) are provided, it will also ensure that
+        references are also fully dereferenced by utilizing the `dereference` function from their respective classes.
+
+        Args:
+            genes (Genes): An instance of the Genes class representing the genes table.
+            resolve_dependencies (bool): If `True`, resolve dependencies within referenced tables.
+            codings (Codings): An instance of the Codings class representing the codings table.
+            mappings (Mappings): An instance of the Mappings class representing the mappings table.
+        """
+        if resolve_dependencies:
+            if codings and mappings:
+                genes.dereference(codings=codings, mappings=mappings, resolve_dependencies=True)
+
         self.dereference_genes(genes=genes)
 
     def dereference_genes(self, genes: 'Genes') -> None:
@@ -175,7 +192,12 @@ class Contributions(BaseTable):
         records (list[dict]): A list of dictionaries representing the contribution records.
     """
     def dereference(self, agents: 'Agents') -> None:
-        """Dereference all keys for this table."""
+        """
+        Dereferences all referenced keys within the Contributions table.
+
+        Args:
+            agents (Agents): An instance of the Agents class representing the agents table.
+        """
         self.dereference_agents(agents=agents)
 
     def dereference_agents(self, agents: 'Agents') -> None:
@@ -209,13 +231,31 @@ class Diseases(BaseTable):
     Represents the Diseases table. This class inherits common functionality from the BaseTable class and
     dereferences keys that reference other tables. This table references the following tables:
     - Codings (initial key: `primary_coding_id`, resulting_key: `primaryCoding`)
+    - Mappings (initial key: `mappings`, resulting_key: `mappings`)
 
     Attributes:
         records (list[dict]): A list of dictionaries representing the therapy records.
     """
 
-    def dereference(self, codings: 'Codings') -> None:
+    def dereference(self, codings: 'Codings', mappings: 'Mappings', resolve_dependencies=True) -> None:
+        """
+        Dereferences all referenced keys within the Diseases table and optionally resolves dependencies
+        within these related tables.
+
+        Calls functions within this class to replace references with actual data from the referenced tables.
+        If `resolve_dependencies` is set to True and the dependent table(s) are provided, it will also ensure that
+        references are also fully dereferenced by utilizing the `dereference` function from their respective classes.
+
+        Args:
+            codings (Codings): An instance of the Codings class representing the codings table.
+            mappings (Mappings): An instance of the Mappings class representing the mappings table.
+            resolve_dependencies (bool): If `True`, resolve dependencies within referenced tables.
+        """
+        if resolve_dependencies:
+            mappings.dereference(codings=codings)
+
         self.dereference_codings(codings=codings)
+        self.dereference_mappings(mappings=mappings)
 
     def dereference_codings(self, codings: 'Codings') -> None:
         """
@@ -243,6 +283,28 @@ class Diseases(BaseTable):
                 new_key='primaryCoding'
             )
 
+    def dereference_mappings(self, mappings: 'Mappings') -> None:
+        """
+        Dereferences the `mappings` key in each gene record.
+
+        Utilizes the `dereference_list` function from the BaseTable class to replace the value associated with the
+        `mappings` key within each record. This key is expected to be present within each record, so a
+        KeyError will be raised if it is missing.
+
+        Args:
+            mappings (Mappings): An instance of the Mappings class representing the mappings table.
+
+        Raises:
+            KeyError: If the referenced_key, `mappings`, is not found in a record.
+        """
+        for record in self.records:
+            self.dereference_list(
+                record=record,
+                referenced_key='mappings',
+                referenced_records=mappings.records,
+                key_always_present=True
+            )
+
 class Documents(BaseTable):
     """
     Represents the Documents table. This class inherits common functionality from the BaseTable class and
@@ -254,7 +316,12 @@ class Documents(BaseTable):
     """
 
     def dereference(self, organizations: 'Organizations') -> None:
-        """Dereference all keys for this table."""
+        """
+        Dereferences all referenced keys within the Diseases table.
+
+        Args:
+            organizations (Organizations): An instance of the Organizations class representing the organizations table.
+        """
         self.dereference_organizations(organizations=organizations)
 
     def dereference_organizations(self, organizations: 'Organizations') -> None:
@@ -288,13 +355,32 @@ class Genes(BaseTable):
     Represents the Genes table. This class inherits common functionality from the BaseTable class and
     dereferences keys that reference other tables. This table references the following tables:
     - Codings (initial key: `primary_coding_id`, resulting_key: `primaryCoding`)
+    - Mappings (initial key: `mappings`, resulting_key: `mappings`)
 
     Attributes:
         records (list[dict]): A list of dictionaries representing the therapy records.
     """
 
-    def dereference(self, codings: 'Codings') -> None:
+    def dereference(self, codings: 'Codings', mappings: 'Mappings', resolve_dependencies=True) -> None:
+        """
+        Dereferences all referenced keys within the Genes table and optionally resolves dependencies
+        within these related tables.
+
+        Calls functions within this class to replace references with actual data from the referenced tables.
+        If `resolve_dependencies` is set to True and the dependent table(s) are provided, it will also ensure that
+        references are also fully dereferenced by utilizing the `dereference` function from their respective classes.
+
+        Args:
+            codings (Codings): An instance of the Codings class representing the codings table.
+            mappings (Mappings): An instance of the Mappings class representing the mappings table.
+            resolve_dependencies (bool): If `True`, resolve dependencies within referenced tables.
+        """
+        if resolve_dependencies:
+            if codings and mappings:
+                mappings.dereference(codings=codings)
+
         self.dereference_codings(codings=codings)
+        self.dereference_mappings(mappings=mappings)
 
     def dereference_codings(self, codings: 'Codings') -> None:
         """
@@ -322,6 +408,28 @@ class Genes(BaseTable):
                 new_key='primaryCoding'
             )
 
+    def dereference_mappings(self, mappings: 'Mappings') -> None:
+        """
+        Dereferences the `mappings` key in each gene record.
+
+        Utilizes the `dereference_list` function from the BaseTable class to replace the value associated with the
+        `mappings` key within each record. This key is expected to be present within each record, so a
+        KeyError will be raised if it is missing.
+
+        Args:
+            mappings (Mappings): An instance of the Mappings class representing the mappings table.
+
+        Raises:
+            KeyError: If the referenced_key, `mappings`, is not found in a record.
+        """
+        for record in self.records:
+            self.dereference_list(
+                record=record,
+                referenced_key='mappings',
+                referenced_records=mappings.records,
+                key_always_present=True
+            )
+
 class Indications(BaseTable):
     """
     Represents the Indications table. This class inherits common functionality from the BaseTable class and
@@ -332,16 +440,29 @@ class Indications(BaseTable):
         records (list[dict]): A list of dictionaries representing the indication records.
     """
 
-    def dereference(self, documents: 'Documents', organizations: 'Organizations') -> None:
-        """Dereference all keys for this table."""
-        self.dereference_documents(documents=documents, organizations=organizations)
+    def dereference(self, documents: 'Documents', resolve_dependencies=True, organizations: 'Organizations'=None) -> None:
+        """
+        Dereferences all referenced keys within the Indications table and optionally resolves dependencies
+        within these related tables.
 
-    def dereference_documents(self, documents: 'Documents', organizations: 'Organizations') -> None:
+        Calls functions within this class to replace references with actual data from the referenced tables.
+        If `resolve_dependencies` is set to True and the dependent table(s) are provided, it will also ensure that
+        references are also fully dereferenced by utilizing the `dereference` function from their respective classes.
+
+        Args:
+            documents (Documents): An instance of the Documents class representing the documents table.
+            resolve_dependencies (bool): If `True`, resolve dependencies within referenced tables.
+            organizations (Organizations): An instance of the Organizations class representing the organizations table.
+        """
+        if resolve_dependencies:
+            if organizations:
+                documents.dereference(organizations=organizations)
+
+        self.dereference_documents(documents=documents)
+
+    def dereference_documents(self, documents: 'Documents') -> None:
         """
         Dereferences the `document_id` key in each indication record.
-
-        Utilizes the `dereference` function from the Documents class to ensure that each document record is
-        fully dereferenced.
 
         Utilizes the `dereference_single` function from the BaseTable class to replace the value associated with the
         `document_id` key within each record. This key is expected to be present within each record, so a
@@ -349,14 +470,10 @@ class Indications(BaseTable):
 
         Args:
             documents (Documents): An instance of the Documents class representing the documents table.
-            organizations (Organizations): An instance of the Organizations class representing the organizations table.
-            dereference_organizations (bool): If `dereference_organizations` is `True`, this function will dereference organizations.
 
         Raises:
             KeyError: If the referenced_key, `document_id`, is not found in a record.
         """
-        documents.dereference(organizations=organizations)
-
         for record in self.records:
             self.dereference_single(
                 record=record,
@@ -379,7 +496,16 @@ class Mappings(BaseTable):
         records (list[dict]): A list of dictionaries representing the contribution records.
     """
     def dereference(self, codings: 'Codings') -> None:
-        """Dereference all keys for this table."""
+        """
+        Dereferences all referenced keys within the Mappings table.
+
+        Calls functions within this class to replace references with actual data from the referenced tables.
+        If `resolve_dependencies` is set to True and the dependent table(s) are provided, it will also ensure that
+        references are also fully dereferenced by utilizing the `dereference` function from their respective classes.
+
+        Args:
+            codings (Codings): An instance of the Codings class representing the codings table.
+        """
         self.dereference_codings(codings=codings)
 
     def dereference_codings(self, codings: 'Codings') -> None:

--- a/utils/dereference.py
+++ b/utils/dereference.py
@@ -719,7 +719,7 @@ class Statements(BaseTable):
                 new_key='proposition'
             )
 
-    def dereference_strengths(self, strengths: 'Strengths'):
+    def dereference_strengths(self, strengths: 'Strengths') -> None:
         """
         Dereferences the `strength_id` key in each statement record.
 
@@ -833,7 +833,7 @@ class TherapyGroups(BaseTable):
         records (list[dict]): A list of dictionaries representing the therapy records.
     """
 
-    def dereference(self, therapies: 'Therapies'):
+    def dereference(self, therapies: 'Therapies') -> None:
         """Dereference all keys for this table."""
         self.dereference_therapies(therapies=therapies)
 

--- a/utils/dereference.py
+++ b/utils/dereference.py
@@ -154,6 +154,17 @@ class Biomarkers(BaseTable):
                 key_always_present=False
             )
 
+class Codings(BaseTable):
+    """
+        Represents the Codings table. This class inherits common functionality from the BaseTable class and
+        dereferences keys that reference other tables. This table does not currently reference any other tables.
+
+        Attributes:
+            records (list[dict]): A list of dictionaries representing the coding records.
+        """
+
+    pass
+
 class Contributions(BaseTable):
     """
     Represents the Contributions table. This class inherits common functionality from the BaseTable class and
@@ -196,13 +207,41 @@ class Contributions(BaseTable):
 class Diseases(BaseTable):
     """
     Represents the Diseases table. This class inherits common functionality from the BaseTable class and
-    dereferences keys that reference other tables. This table does not currently reference any other tables.
+    dereferences keys that reference other tables. This table references the following tables:
+    - Codings (initial key: `primary_coding_id`, resulting_key: `primaryCoding`)
 
     Attributes:
-        records (list[dict]): A list of dictionaries representing the disease records.
+        records (list[dict]): A list of dictionaries representing the therapy records.
     """
 
-    pass
+    def dereference(self, codings: 'Codings') -> None:
+        self.dereference_codings(codings=codings)
+
+    def dereference_codings(self, codings: 'Codings') -> None:
+        """
+        Dereferences the `primary_coding_id` key in each strength record.
+
+        Utilizes the `dereference_single` function from the BaseTable class to replace the value associated with the
+        `primary_coding_id` key within each record. This key is expected to be present within each record, so a
+        KeyError will be raised if it is missing.
+
+        Args:
+            codings (Codings): An instance of the Codings class representing the codings table.
+
+        Raises:
+            KeyError: If the referenced_key, `primary_coding_id`, is not found in a record.
+        """
+        for record in self.records:
+            self.dereference_single(
+                record=record,
+                referenced_key='primary_coding_id',
+                referenced_records=codings.records
+            )
+            self.replace_key(
+                record=record,
+                old_key='primary_coding_id',
+                new_key='primaryCoding'
+            )
 
 class Documents(BaseTable):
     """
@@ -247,13 +286,41 @@ class Documents(BaseTable):
 class Genes(BaseTable):
     """
     Represents the Genes table. This class inherits common functionality from the BaseTable class and
-    dereferences keys that reference other tables. This table does not currently reference any other tables.
+    dereferences keys that reference other tables. This table references the following tables:
+    - Codings (initial key: `primary_coding_id`, resulting_key: `primaryCoding`)
 
     Attributes:
-        records (list[dict]): A list of dictionaries representing the gene records.
+        records (list[dict]): A list of dictionaries representing the therapy records.
     """
 
-    pass
+    def dereference(self, codings: 'Codings') -> None:
+        self.dereference_codings(codings=codings)
+
+    def dereference_codings(self, codings: 'Codings') -> None:
+        """
+        Dereferences the `primary_coding_id` key in each strength record.
+
+        Utilizes the `dereference_single` function from the BaseTable class to replace the value associated with the
+        `primary_coding_id` key within each record. This key is expected to be present within each record, so a
+        KeyError will be raised if it is missing.
+
+        Args:
+            codings (Codings): An instance of the Codings class representing the codings table.
+
+        Raises:
+            KeyError: If the referenced_key, `primary_coding_id`, is not found in a record.
+        """
+        for record in self.records:
+            self.dereference_single(
+                record=record,
+                referenced_key='primary_coding_id',
+                referenced_records=codings.records
+            )
+            self.replace_key(
+                record=record,
+                old_key='primary_coding_id',
+                new_key='primaryCoding'
+            )
 
 class Indications(BaseTable):
     """
@@ -300,6 +367,50 @@ class Indications(BaseTable):
                 record=record,
                 old_key='document_id',
                 new_key='document'
+            )
+
+class Mappings(BaseTable):
+    """
+    Represents the Mappings table. This class inherits common functionality from the BaseTable class and
+    dereferences keys that reference other tables. This table references the following tables:
+    - Codings (initial key: `coding_id`, resulting key: `coding`)
+
+    Attributes:
+        records (list[dict]): A list of dictionaries representing the contribution records.
+    """
+    def dereference(self, codings: 'Codings') -> None:
+        """Dereference all keys for this table."""
+        self.dereference_codings(codings=codings)
+
+    def dereference_codings(self, codings: 'Codings') -> None:
+        """
+        Dereferences the `coding_id` key in each coding record.
+
+        Utilizes the `dereference_list` function from the BaseTable class to replace the value associated with the
+        `coding_id` key within each record. This key is not expected to be present within each record, so no KeyError will
+        be raised if it is missing.
+
+        Args:
+            codings (Codings): An instance of the Codings class representing the codings table.
+        """
+        for record in self.records:
+            self.dereference_single(
+                record=record,
+                referenced_key='coding_id',
+                referenced_records=codings.records
+            )
+            self.replace_key(
+                record=record,
+                old_key='coding_id',
+                new_key='coding'
+            )
+            self.remove_key(
+                record=record,
+                key='id'
+            )
+            self.remove_key(
+                record=record,
+                key='primary_coding_id'
             )
 
 class Organizations(BaseTable):
@@ -444,14 +555,15 @@ class Statements(BaseTable):
     dereferences keys that reference other tables. This table references the following tables:
     - Contributions (initial key: `contributions`, resulting key: `contributions`)
     - Documents (initial key: `reportedIn`, resulting key: `reportedIn`)
-    - Propositions (initial key: `proposition_id`, resulting key: `proposition`)
     - Indications (initial key: `indication_id, resulting key: `indication`)
+    - Propositions (initial key: `proposition_id`, resulting key: `proposition`)
+    - Strengths (initial key: `strength_id`, resulting key: `strength`)
 
     Attributes:
         records (list[dict]): A list of dictionaries representing the statement records.
     """
 
-    def dereference(self, agents: 'Agents', biomarkers: 'Biomarkers', contributions: 'Contributions', diseases: 'Diseases', documents: 'Documents', genes: 'Genes', indications: 'Indications', organizations: 'Organizations', propositions: 'Propositions', therapies: 'Therapies', therapy_groups: 'TherapyGroups') -> None:
+    def dereference(self, agents: 'Agents', biomarkers: 'Biomarkers', codings: 'Codings', contributions: 'Contributions', diseases: 'Diseases', documents: 'Documents', genes: 'Genes', indications: 'Indications', mappings: 'Mappings', organizations: 'Organizations', propositions: 'Propositions', therapies: 'Therapies', therapy_groups: 'TherapyGroups') -> None:
         """Dereferences all keys for this table."""
         self.dereference_contributions(contributions=contributions, agents=agents)
         self.dereference_documents(documents=documents, organizations=organizations)
@@ -607,16 +719,109 @@ class Statements(BaseTable):
                 new_key='proposition'
             )
 
-class Therapies(BaseTable):
+    def dereference_strengths(self, strengths: 'Strengths'):
+        """
+        Dereferences the `strength_id` key in each statement record.
+
+        Utilizes the `dereference_list` function from the BaseTable class to replace the value associated with the
+        `strength_id` key within each record. This key is expected to be present within each record, so a
+        KeyError will be raised if it is missing.
+
+        Args:
+            strengths (Strengths): An instance of the Strengths class representing the strengths table.
+
+        Raises:
+            KeyError: If the referenced_key, `strength_id`, is not found in a record.
+        """
+        for record in self.records:
+            self.dereference_single(
+                record=record,
+                referenced_key='strength_id',
+                referenced_records=strengths.records
+            )
+            self.replace_key(
+                record=record,
+                old_key='strength_id',
+                new_key='strength'
+            )
+
+class Strengths(BaseTable):
     """
-    Represents the Therapies table. This class inherits common functionality from the BaseTable class and
-    dereferences keys that reference other tables. This table does not currently reference any other tables.
+    Represents the Strengths table. This class inherits common functionality from the BaseTable class and
+    dereferences keys that reference other tables. This table references the following tables:
+    - Codings (initial key: `primary_coding_id`, resulting_key: `primaryCoding`)
 
     Attributes:
         records (list[dict]): A list of dictionaries representing the therapy records.
     """
 
-    pass
+    def dereference(self, codings: 'Codings') -> None:
+        self.dereference_codings(codings=codings)
+
+    def dereference_codings(self, codings: 'Codings') -> None:
+        """
+        Dereferences the `primary_coding_id` key in each strength record.
+
+        Utilizes the `dereference_single` function from the BaseTable class to replace the value associated with the
+        `primary_coding_id` key within each record. This key is expected to be present within each record, so a
+        KeyError will be raised if it is missing.
+
+        Args:
+            codings (Codings): An instance of the Codings class representing the codings table.
+
+        Raises:
+            KeyError: If the referenced_key, `primary_coding_id`, is not found in a record.
+        """
+        for record in self.records:
+            self.dereference_single(
+                record=record,
+                referenced_key='primary_coding_id',
+                referenced_records=codings.records
+            )
+            self.replace_key(
+                record=record,
+                old_key='primary_coding_id',
+                new_key='primaryCoding'
+            )
+
+class Therapies(BaseTable):
+    """
+    Represents the Therapies table. This class inherits common functionality from the BaseTable class and
+    dereferences keys that reference other tables. This table references the following tables:
+    - Codings (initial key: `primary_coding_id`, resulting_key: `primaryCoding`)
+
+    Attributes:
+        records (list[dict]): A list of dictionaries representing the therapy records.
+    """
+
+    def dereference(self, codings: 'Codings') -> None:
+        self.dereference_codings(codings=codings)
+
+    def dereference_codings(self, codings: 'Codings') -> None:
+        """
+        Dereferences the `primary_coding_id` key in each strength record.
+
+        Utilizes the `dereference_single` function from the BaseTable class to replace the value associated with the
+        `primary_coding_id` key within each record. This key is expected to be present within each record, so a
+        KeyError will be raised if it is missing.
+
+        Args:
+            codings (Codings): An instance of the Codings class representing the codings table.
+
+        Raises:
+            KeyError: If the referenced_key, `primary_coding_id`, is not found in a record.
+        """
+        for record in self.records:
+            self.dereference_single(
+                record=record,
+                referenced_key='primary_coding_id',
+                referenced_records=codings.records
+            )
+            self.replace_key(
+                record=record,
+                old_key='primary_coding_id',
+                new_key='primaryCoding'
+            )
 
 class TherapyGroups(BaseTable):
     """
@@ -672,11 +877,13 @@ def main(input_paths):
     about = json_utils.load(file=input_paths['about'])
     agents = json_utils.load(file=input_paths['agents'])
     biomarkers = json_utils.load(file=input_paths['biomarkers'])
+    codings = json_utils.load(file=input_paths['codings'])
     contributions = json_utils.load(file=input_paths['contributions'])
     diseases = json_utils.load(file=input_paths['diseases'])
     documents = json_utils.load(file=input_paths['documents'])
     genes = json_utils.load(file=input_paths['genes'])
     indications = json_utils.load(file=input_paths['indications'])
+    mappings = json_utils.load(file=input_paths['mappings'])
     organizations = json_utils.load(file=input_paths['organizations'])
     propositions = json_utils.load(file=input_paths['propositions'])
     statements = json_utils.load(file=input_paths['statements'])
@@ -686,11 +893,13 @@ def main(input_paths):
     # Step 2: Generate table objects
     agents = Agents(records=agents)
     biomarkers = Biomarkers(records=biomarkers)
+    codings = Codings(records=codings)
     contributions = Contributions(records=contributions)
     diseases = Diseases(records=diseases)
     documents = Documents(records=documents)
     genes = Genes(records=genes)
     indications = Indications(records=indications)
+    mappings = Mappings(records=mappings)
     organizations = Organizations(records=organizations)
     propositions = Propositions(records=propositions)
     statements = Statements(records=statements)
@@ -701,11 +910,13 @@ def main(input_paths):
     statements.dereference(
         agents=agents,
         biomarkers=biomarkers,
+        codings=codings,
         contributions=contributions,
         diseases=diseases,
         documents=documents,
         genes=genes,
         indications=indications,
+        mappings=mappings,
         organizations=organizations,
         propositions=propositions,
         therapies=therapies,
@@ -738,6 +949,11 @@ if __name__ =="__main__":
         default='referenced/biomarkers.json'
     ),
     arg_parser.add_argument(
+        '--codings',
+        help='json detailing db codings',
+        default='referenced/codings.json'
+    )
+    arg_parser.add_argument(
         '--contributions',
         help='json detailing db contributions',
         default='referenced/contributions.json'
@@ -762,6 +978,11 @@ if __name__ =="__main__":
         help='json detailing db indications',
         default='referenced/indications.json'
     ),
+    arg_parser.add_argument(
+        '--mappings',
+        help='json detailing db mappings',
+        default='referenced/mappings.json'
+    )
     arg_parser.add_argument(
         '--organizations',
         help='json detailing db organizations',
@@ -798,11 +1019,13 @@ if __name__ =="__main__":
         'about': args.about,
         'agents': args.agents,
         'biomarkers': args.biomarkers,
+        'codings': args.codings,
         'contributions': args.contributions,
         'diseases': args.diseases,
         'documents': args.documents,
         'genes': args.genes,
         'indications': args.indications,
+        'mappings': args.mappings,
         'organizations': args.organizations,
         'propositions': args.propositions,
         'statements': args.statements,


### PR DESCRIPTION
## Overview
Dereferenced codings and mappings to their own table.

## Feature updates
**Description**:
Codings and mappings were previously included within each respective json file for the referenced data model. This has been updated to align with the [latest version of gks-core](https://va-ga4gh.readthedocs.io/en/latest/core-information-model/elements/mappable-concept.html) and the two now exist within their own referenced data files.

**Objective**:
Move codings and mappings to their own data files.

**Implementation details**:
To move codings and mappings to their own data files
- All codings and mappings were aggregated from tables that use them -- diseases, genes, strengths, and therapies. An `id` was assigned to each coding based on their `system` and `code`.
- The `mappings` key for each record was updated to remove the primaryCoding `id` remaining `mappings` were replaced with the coding's `id`. 
- utils/dereference.py was refactored to dereference against `codings` and `mappings`. It now also better handles the cascade of referencing between tables. This new structure should also enable us to complete [Issue 54: Add ability to dereference particular record](https://github.com/vanallenlab/moalmanac-db/issues/54).
- Documentation was updated to reflect this update. 

## Checklist
- [x] All files changed have been reviewed.
- [x] All relevant documentation has been updated.
- [ ] All unit tests have passed.
