### PR TITLE
2025-06-12 release

### DIFF
--- a/referenced/about.json
+++ b/referenced/about.json
@@ -4,5 +4,5 @@
   "license": "GPL-2.0",
   "release": "draft",
   "url": "https://moalmanac.org",
-  "last_updated": "2025-04-30"
+  "last_updated": "2025-06-12"
 }

--- a/referenced/biomarkers.json
+++ b/referenced/biomarkers.json
@@ -8703,5 +8703,71 @@
         "value": true
       }
     ]
+  },
+  {
+    "id": 171,
+    "type": "CategoricalVariant",
+    "name": "KRAS p.G12V",
+    "genes": [
+      31
+    ],
+    "extensions": [
+      {
+        "name": "biomarker_type",
+        "value": "Somatic Variant"
+      },
+      {
+        "name": "chromosome",
+        "value": "12"
+      },
+      {
+        "name": "start_position",
+        "value": 25398284
+      },
+      {
+        "name": "end_position",
+        "value": 25398284
+      },
+      {
+        "name": "reference_allele",
+        "value": "C"
+      },
+      {
+        "name": "alternate_allele",
+        "value": "A"
+      },
+      {
+        "name": "cdna_change",
+        "value": "c.35G>T"
+      },
+      {
+        "name": "protein_change",
+        "value": "p.G12V"
+      },
+      {
+        "name": "variant_annotation",
+        "value": "Missense"
+      },
+      {
+        "name": "exon",
+        "value": 2
+      },
+      {
+        "name": "rsid",
+        "value": "rs121913529"
+      },
+      {
+        "name": "hgvsg",
+        "value": "12:g.25398284C>A"
+      },
+      {
+        "name": "hgvsc",
+        "value": "ENST00000311936.3:c.35G>T"
+      },
+      {
+        "name": "_present",
+        "value": true
+      }
+    ]
   }
 ]

--- a/referenced/biomarkers.json
+++ b/referenced/biomarkers.json
@@ -8672,5 +8672,36 @@
         "value": true
       }
     ]
+  },
+  {
+    "id": 170,
+    "type": "CategoricalVariant",
+    "name": "c-Met >= 50%",
+    "extensions": [
+      {
+        "name": "biomarker_type",
+        "value": "Protein expression"
+      },
+      {
+        "name": "marker",
+        "value": "c-Met"
+      },
+      {
+        "name": "unit",
+        "value": "status"
+      },
+      {
+        "name": "equality",
+        "value": ">="
+      },
+      {
+        "name": "value",
+        "value": "0.50"
+      },
+      {
+        "name": "_present",
+        "value": true
+      }
+    ]
   }
 ]

--- a/referenced/codings.json
+++ b/referenced/codings.json
@@ -4246,5 +4246,15 @@
     "iris": [
       "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C118948"
     ]
+  },
+  {
+    "id": "ncit:C135017",
+    "code": "C135017",
+    "name": "Lung Non-Squamous Non-Small Cell Carcinoma",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C135017"
+    ]
   }
 ]

--- a/referenced/codings.json
+++ b/referenced/codings.json
@@ -4256,5 +4256,45 @@
     "iris": [
       "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C135017"
     ]
+  },
+  {
+    "id": "ncit:C118571",
+    "code": "C118571",
+    "name": "Telisotuzumab Vedotin",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C135017"
+    ]
+  },
+  {
+    "id": "ncit:C80060",
+    "code": "C80060",
+    "name": "Avutometinib",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C135017"
+    ]
+  },
+  {
+    "id": "ncit:C79809",
+    "code": "C79809",
+    "name": "Defactinib",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C135017"
+    ]
+  },
+  {
+    "id": "oncotree:LGSOC",
+    "code": "LGSOC",
+    "name": "Low-Grade Serous Ovarian Cancer",
+    "system": "https://oncotree.mskcc.org",
+    "systemVersion": "oncotree_2021_11_02",
+    "iris": [
+      "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=ALL"
+    ]
   }
 ]

--- a/referenced/codings.json
+++ b/referenced/codings.json
@@ -4236,5 +4236,15 @@
     "iris": [
       "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C3163"
     ]
+  },
+  {
+    "id": "ncit:C118948",
+    "code": "C118948",
+    "name": "Taletrectinib",
+    "system": "https://evsexplore.semantics.cancer.gov",
+    "systemVersion": "25.01d",
+    "iris": [
+      "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C118948"
+    ]
   }
 ]

--- a/referenced/contributions.json
+++ b/referenced/contributions.json
@@ -45,7 +45,7 @@
     "id": 6,
     "type": "Contribution",
     "agent_id": 0,
-    "description": "The FDA provided regular approval to taletrectinib for the treatment of patients with ROS1 positive non-small cell lung cancer.",
+    "description": "The FDA provided regular approval to taletrectinib for the treatment of patients with ROS1 positive non-small cell lung cancer, and accelerated approval to telisotuzumab vedotin-tllv for the treatment of patients with non-squamous non-small cell lung cancer with high c-Met expression.",
     "date": "2025-06-12"
   }
 ]

--- a/referenced/contributions.json
+++ b/referenced/contributions.json
@@ -45,7 +45,7 @@
     "id": 6,
     "type": "Contribution",
     "agent_id": 0,
-    "description": "The FDA provided regular approval to taletrectinib for the treatment of patients with ROS1 positive non-small cell lung cancer, and accelerated approval to telisotuzumab vedotin-tllv for the treatment of patients with non-squamous non-small cell lung cancer with high c-Met expression.",
+    "description": "The FDA provided regular approval to taletrectinib for the treatment of patients with ROS1 positive non-small cell lung cancer, accelerated approval to telisotuzumab vedotin-tllv for the treatment of patients with non-squamous non-small cell lung cancer with high c-Met expression, and avutometinib in combination with defactinib (Avmapki Fakzynja co-pack) for the treatment of adult patients with KRAS-mutated recurrent low-grade serous ovarian cancer.",
     "date": "2025-06-12"
   }
 ]

--- a/referenced/contributions.json
+++ b/referenced/contributions.json
@@ -40,5 +40,12 @@
     "agent_id": 0,
     "description": "The FDA provided regular approval to larotrectinib for the treatment of adult and pediatric patients with solid tumors that: have a neurotrophic receptor tyrosine kinase (NTRK) gene fusion without a known acquired resistance mutation, are metastatic or where surgical resection is likely to result in severe morbidity, and have no satisfactory alternative treatments or that have progressed following treatment.",
     "date": "2025-04-30"
+  },
+  {
+    "id": 6,
+    "type": "Contribution",
+    "agent_id": 0,
+    "description": "The FDA provided regular approval to taletrectinib for the treatment of patients with ROS1 positive non-small cell lung cancer.",
+    "date": "2025-06-12"
   }
 ]

--- a/referenced/diseases.json
+++ b/referenced/diseases.json
@@ -1260,5 +1260,19 @@
         "description": "Boolean value for if this tumor type is categorized as a solid tumor."
       }
     ]
+  },
+  {
+    "id": 90,
+    "conceptType": "Disease",
+    "name": "Low-Grade Serous Ovarian Cancer",
+    "primary_coding_id": "oncotree:LGSOC",
+    "mappings": [],
+    "extensions": [
+      {
+        "name": "solid_tumor",
+        "value": true,
+        "description": "Boolean value for if this tumor type is categorized as a solid tumor."
+      }
+    ]
   }
 ]

--- a/referenced/diseases.json
+++ b/referenced/diseases.json
@@ -1246,5 +1246,19 @@
         "description": "Boolean value for if this tumor type is categorized as a solid tumor."
       }
     ]
+  },
+  {
+    "id": 89,
+    "conceptType": "Disease",
+    "name": "Lung Non-Squamous Non-Small Cell Carcinoma",
+    "primary_coding_id": "nct:C135017",
+    "mappings": [],
+    "extensions": [
+      {
+        "name": "solid_tumor",
+        "value": true,
+        "description": "Boolean value for if this tumor type is categorized as a solid tumor."
+      }
+    ]
   }
 ]

--- a/referenced/documents.json
+++ b/referenced/documents.json
@@ -1726,5 +1726,23 @@
     "url": "https://www.accessdata.fda.gov/drugsatfda_docs/label/2024/218944s000lbl.pdf",
     "url_drug": "https://www.accessdata.fda.gov/scripts/cder/daf/index.cfm?event=overview.process&ApplNo=218944",
     "application_number": 218944
+  },
+  {
+    "id": "doc:fda.ibtrozi",
+    "type": "Document",
+    "subtype": "Regulatory approval",
+    "name": "Ibtrozi (taletrectinib) [package insert]. FDA.",
+    "aliases": null,
+    "citation": "Nuvation Bio Inc. Ibtrozi (taletrectinib) [package insert]. U.S. Food and Drug Administration website. https://www.accessdata.fda.gov/drugsatfda_docs/label/2025/219713s000lbl.pdf. Revised June 2025. Accessed June 12, 2025.",
+    "company": "Nuvation Bio Inc",
+    "drug_name_brand": "Ibtrozi",
+    "drug_name_generic": "taletrectinib",
+    "first_published": "2025-06-11",
+    "access_date": "2025-06-12",
+    "organization_id": "fda",
+    "publication_date": "2025-06-11",
+    "url": "https://www.accessdata.fda.gov/drugsatfda_docs/label/2025/219713s000lbl.pdf",
+    "url_drug": "https://www.accessdata.fda.gov/scripts/cder/daf/index.cfm?event=overview.process&ApplNo=219713",
+    "application_number": 219713
   }
 ]

--- a/referenced/documents.json
+++ b/referenced/documents.json
@@ -1744,5 +1744,23 @@
     "url": "https://www.accessdata.fda.gov/drugsatfda_docs/label/2025/219713s000lbl.pdf",
     "url_drug": "https://www.accessdata.fda.gov/scripts/cder/daf/index.cfm?event=overview.process&ApplNo=219713",
     "application_number": 219713
+  },
+  {
+    "id": "doc:fda.emrelis",
+    "type": "Document",
+    "subtype": "Regulatory approval",
+    "name": "Emrelis (telisotuzumab vedotin-tllv) [package insert]. FDA.",
+    "aliases": null,
+    "citation": "Nuvation Bio Inc. Emrelis (telisotuzumab vedotin-tllv) [package insert]. U.S. Food and Drug Administration website. https://www.accessdata.fda.gov/drugsatfda_docs/label/2025/761384s000lbl.pdf. Revised May 2025. Accessed June 12, 2025.",
+    "company": "Nuvation Bio Inc",
+    "drug_name_brand": "Emrelis",
+    "drug_name_generic": "telisotuzumab vedotin",
+    "first_published": "2025-05-14",
+    "access_date": "2025-06-12",
+    "organization_id": "fda",
+    "publication_date": "2025-05-14",
+    "url": "https://www.accessdata.fda.gov/drugsatfda_docs/label/2025/761384s000lbl.pdf",
+    "url_drug": "https://www.accessdata.fda.gov/scripts/cder/daf/index.cfm?event=overview.process&ApplNo=761384",
+    "application_number": 761384
   }
 ]

--- a/referenced/documents.json
+++ b/referenced/documents.json
@@ -1751,8 +1751,8 @@
     "subtype": "Regulatory approval",
     "name": "Emrelis (telisotuzumab vedotin-tllv) [package insert]. FDA.",
     "aliases": null,
-    "citation": "Nuvation Bio Inc. Emrelis (telisotuzumab vedotin-tllv) [package insert]. U.S. Food and Drug Administration website. https://www.accessdata.fda.gov/drugsatfda_docs/label/2025/761384s000lbl.pdf. Revised May 2025. Accessed June 12, 2025.",
-    "company": "Nuvation Bio Inc",
+    "citation": "Abbvie Inc. Emrelis (telisotuzumab vedotin-tllv) [package insert]. U.S. Food and Drug Administration website. https://www.accessdata.fda.gov/drugsatfda_docs/label/2025/761384s000lbl.pdf. Revised May 2025. Accessed June 12, 2025.",
+    "company": "Abbvie Inc.",
     "drug_name_brand": "Emrelis",
     "drug_name_generic": "telisotuzumab vedotin",
     "first_published": "2025-05-14",
@@ -1762,5 +1762,23 @@
     "url": "https://www.accessdata.fda.gov/drugsatfda_docs/label/2025/761384s000lbl.pdf",
     "url_drug": "https://www.accessdata.fda.gov/scripts/cder/daf/index.cfm?event=overview.process&ApplNo=761384",
     "application_number": 761384
+  },
+  {
+    "id": "doc:fda.avmapki-fakzynja",
+    "type": "Document",
+    "subtype": "Regulatory approval",
+    "name": "Avmapki Fakzynja co-pack (avutometinib potassium; defactinib hydrochloride) [package insert]. FDA.",
+    "aliases": null,
+    "citation": "Verastem Inc. Avmapki Fakzynja co-pack (avutometinib potassium; defactinib hydrochloride) [package insert]. U.S. Food and Drug Administration website. https://www.accessdata.fda.gov/drugsatfda_docs/label/2025/219616s000lbl.pdf. Revised May 2025. Accessed June 12, 2025.",
+    "company": "Verastem Inc",
+    "drug_name_brand": "Avmapki Fakzynja co-pack",
+    "drug_name_generic": "avutometinib; defactinib",
+    "first_published": "2025-05-08",
+    "access_date": "2025-06-12",
+    "organization_id": "fda",
+    "publication_date": "2025-05-08",
+    "url": "https://www.accessdata.fda.gov/drugsatfda_docs/label/2025/219616s000lbl.pdf",
+    "url_drug": "https://www.accessdata.fda.gov/scripts/cder/daf/index.cfm?event=overview.process&ApplNo=219616",
+    "application_number": 219616
   }
 ]

--- a/referenced/indications.json
+++ b/referenced/indications.json
@@ -2645,5 +2645,18 @@
     "raw_therapeutics": "telisotuzumab vedotin",
     "date_regular_approval": null,
     "date_accelerated_approval": "2025-05-14"
+  },
+  {
+    "id": "ind:fda.avmapki-fakzynja:0",
+    "document_id": "doc:fda.avmapki-fakzynja",
+    "indication": "AVMAPKI FAKZYNJA CO-PACK, a combination of avutometinib and defactinib, each kinase inhibitors, is indicated for the treatment of adult patients with KRAS-mutated recurrent low-grade serous ovarian cancer (LGSOC) who have received prior systemic therapy.",
+    "initial_approval_date": "2025-05-08",
+    "initial_approval_url": "https://www.accessdata.fda.gov/drugsatfda_docs/label/2025/219616s000lbl.pdf",
+    "description": "The U.S. Food and Drug Administration (FDA) granted accelerated approval to avutometinib in combination with defactinib (Avmapki Fakzynja co-pack) for the treatment of adult patients with KRAS-mutated recurrent low-grade serous ovarian cancer (LGSOC) who have received prior systemic therapy. The package insert notes that this indication is approved under accelerated approval based on tumor response rate and duration of response. Continued approval for this indication may be contingent upon verification and description of clinical benefit in a confirmatory trial. This approval is based on RAMP-201 (NCT04625270), an open-label, multicenter study that included 57 adult patients with measurable KRAS-mutated recurrent LGSOC. The KRAS mutations identified by local testing were G12V (53%), G12D (35%), Q61H (3.5%), G12C (1.8%), G12R (1.8%), A146V (1.8%), and mutations not otherwise specified at G12x (1.8%) and on codon 12/13 (1.8%). 44% of patients responded (3.5% with complete response, 40% with partial response), and the package insert notes that the tumor KRAS mutations observed in the 25 responders were A146V, G12D, G12R, G12V, and Q61H.",
+    "raw_biomarkers": "KRAS-mutated",
+    "raw_cancer_type": "low-grade serous ovarian cancer (LGSOC)",
+    "raw_therapeutics": "avutometinib; defactinib",
+    "date_regular_approval": null,
+    "date_accelerated_approval": "2025-05-08"
   }
 ]

--- a/referenced/indications.json
+++ b/referenced/indications.json
@@ -2619,5 +2619,18 @@
     "raw_therapeutics": "nivolumab in combination with ipilimumab",
     "date_regular_approval": "2025-04-08",
     "date_accelerated_approval": "2018-07-10"
+  },
+  {
+    "id": "ind:fda.ibtrozi:0",
+    "document_id": "doc:fda.ibtrozi",
+    "indication": "IBTROZI is a kinase inhibitor indicated for the treatment of adult patients with locally advanced or metastatic ROS1-positive non-small cell lung cancer (NSCLC).",
+    "initial_approval_date": "2015-06-11",
+    "initial_approval_url": "https://www.accessdata.fda.gov/drugsatfda_docs/label/2025/219713s000lbl.pdf",
+    "description": "The U.S. Food and Drug Administration (FDA) granted approval to taletrectinib for the treatment of adult patients with locally advanced or metastatic ROS1-positive non-small cell lung cancer. The package insert instructs to select patients based on the presence of ROS1 rearrangements in tumor specimen(s).",
+    "raw_biomarkers": "ROS1-positive",
+    "raw_cancer_type": "non-small cell lung cancer",
+    "raw_therapeutics": "taletrectinib",
+    "date_regular_approval": "2025-06-11",
+    "date_accelerated_approval": null
   }
 ]

--- a/referenced/indications.json
+++ b/referenced/indications.json
@@ -2397,7 +2397,7 @@
     "indication": "IMFINZI is a programmed death-ligand 1 (PD-L1) blocking antibody indicated in combination with platinum-containing chemotherapy as neoadjuvant treatment, followed by IMFINZI continued as a single agent as adjuvant treatment after surgery, for the treatment of adult patients with resectable (tumors \u2265 4 cm and/or node positive) non-small cell lung cancer (NSCLC) and no known epidermal growth factor receptor (EGFR) mutations or anaplastic lymphoma kinase (ALK) rearrangements.",
     "initial_approval_date": "2024-08-15",
     "initial_approval_url": "https://www.accessdata.fda.gov/drugsatfda_docs/label/2024/761069s043lbledt.pdf",
-    "description": "The U.S. Food and Drug Administration (FDA) granted approval to durvalumab in combination with platinum-containing chemotherapy for the neoadjuvant treatment, followed by durvalumab as a single agent as adjuvant treatment after surgery, of adult patients with resectable (tumors \u2265 4 cm and/or node positive) non-small cell lung cancer (NSCLC) and no known epidermal growth factor receptor (EGFR) mutations or anaplastic lymphoma kinase (ALK) rearrangements. This indication is based on AEGEAN\n(NCT03800134), a randomized, double-blind, placebo-controlled, multicenter trial where the choice of platinum-containing chemotherapy was dependent on tumor histology. Specifically, patients with squamous tumor histology received either carboplatin with paclitaxel or cisplatin with gemcitabine, and patients with non-squamous tumor histology received either pemetrexed with carboplatin or pemetrexed with cisplatin.",
+    "description": "The U.S. Food and Drug Administration (FDA) granted approval to durvalumab in combination with platinum-containing chemotherapy for the neoadjuvant treatment, followed by durvalumab as a single agent as adjuvant treatment after surgery, of adult patients with resectable (tumors \u2265 4 cm and/or node positive) non-small cell lung cancer (NSCLC) and no known epidermal growth factor receptor (EGFR) mutations or anaplastic lymphoma kinase (ALK) rearrangements. This indication is based on AEGEAN (NCT03800134), a randomized, double-blind, placebo-controlled, multicenter trial where the choice of platinum-containing chemotherapy was dependent on tumor histology. Specifically, patients with squamous tumor histology received either carboplatin with paclitaxel or cisplatin with gemcitabine, and patients with non-squamous tumor histology received either pemetrexed with carboplatin or pemetrexed with cisplatin.",
     "raw_biomarkers": "no known epidermal growth factor receptor (EGFR) mutations or anaplastic lymphoma kinase (ALK) rearrangements.",
     "raw_cancer_type": "non-small cell lung cancer",
     "raw_therapeutics": "durvalumab in combination with platinum-containing chemotherapy"
@@ -2632,5 +2632,18 @@
     "raw_therapeutics": "taletrectinib",
     "date_regular_approval": "2025-06-11",
     "date_accelerated_approval": null
+  },
+  {
+    "id": "ind:fda.emrelis:0",
+    "document_id": "doc:fda.emrelis",
+    "indication": "EMRELIS is a c-Met-directed antibody and microtubule inhibitor conjugate indicated for the treatment of adult patients with locally advanced or metastatic non-squamous non-small cell lung cancer (NSCLC) with high c-Met protein overexpression [>=50% of tumor cells with strong (3+) staining], as determined by an FDA-approved test, who have received a prior systemic therapy.",
+    "initial_approval_date": "2025-05-14",
+    "initial_approval_url": "https://www.accessdata.fda.gov/drugsatfda_docs/label/2025/761384s000lbl.pdf",
+    "description": "The U.S. Food and Drug Administration (FDA) granted accelerated approval to telisotuzumab vedotin, a c-Met-directed antibody and microtubule inhibitor conjugate, for the treatment of adult patients with locally advanced or metastatic non-squamous non-small cell lung cancer (NSCLC) with high c-Met protein overexpression [>=50% of tumor cells with strong (3+) staining], as determined by an FDA-approved test, who have received a prior systemic therapy. This indication is approved under accelerated approval based on objective response rate (ORR) and duration of response (DOR). Continued approval for this indication may be contingent upon verification and description of a clinical benefit in a confirmatory trial(s).",
+    "raw_biomarkers": "high c-Met protein overexpression [>=50% of tumor cells with strong (3+) staining]",
+    "raw_cancer_type": "non-squamous non-small cell lung cancer",
+    "raw_therapeutics": "telisotuzumab vedotin",
+    "date_regular_approval": null,
+    "date_accelerated_approval": "2025-05-14"
   }
 ]

--- a/referenced/organizations.json
+++ b/referenced/organizations.json
@@ -4,6 +4,6 @@
     "name": "Food and Drug Administration",
     "description": "Regulatory agency that approves drugs for use in the United States.",
     "url": "https://www.accessdata.fda.gov/scripts/cder/daf/index.cfm",
-    "last_updated": "2025-04-30"
+    "last_updated": "2025-06-12"
   }
 ]

--- a/referenced/propositions.json
+++ b/referenced/propositions.json
@@ -10401,5 +10401,17 @@
     "subjectVariant": {},
     "therapy_id": 149,
     "therapy_group_id": null
+  },
+  {
+    "id": 837,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      170
+    ],
+    "conditionQualifier_id": 89,
+    "subjectVariant": {},
+    "therapy_id": 150,
+    "therapy_group_id": null
   }
 ]

--- a/referenced/propositions.json
+++ b/referenced/propositions.json
@@ -10413,5 +10413,29 @@
     "subjectVariant": {},
     "therapy_id": 150,
     "therapy_group_id": null
+  },
+  {
+    "id": 838,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      45
+    ],
+    "conditionQualifier_id": 90,
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 182
+  },
+  {
+    "id": 839,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      171
+    ],
+    "conditionQualifier_id": 90,
+    "subjectVariant": {},
+    "therapy_id": null,
+    "therapy_group_id": 182
   }
 ]

--- a/referenced/propositions.json
+++ b/referenced/propositions.json
@@ -10389,5 +10389,17 @@
     "subjectVariant": {},
     "therapy_id": null,
     "therapy_group_id": 142
+  },
+  {
+    "id": 836,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      62
+    ],
+    "conditionQualifier_id": 47,
+    "subjectVariant": {},
+    "therapy_id": 149,
+    "therapy_group_id": null
   }
 ]

--- a/referenced/statements.json
+++ b/referenced/statements.json
@@ -9376,5 +9376,20 @@
     "direction": "supports",
     "strength_id": 0,
     "indication_id": "ind:fda.opdivo:4"
+  },
+  {
+    "id": 625,
+    "type": "Statement",
+    "description": "The U.S. Food and Drug Administration (FDA) granted approval to taletrectinib for the treatment of adult patients with locally advanced or metastatic ROS1-positive non-small cell lung cancer. The package insert instructs to select patients based on the presence of ROS1 rearrangements in tumor specimen(s).",
+    "contributions": [
+      6
+    ],
+    "reportedIn": [
+      "doc:fda.ibtrozi"
+    ],
+    "proposition_id": 836,
+    "direction": "supports",
+    "strength_id": 0,
+    "indication_id": "ind:fda.ibtrozi:0"
   }
 ]

--- a/referenced/statements.json
+++ b/referenced/statements.json
@@ -9406,5 +9406,36 @@
     "direction": "supports",
     "strength_id": 0,
     "indication_id": "ind:fda.emrelis:0"
+  },
+
+  {
+    "id": 627,
+    "type": "Statement",
+    "description": "The U.S. Food and Drug Administration (FDA) granted accelerated approval to avutometinib in combination with defactinib (Avmapki Fakzynja co-pack) for the treatment of adult patients with KRAS-mutated recurrent low-grade serous ovarian cancer (LGSOC) who have received prior systemic therapy. The package insert notes that this indication is approved under accelerated approval based on tumor response rate and duration of response. Continued approval for this indication may be contingent upon verification and description of clinical benefit in a confirmatory trial. This approval is based on RAMP-201 (NCT04625270), an open-label, multicenter study that included 57 adult patients with measurable KRAS-mutated recurrent LGSOC. The KRAS mutations identified by local testing were G12V (53%), G12D (35%), Q61H (3.5%), G12C (1.8%), G12R (1.8%), A146V (1.8%), and mutations not otherwise specified at G12x (1.8%) and on codon 12/13 (1.8%). 44% of patients responded (3.5% with complete response, 40% with partial response), and the package insert notes that the tumor KRAS mutations observed in the 25 responders were A146V, G12D, G12R, G12V, and Q61H.",
+    "contributions": [
+      6
+    ],
+    "reportedIn": [
+      "doc:fda.avmapki-fakzynja"
+    ],
+    "proposition_id": 838,
+    "direction": "supports",
+    "strength_id": 0,
+    "indication_id": "ind:fda.avmapki-fakzynja:0"
+  },
+  {
+    "id": 628,
+    "type": "Statement",
+    "description": "The U.S. Food and Drug Administration (FDA) granted accelerated approval to avutometinib in combination with defactinib (Avmapki Fakzynja co-pack) for the treatment of adult patients with KRAS-mutated recurrent low-grade serous ovarian cancer (LGSOC) who have received prior systemic therapy. The package insert notes that this indication is approved under accelerated approval based on tumor response rate and duration of response. Continued approval for this indication may be contingent upon verification and description of clinical benefit in a confirmatory trial. This approval is based on RAMP-201 (NCT04625270), an open-label, multicenter study that included 57 adult patients with measurable KRAS-mutated recurrent LGSOC. The KRAS mutations identified by local testing were G12V (53%), G12D (35%), Q61H (3.5%), G12C (1.8%), G12R (1.8%), A146V (1.8%), and mutations not otherwise specified at G12x (1.8%) and on codon 12/13 (1.8%). 44% of patients responded (3.5% with complete response, 40% with partial response), and the package insert notes that the tumor KRAS mutations observed in the 25 responders were A146V, G12D, G12R, G12V, and Q61H.",
+    "contributions": [
+      6
+    ],
+    "reportedIn": [
+      "doc:fda.avmapki-fakzynja"
+    ],
+    "proposition_id": 839,
+    "direction": "supports",
+    "strength_id": 0,
+    "indication_id": "ind:fda.avmapki-fakzynja:0"
   }
 ]

--- a/referenced/statements.json
+++ b/referenced/statements.json
@@ -9391,5 +9391,20 @@
     "direction": "supports",
     "strength_id": 0,
     "indication_id": "ind:fda.ibtrozi:0"
+  },
+  {
+    "id": 626,
+    "type": "Statement",
+    "description": "The U.S. Food and Drug Administration (FDA) granted accelerated approval to telisotuzumab vedotin, a c-Met-directed antibody and microtubule inhibitor conjugate, for the treatment of adult patients with locally advanced or metastatic non-squamous non-small cell lung cancer (NSCLC) with high c-Met protein overexpression [>=50% of tumor cells with strong (3+) staining], as determined by an FDA-approved test, who have received a prior systemic therapy. This indication is approved under accelerated approval based on objective response rate (ORR) and duration of response (DOR). Continued approval for this indication may be contingent upon verification and description of a clinical benefit in a confirmatory trial(s).",
+    "contributions": [
+      6
+    ],
+    "reportedIn": [
+      "doc:fda.emrelis"
+    ],
+    "proposition_id": 837,
+    "direction": "supports",
+    "strength_id": 0,
+    "indication_id": "ind:fda.emrelis:0"
   }
 ]

--- a/referenced/therapies.json
+++ b/referenced/therapies.json
@@ -3028,5 +3028,27 @@
         "description": "Type of cancer treatment from cancer.gov: https://www.cancer.gov/about-cancer/treatment/types"
       }
     ]
+  },
+  {
+    "id": 149,
+    "conceptType": "Drug",
+    "name": "Taletrectinib",
+    "primary_coding_id": "ncit:C118948",
+    "mappings": [],
+    "extensions": [
+      {
+        "name": "therapy_strategy",
+        "value": [
+          "NTRK inhibition",
+          "ROS1 inhibition"
+        ],
+        "description": "Associated therapeutic strategy or mechanism of action of the therapy."
+      },
+      {
+        "name": "therapy_type",
+        "value": "Targeted therapy",
+        "description": "Type of cancer treatment from cancer.gov: https://www.cancer.gov/about-cancer/treatment/types"
+      }
+    ]
   }
 ]

--- a/referenced/therapies.json
+++ b/referenced/therapies.json
@@ -3050,5 +3050,69 @@
         "description": "Type of cancer treatment from cancer.gov: https://www.cancer.gov/about-cancer/treatment/types"
       }
     ]
+  },
+  {
+    "id": 150,
+    "conceptType": "Drug",
+    "name": "Telisotuzumab Vedotin",
+    "primary_coding_id": "ncit:C118571",
+    "mappings": [],
+    "extensions": [
+      {
+        "name": "therapy_strategy",
+        "value": [
+          "MET inhibition"
+        ],
+        "description": "Associated therapeutic strategy or mechanism of action of the therapy."
+      },
+      {
+        "name": "therapy_type",
+        "value": "Targeted therapy",
+        "description": "Type of cancer treatment from cancer.gov: https://www.cancer.gov/about-cancer/treatment/types"
+      }
+    ]
+  },
+  {
+    "id": 151,
+    "conceptType": "Drug",
+    "name": "Avutometinib",
+    "primary_coding_id": "ncit:C80060",
+    "mappings": [],
+    "extensions": [
+      {
+        "name": "therapy_strategy",
+        "value": [
+          "MEK inhibition",
+          "RAF inhibition"
+        ],
+        "description": "Associated therapeutic strategy or mechanism of action of the therapy."
+      },
+      {
+        "name": "therapy_type",
+        "value": "Targeted therapy",
+        "description": "Type of cancer treatment from cancer.gov: https://www.cancer.gov/about-cancer/treatment/types"
+      }
+    ]
+  },
+  {
+    "id": 152,
+    "conceptType": "Drug",
+    "name": "Defactinib",
+    "primary_coding_id": "ncit:C79809",
+    "mappings": [],
+    "extensions": [
+      {
+        "name": "therapy_strategy",
+        "value": [
+          "FAK inhibition"
+        ],
+        "description": "Associated therapeutic strategy or mechanism of action of the therapy."
+      },
+      {
+        "name": "therapy_type",
+        "value": "Targeted therapy",
+        "description": "Type of cancer treatment from cancer.gov: https://www.cancer.gov/about-cancer/treatment/types"
+      }
+    ]
   }
 ]

--- a/referenced/therapy_groups.json
+++ b/referenced/therapy_groups.json
@@ -1660,5 +1660,13 @@
       8,
       60
     ]
+  },
+  {
+    "id": 182,
+    "membershipOperator": "AND",
+    "therapies": [
+      151,
+      152
+    ]
   }
 ]


### PR DESCRIPTION
## Overview
Updated FDA approvals from May and early June 2025.

## Database content updates
Added entries:
- (FDA) Taletrectinib for the treatment of patients with ROS1-positive non-small cell lung cancer.
- (FDA) Telisotuzumab vedotin for the treatment of patients with high c-Met protein overexpression non-squamous non-small cell lung cancer.
- (FDA) Avutometinib in combination with defactinib for the treatment of patients with KRAS-mutant low-grade serous ovarian cancer (G12C, G12V).

## Checklist
- [x] All files changed have been reviewed.
- [x] All relevant documentation has been updated.
- [ ] All unit tests have passed.
