### PR TITLE
Bug fix: dereferencing

### DIFF
--- a/utils/README.md
+++ b/utils/README.md
@@ -37,7 +37,7 @@ Optional arguments:
 
 Example:
 ```bash
-python -m utils/dereference \
+python -m utils.dereference \
   --about referenced/about.json \
   --agents referenced/agents.json \
   --biomarkers referenced/biomarkers.json \

--- a/utils/dereference.py
+++ b/utils/dereference.py
@@ -71,7 +71,7 @@ class BaseTable:
         else:
             _values = []
             for value in record[referenced_key]:
-                _value = json_utils.get_records_by_key_value(
+                _value = json_utils.get_record_by_key_value(
                     records=referenced_records,
                     key='id',
                     value=value


### PR DESCRIPTION
## Overview
The function `Base.dereference_list` in `utils/dereference.py` was using `json_utils.get_records_by_key_value` instead of `json_utils.get_record_by_key_value`. 

## Checklist
- [x] All files changed have been reviewed.
- [x] All relevant documentation has been updated.
- [x] All unit tests have passed.
