### PR TITLE
Update biomarker names

### DIFF
--- a/referenced/biomarkers.json
+++ b/referenced/biomarkers.json
@@ -908,7 +908,7 @@
   {
     "id": 19,
     "type": "CategoricalVariant",
-    "name": "EGFR oncogenic variants",
+    "name": "EGFR activating variants",
     "genes": [
       17
     ],
@@ -1066,7 +1066,7 @@
   {
     "id": 23,
     "type": "CategoricalVariant",
-    "name": "ERBB2 oncogenic variants",
+    "name": "ERBB2 activating variants",
     "genes": [
       18
     ],
@@ -2261,7 +2261,7 @@
   {
     "id": 58,
     "type": "CategoricalVariant",
-    "name": "ESR1 oncogenic variants",
+    "name": "ESR1 activating variants",
     "genes": [
       19
     ],

--- a/referenced/biomarkers.json
+++ b/referenced/biomarkers.json
@@ -9088,5 +9088,75 @@
         "value": true
       }
     ]
+  },
+  {
+    "id": 179,
+    "type": "CategoricalVariant",
+    "name": "EGFR TKD activating variants",
+    "genes": [
+      17
+    ],
+    "extensions": [
+      {
+        "name": "biomarker_type",
+        "value": "Somatic Variant"
+      },
+      {
+        "name": "chromosome",
+        "value": "7"
+      },
+      {
+        "name": "start_position",
+        "value": null
+      },
+      {
+        "name": "end_position",
+        "value": null
+      },
+      {
+        "name": "reference_allele",
+        "value": null
+      },
+      {
+        "name": "alternate_allele",
+        "value": null
+      },
+      {
+        "name": "cdna_change",
+        "value": null
+      },
+      {
+        "name": "protein_change",
+        "value": null
+      },
+      {
+        "name": "variant_annotation",
+        "value": null
+      },
+      {
+        "name": "exon",
+        "value": null
+      },
+      {
+        "name": "rsid",
+        "value": null
+      },
+      {
+        "name": "hgvsg",
+        "value": null
+      },
+      {
+        "name": "hgvsc",
+        "value": null
+      },
+      {
+        "name": "requires_oncogenic",
+        "value": true
+      },
+      {
+        "name": "_present",
+        "value": true
+      }
+    ]
   }
 ]

--- a/referenced/propositions.json
+++ b/referenced/propositions.json
@@ -10237,5 +10237,17 @@
     "subjectVariant": {},
     "therapy_id": null,
     "therapy_group_id": 197
+  },
+  {
+    "id": 911,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      173
+    ],
+    "conditionQualifier_id": 47,
+    "subjectVariant": {},
+    "therapy_id": 33,
+    "therapy_group_id": null
   }
 ]

--- a/referenced/statements.json
+++ b/referenced/statements.json
@@ -10497,7 +10497,7 @@
     "reportedIn": [
       "doc:ema.iressa"
     ],
-    "proposition_id": 559,
+    "proposition_id": 911,
     "direction": "supports",
     "strength_id": 0,
     "indication_id": "ind:ema.iressa:0"
@@ -24382,7 +24382,7 @@
     "reportedIn": [
       "doc:hc.iressa"
     ],
-    "proposition_id": 559,
+    "proposition_id": 911,
     "direction": "supports",
     "strength_id": 0,
     "indication_id": "ind:hc.iressa:0"


### PR DESCRIPTION
## Overview
Biomarker names for _EGFR_, _ERBB2_, and _ESR1_ oncogenic variants were renamed to activating variants to align with the scope of the associated regulatory approvals. A new biomarker record for _EGFR_ TKD activating variants was also created, and associated with gefitinib approvals from the European Medicine Agency and Health Canada.

## Checklist
- [ ] `referenced/about.json` and `referenced/agents.json` last updated dates were updated.
- [ ] All files changed have been reviewed.
- [x] All relevant documentation has been updated.
- [x] All unit tests have passed.
