### PR TITLE
Additional hc updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.DS_Store
 *__pycache__*
+*.pytest_cache*
 
 # environments
 *venv*

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+*.DS_Store
+*__pycache__*
+
+# environments
+*venv*
+
+# Jupyter notebooks
+*.ipynb
+*.ipynb_checkpoints*
+
+feature_definitions.tsv

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -43,7 +43,9 @@
     // pyproject.toml
   "[toml]": {
     "editor.defaultFormatter": "tamasfe.even-better-toml",
-    "editor.formatOnSave": true
+    "editor.formatOnSave": true,
+    "editor.insertSpaces": true,
+    "editor.tabSize": 2,
   },
 
   // Testing UI

--- a/dereferenced/agents/hc.json
+++ b/dereferenced/agents/hc.json
@@ -7,7 +7,7 @@
   "extensions": [
     {
       "name": "last_updated",
-      "value": "2026-05-07",
+      "value": "2026-05-22",
       "description": ""
     },
     {

--- a/dereferenced/indications/ind:hc.enhertu:4.json
+++ b/dereferenced/indications/ind:hc.enhertu:4.json
@@ -3,7 +3,7 @@
   "indication": "ENHERTU as monotherapy is indicated for the treatment of adult patients with unresectable or metastatic HER2-positive (IHC 3+) solid tumours who have received prior systemic treatment and have no satisfactory alternative treatment options.",
   "initial_approval_date": null,
   "initial_approval_url": null,
-  "description": "HHealth Canada approved fam-trastuzumab deruxtecan-nxki as monotherapy is indicated for the treatment of adult patients with unresectable or metastatic HER2-positive (IHC 3+) solid tumours who have received prior systemic treatment and have no satisfactory alternative treatment options.",
+  "description": "Health Canada approved trastuzumab deruxtecan as monotherapy is indicated for the treatment of adult patients with unresectable or metastatic HER2-positive (IHC 3+) solid tumours who have received prior systemic treatment and have no satisfactory alternative treatment options.",
   "raw_biomarkers": "HER2-positive (IHC 3+)",
   "raw_cancer_type": "unresectable or metastatic solid tumours",
   "raw_therapeutics": "Enhertu (trastuzumab deruxtecan)",

--- a/dereferenced/statements/2332.json
+++ b/dereferenced/statements/2332.json
@@ -1,0 +1,667 @@
+{
+  "id": 2332,
+  "type": "Statement",
+  "description": "Health Canada approved encorafenib in combination with cetuximab and mFOLFOX6, for the treatment of patients with metastatic colorectal cancer (mCRC) with a BRAF V600E mutation.",
+  "contributions": [
+    {
+      "id": 0,
+      "type": "Contribution",
+      "description": "Initial access of FDA approvals",
+      "date": "2024-10-30",
+      "contributor": {
+        "id": "vanallenlab",
+        "type": "Agent",
+        "agentType": "contributor",
+        "name": "Van Allen lab",
+        "description": "Van Allen lab, Dana-Farber Cancer Institute"
+      }
+    }
+  ],
+  "reportedIn": [
+    {
+      "id": "doc:hc.braftovi",
+      "type": "Document",
+      "documentType": "Regulatory approval",
+      "name": "Braftovi (encorafenib) [product monograph]. HC.",
+      "title": null,
+      "aliases": [],
+      "description": "Pfizer Canada ULC. Braftovi (encorafenib) [product monograph]. Health Canada website. https://pdf.hres.ca/dpd_pm/00081199.PDF. Revised July 2025. Accessed April 2026.",
+      "urls": [
+        "https://pdf.hres.ca/dpd_pm/00081199.PDF",
+        "https://health-products.canada.ca/dpd-bdpp/info?lang=eng&code=100233"
+      ],
+      "doi": null,
+      "pmid": null,
+      "extensions": [
+        {
+          "name": "agent",
+          "value": {
+            "id": "hc",
+            "type": "Agent",
+            "agentType": "organization",
+            "name": "Health Canada",
+            "description": "Regulatory agency that approves drugs for sale and use in Canada."
+          },
+          "description": "The organization that published this document."
+        },
+        {
+          "name": "company",
+          "value": "Pfizer Canada ULC",
+          "description": "The company that manufactures the cancer drug. Only applicable to market authorization documents."
+        },
+        {
+          "name": "drug_name_brand",
+          "value": "Braftovi",
+          "description": "The brand name of the cancer drug, per this document. Only applicable to market authorization documents."
+        },
+        {
+          "name": "drug_name_generic",
+          "value": "encorafenib",
+          "description": "The generic name of the cancer drug, per this document. Only applicable to market authorization documents."
+        },
+        {
+          "name": "first_publication_date",
+          "value": "2021-03-02",
+          "description": "The publication date for the initial version of this document."
+        },
+        {
+          "name": "identification_number",
+          "value": null,
+          "description": "Identification number used by the publishing organization."
+        },
+        {
+          "name": "publication_date",
+          "value": "2025-07-25",
+          "description": "The publication date for the document."
+        },
+        {
+          "name": "status",
+          "value": "Active",
+          "description": "Whether this document is Active or Deprecated within moalmanac-db."
+        }
+      ]
+    }
+  ],
+  "direction": "supports",
+  "indication": {
+    "id": "ind:hc.braftovi:2",
+    "indication": "BRAFTOVI (encorafenib) is indicated, in combination with cetuximab and mFOLFOX6, for the treatment of patients with metastatic colorectal cancer (mCRC) with a BRAF V600E mutation, as detected by a validated test.",
+    "initial_approval_date": null,
+    "initial_approval_url": null,
+    "description": "Health Canada approved encorafenib in combination with cetuximab and mFOLFOX6, for the treatment of patients with metastatic colorectal cancer (mCRC) with a BRAF V600E mutation.",
+    "raw_biomarkers": "BRAF V600E",
+    "raw_cancer_type": "metastatic colorectal cancer (mCRC)",
+    "raw_therapeutics": "Braftovi (encorafenib) in combination with cetuximab and mFOLFOX6",
+    "document": {
+      "id": "doc:hc.braftovi",
+      "type": "Document",
+      "documentType": "Regulatory approval",
+      "name": "Braftovi (encorafenib) [product monograph]. HC.",
+      "title": null,
+      "aliases": [],
+      "description": "Pfizer Canada ULC. Braftovi (encorafenib) [product monograph]. Health Canada website. https://pdf.hres.ca/dpd_pm/00081199.PDF. Revised July 2025. Accessed April 2026.",
+      "urls": [
+        "https://pdf.hres.ca/dpd_pm/00081199.PDF",
+        "https://health-products.canada.ca/dpd-bdpp/info?lang=eng&code=100233"
+      ],
+      "doi": null,
+      "pmid": null,
+      "extensions": [
+        {
+          "name": "agent",
+          "value": {
+            "id": "hc",
+            "type": "Agent",
+            "agentType": "organization",
+            "name": "Health Canada",
+            "description": "Regulatory agency that approves drugs for sale and use in Canada."
+          },
+          "description": "The organization that published this document."
+        },
+        {
+          "name": "company",
+          "value": "Pfizer Canada ULC",
+          "description": "The company that manufactures the cancer drug. Only applicable to market authorization documents."
+        },
+        {
+          "name": "drug_name_brand",
+          "value": "Braftovi",
+          "description": "The brand name of the cancer drug, per this document. Only applicable to market authorization documents."
+        },
+        {
+          "name": "drug_name_generic",
+          "value": "encorafenib",
+          "description": "The generic name of the cancer drug, per this document. Only applicable to market authorization documents."
+        },
+        {
+          "name": "first_publication_date",
+          "value": "2021-03-02",
+          "description": "The publication date for the initial version of this document."
+        },
+        {
+          "name": "identification_number",
+          "value": null,
+          "description": "Identification number used by the publishing organization."
+        },
+        {
+          "name": "publication_date",
+          "value": "2025-07-25",
+          "description": "The publication date for the document."
+        },
+        {
+          "name": "status",
+          "value": "Active",
+          "description": "Whether this document is Active or Deprecated within moalmanac-db."
+        }
+      ]
+    }
+  },
+  "proposition": {
+    "id": 521,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      {
+        "id": 16,
+        "type": "CategoricalVariant",
+        "name": "BRAF p.V600E",
+        "genes": [
+          {
+            "id": 8,
+            "conceptType": "Gene",
+            "name": "BRAF",
+            "mappings": [
+              {
+                "relation": "exactMatch",
+                "coding": {
+                  "id": "ensembl:ensg00000157764",
+                  "code": "ENSG00000157764",
+                  "system": "https://www.ensembl.org",
+                  "iris": [
+                    "https://www.ensembl.org/id/ENSG00000157764"
+                  ]
+                }
+              },
+              {
+                "relation": "exactMatch",
+                "coding": {
+                  "id": "ncbi:673",
+                  "code": "673",
+                  "system": "https://www.ncbi.nlm.nih.gov/gene",
+                  "iris": [
+                    "https://www.ncbi.nlm.nih.gov/gene/673"
+                  ]
+                }
+              },
+              {
+                "relation": "relatedMatch",
+                "coding": {
+                  "id": "refseq:NM_004333.6",
+                  "code": "NM_004333.6",
+                  "system": "https://www.ncbi.nlm.nih.gov/nuccore",
+                  "iris": [
+                    "https://www.ncbi.nlm.nih.gov/nuccore/NM_004333.6"
+                  ]
+                }
+              }
+            ],
+            "extensions": [
+              {
+                "name": "location",
+                "value": "7q34"
+              },
+              {
+                "name": "location_sortable",
+                "value": "07q34"
+              }
+            ],
+            "primaryCoding": {
+              "id": "hgnc:1097",
+              "code": "HGNC:1097",
+              "system": "https://genenames.org",
+              "iris": [
+                "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/HGNC:1097"
+              ]
+            }
+          }
+        ],
+        "extensions": [
+          {
+            "name": "biomarker_type",
+            "value": "Somatic Variant"
+          },
+          {
+            "name": "chromosome",
+            "value": "7"
+          },
+          {
+            "name": "start_position",
+            "value": 140453136
+          },
+          {
+            "name": "end_position",
+            "value": 140453136
+          },
+          {
+            "name": "reference_allele",
+            "value": "A"
+          },
+          {
+            "name": "alternate_allele",
+            "value": "T"
+          },
+          {
+            "name": "cdna_change",
+            "value": "c.1799T>A"
+          },
+          {
+            "name": "protein_change",
+            "value": "p.V600E"
+          },
+          {
+            "name": "variant_annotation",
+            "value": "Missense"
+          },
+          {
+            "name": "exon",
+            "value": 15
+          },
+          {
+            "name": "rsid",
+            "value": "rs113488022"
+          },
+          {
+            "name": "hgvsg",
+            "value": "7:g.140453136A>T"
+          },
+          {
+            "name": "hgvsc",
+            "value": "ENST00000288602.6:c.1799T>A"
+          },
+          {
+            "name": "_present",
+            "value": true
+          }
+        ]
+      }
+    ],
+    "subjectVariant": {},
+    "conditionQualifier": {
+      "id": 15,
+      "conceptType": "Disease",
+      "name": "Colorectal Adenocarcinoma",
+      "mappings": [],
+      "extensions": [
+        {
+          "name": "solid_tumor",
+          "value": true,
+          "description": "Boolean value for if this tumor type is categorized as a solid tumor."
+        }
+      ],
+      "primaryCoding": {
+        "id": "oncotree:COADREAD",
+        "code": "COADREAD",
+        "name": "Colorectal Adenocarcinoma",
+        "system": "https://oncotree.mskcc.org",
+        "systemVersion": "oncotree_2021_11_02",
+        "iris": [
+          "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=COADREAD"
+        ]
+      }
+    },
+    "objectTherapeutic": {
+      "id": 98,
+      "membershipOperator": "AND",
+      "therapies": [
+        {
+          "id": 29,
+          "conceptType": "Drug",
+          "name": "Fluorouracil",
+          "mappings": [
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "rxcui:4492",
+                "code": "4492",
+                "name": "fluorouracil",
+                "system": "RxNorm",
+                "systemVersion": "20250602",
+                "iris": [
+                  "https://mor.nlm.nih.gov/RxNav/search?searchBy=RXCUI&searchTerm=4492"
+                ]
+              }
+            },
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "omop:4300009",
+                "code": "4300009",
+                "name": "Fluorouracil",
+                "system": "OMOP",
+                "systemVersion": "v20250827",
+                "iris": [
+                  "https://athena.ohdsi.org/search-terms/terms/4300009"
+                ]
+              }
+            },
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "sctid:387172005",
+                "code": "387172005",
+                "name": "Fluorouracil",
+                "system": "SNOMED",
+                "systemVersion": "2026-03-01",
+                "iris": [
+                  "https://browser.ihtsdotools.org/?perspective=full&conceptId1=387172005&edition=MAIN/2026-03-01&release=&languages=en"
+                ]
+              }
+            },
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "omop:955632",
+                "code": "955632",
+                "name": "fluorouracil",
+                "system": "OMOP",
+                "systemVersion": "v20250827",
+                "iris": [
+                  "https://athena.ohdsi.org/search-terms/terms/955632"
+                ]
+              }
+            }
+          ],
+          "extensions": [
+            {
+              "name": "therapy_strategy",
+              "value": [
+                "Thymidylate synthase inhibition"
+              ],
+              "description": "Associated therapeutic strategy or mechanism of action of the therapy."
+            },
+            {
+              "name": "therapy_type",
+              "value": "Chemotherapy",
+              "description": "Type of cancer treatment from cancer.gov: https://www.cancer.gov/about-cancer/treatment/types"
+            }
+          ],
+          "primaryCoding": {
+            "id": "ncit:C505",
+            "code": "C505",
+            "name": "Fluorouracil",
+            "system": "https://evsexplore.semantics.cancer.gov",
+            "systemVersion": "25.01d",
+            "iris": [
+              "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C505"
+            ]
+          }
+        },
+        {
+          "id": 19,
+          "conceptType": "Drug",
+          "name": "Cetuximab",
+          "mappings": [
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "rxcui:318341",
+                "code": "318341",
+                "name": "cetuximab",
+                "system": "RxNorm",
+                "systemVersion": "20250602",
+                "iris": [
+                  "https://mor.nlm.nih.gov/RxNav/search?searchBy=RXCUI&searchTerm=318341"
+                ]
+              }
+            },
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "omop:4247978",
+                "code": "4247978",
+                "name": "Cetuximab",
+                "system": "OMOP",
+                "systemVersion": "v20250827",
+                "iris": [
+                  "https://athena.ohdsi.org/search-terms/terms/4247978"
+                ]
+              }
+            },
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "sctid:409400001",
+                "code": "409400001",
+                "name": "Cetuximab",
+                "system": "SNOMED",
+                "systemVersion": "2026-03-01",
+                "iris": [
+                  "https://browser.ihtsdotools.org/?perspective=full&conceptId1=409400001&edition=MAIN/2026-03-01&release=&languages=en"
+                ]
+              }
+            },
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "omop:1315411",
+                "code": "1315411",
+                "name": "cetuximab",
+                "system": "OMOP",
+                "systemVersion": "v20250827",
+                "iris": [
+                  "https://athena.ohdsi.org/search-terms/terms/1315411"
+                ]
+              }
+            }
+          ],
+          "extensions": [
+            {
+              "name": "therapy_strategy",
+              "value": [
+                "EGFR inhibition"
+              ],
+              "description": "Associated therapeutic strategy or mechanism of action of the therapy."
+            },
+            {
+              "name": "therapy_type",
+              "value": "Targeted therapy",
+              "description": "Type of cancer treatment from cancer.gov: https://www.cancer.gov/about-cancer/treatment/types"
+            }
+          ],
+          "primaryCoding": {
+            "id": "ncit:C1723",
+            "code": "C1723",
+            "name": "Cetuximab",
+            "system": "https://evsexplore.semantics.cancer.gov",
+            "systemVersion": "25.01d",
+            "iris": [
+              "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C1723"
+            ]
+          }
+        },
+        {
+          "id": 18,
+          "conceptType": "Drug",
+          "name": "Encorafenib",
+          "mappings": [
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "rxcui:2049106",
+                "code": "2049106",
+                "name": "encorafenib",
+                "system": "RxNorm",
+                "systemVersion": "20250602",
+                "iris": [
+                  "https://mor.nlm.nih.gov/RxNav/search?searchBy=RXCUI&searchTerm=2049106"
+                ]
+              }
+            },
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "omop:36674339",
+                "code": "36674339",
+                "name": "Encorafenib",
+                "system": "OMOP",
+                "systemVersion": "v20250827",
+                "iris": [
+                  "https://athena.ohdsi.org/search-terms/terms/36674339"
+                ]
+              }
+            },
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "sctid:772201002",
+                "code": "772201002",
+                "name": "Encorafenib",
+                "system": "SNOMED",
+                "systemVersion": "2026-03-01",
+                "iris": [
+                  "https://browser.ihtsdotools.org/?perspective=full&conceptId1=772201002&edition=MAIN/2026-03-01&release=&languages=en"
+                ]
+              }
+            },
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "omop:1559914",
+                "code": "1559914",
+                "name": "encorafenib",
+                "system": "OMOP",
+                "systemVersion": "v20250827",
+                "iris": [
+                  "https://athena.ohdsi.org/search-terms/terms/1559914"
+                ]
+              }
+            }
+          ],
+          "extensions": [
+            {
+              "name": "therapy_strategy",
+              "value": [
+                "B-RAF inhibition"
+              ],
+              "description": "Associated therapeutic strategy or mechanism of action of the therapy."
+            },
+            {
+              "name": "therapy_type",
+              "value": "Targeted therapy",
+              "description": "Type of cancer treatment from cancer.gov: https://www.cancer.gov/about-cancer/treatment/types"
+            }
+          ],
+          "primaryCoding": {
+            "id": "ncit:C98283",
+            "code": "C98283",
+            "name": "Encorafenib",
+            "system": "https://evsexplore.semantics.cancer.gov",
+            "systemVersion": "25.01d",
+            "iris": [
+              "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C98283"
+            ]
+          }
+        },
+        {
+          "id": 28,
+          "conceptType": "Drug",
+          "name": "Oxaliplatin",
+          "mappings": [
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "rxcui:32592",
+                "code": "32592",
+                "name": "oxaliplatin",
+                "system": "RxNorm",
+                "systemVersion": "20250602",
+                "iris": [
+                  "https://mor.nlm.nih.gov/RxNav/search?searchBy=RXCUI&searchTerm=32592"
+                ]
+              }
+            },
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "omop:4216937",
+                "code": "4216937",
+                "name": "Oxaliplatin",
+                "system": "OMOP",
+                "systemVersion": "v20250827",
+                "iris": [
+                  "https://athena.ohdsi.org/search-terms/terms/4216937"
+                ]
+              }
+            },
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "sctid:395814003",
+                "code": "395814003",
+                "name": "Oxaliplatin",
+                "system": "SNOMED",
+                "systemVersion": "2026-03-01",
+                "iris": [
+                  "https://browser.ihtsdotools.org/?perspective=full&conceptId1=395814003&edition=MAIN/2026-03-01&release=&languages=en"
+                ]
+              }
+            },
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "omop:1318011",
+                "code": "1318011",
+                "name": "oxaliplatin",
+                "system": "OMOP",
+                "systemVersion": "v20250827",
+                "iris": [
+                  "https://athena.ohdsi.org/search-terms/terms/1318011"
+                ]
+              }
+            }
+          ],
+          "extensions": [
+            {
+              "name": "therapy_strategy",
+              "value": [
+                "Platinum-based chemotherapy"
+              ],
+              "description": "Associated therapeutic strategy or mechanism of action of the therapy."
+            },
+            {
+              "name": "therapy_type",
+              "value": "Chemotherapy",
+              "description": "Type of cancer treatment from cancer.gov: https://www.cancer.gov/about-cancer/treatment/types"
+            }
+          ],
+          "primaryCoding": {
+            "id": "ncit:C1181",
+            "code": "C1181",
+            "name": "Oxaliplatin",
+            "system": "https://evsexplore.semantics.cancer.gov",
+            "systemVersion": "25.01d",
+            "iris": [
+              "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C1181"
+            ]
+          }
+        }
+      ]
+    }
+  },
+  "strength": {
+    "id": 0,
+    "conceptType": "Evidence",
+    "name": "Approval",
+    "mappings": [],
+    "primaryCoding": {
+      "id": "ncit:C25425",
+      "code": "C25425",
+      "name": "Approval",
+      "system": "https://evsexplore.semantics.cancer.gov",
+      "systemVersion": "25.01d",
+      "iris": [
+        "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C25425"
+      ]
+    }
+  }
+}

--- a/dereferenced/statements/2334.json
+++ b/dereferenced/statements/2334.json
@@ -1,0 +1,320 @@
+{
+  "id": 2334,
+  "type": "Statement",
+  "description": "Health Canada approved pembrolizumab, in combination with chemotherapy with or without bevacizumab, for the treatment of adult patients with persistent, recurrent, or metastatic cervical cancer whose tumours express PD-L1 (CPS >= 1) as determined by a validated test.",
+  "contributions": [
+    {
+      "id": 0,
+      "type": "Contribution",
+      "description": "Initial access of FDA approvals",
+      "date": "2024-10-30",
+      "contributor": {
+        "id": "vanallenlab",
+        "type": "Agent",
+        "agentType": "contributor",
+        "name": "Van Allen lab",
+        "description": "Van Allen lab, Dana-Farber Cancer Institute"
+      }
+    }
+  ],
+  "reportedIn": [
+    {
+      "id": "doc:hc.keytruda",
+      "type": "Document",
+      "documentType": "Regulatory approval",
+      "name": "Keytruda (pembrolizumab) [product monograph]. HC.",
+      "title": null,
+      "aliases": [],
+      "description": "Merck Canada Inc. Keytruda (pembrolizumab) [product monograph]. Health Canada website. https://pdf.hres.ca/dpd_pm/00083378.PDF. Published January 2026. Accessed April 2026.",
+      "urls": [
+        "https://pdf.hres.ca/dpd_pm/00083378.PDF",
+        "https://health-products.canada.ca/dpd-bdpp/info?lang=eng&code=94388"
+      ],
+      "doi": null,
+      "pmid": null,
+      "extensions": [
+        {
+          "name": "agent",
+          "value": {
+            "id": "hc",
+            "type": "Agent",
+            "agentType": "organization",
+            "name": "Health Canada",
+            "description": "Regulatory agency that approves drugs for sale and use in Canada."
+          },
+          "description": "The organization that published this document."
+        },
+        {
+          "name": "company",
+          "value": "Merck Canada Inc.",
+          "description": "The company that manufactures the cancer drug. Only applicable to market authorization documents."
+        },
+        {
+          "name": "drug_name_brand",
+          "value": "Keytruda",
+          "description": "The brand name of the cancer drug, per this document. Only applicable to market authorization documents."
+        },
+        {
+          "name": "drug_name_generic",
+          "value": "pembrolizumab",
+          "description": "The generic name of the cancer drug, per this document. Only applicable to market authorization documents."
+        },
+        {
+          "name": "first_publication_date",
+          "value": "2025-04-11",
+          "description": "The publication date for the initial version of this document."
+        },
+        {
+          "name": "identification_number",
+          "value": null,
+          "description": "Identification number used by the publishing organization."
+        },
+        {
+          "name": "publication_date",
+          "value": "2026-01-14",
+          "description": "The publication date for the document."
+        },
+        {
+          "name": "status",
+          "value": "Active",
+          "description": "Whether this document is Active or Deprecated within moalmanac-db."
+        }
+      ]
+    }
+  ],
+  "direction": "supports",
+  "indication": {
+    "id": "ind:hc.keytruda:12",
+    "indication": "KEYTRUDA (pembrolizumab), in combination with chemotherapy with or without bevacizumab, is indicated for the treatment of adult patients with persistent, recurrent, or metastatic cervical cancer whose tumours express PD-L1 (CPS >= 1) as determined by a validated test.",
+    "initial_approval_date": null,
+    "initial_approval_url": null,
+    "description": "Health Canada approved pembrolizumab, in combination with chemotherapy with or without bevacizumab, for the treatment of adult patients with persistent, recurrent, or metastatic cervical cancer whose tumours express PD-L1 (CPS >= 1) as determined by a validated test.",
+    "raw_biomarkers": "PD-L1 (CPS >= 1)",
+    "raw_cancer_type": "persistent, recurrent, or metastatic cervical cancer",
+    "raw_therapeutics": "Keytruda (pembrolizumab), chemotherapy, bevacizumab",
+    "document": {
+      "id": "doc:hc.keytruda",
+      "type": "Document",
+      "documentType": "Regulatory approval",
+      "name": "Keytruda (pembrolizumab) [product monograph]. HC.",
+      "title": null,
+      "aliases": [],
+      "description": "Merck Canada Inc. Keytruda (pembrolizumab) [product monograph]. Health Canada website. https://pdf.hres.ca/dpd_pm/00083378.PDF. Published January 2026. Accessed April 2026.",
+      "urls": [
+        "https://pdf.hres.ca/dpd_pm/00083378.PDF",
+        "https://health-products.canada.ca/dpd-bdpp/info?lang=eng&code=94388"
+      ],
+      "doi": null,
+      "pmid": null,
+      "extensions": [
+        {
+          "name": "agent",
+          "value": {
+            "id": "hc",
+            "type": "Agent",
+            "agentType": "organization",
+            "name": "Health Canada",
+            "description": "Regulatory agency that approves drugs for sale and use in Canada."
+          },
+          "description": "The organization that published this document."
+        },
+        {
+          "name": "company",
+          "value": "Merck Canada Inc.",
+          "description": "The company that manufactures the cancer drug. Only applicable to market authorization documents."
+        },
+        {
+          "name": "drug_name_brand",
+          "value": "Keytruda",
+          "description": "The brand name of the cancer drug, per this document. Only applicable to market authorization documents."
+        },
+        {
+          "name": "drug_name_generic",
+          "value": "pembrolizumab",
+          "description": "The generic name of the cancer drug, per this document. Only applicable to market authorization documents."
+        },
+        {
+          "name": "first_publication_date",
+          "value": "2025-04-11",
+          "description": "The publication date for the initial version of this document."
+        },
+        {
+          "name": "identification_number",
+          "value": null,
+          "description": "Identification number used by the publishing organization."
+        },
+        {
+          "name": "publication_date",
+          "value": "2026-01-14",
+          "description": "The publication date for the document."
+        },
+        {
+          "name": "status",
+          "value": "Active",
+          "description": "Whether this document is Active or Deprecated within moalmanac-db."
+        }
+      ]
+    }
+  },
+  "proposition": {
+    "id": 320,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      {
+        "id": 42,
+        "type": "CategoricalVariant",
+        "name": "PD-L1 (CPS) >= 1",
+        "extensions": [
+          {
+            "name": "biomarker_type",
+            "value": "Protein expression"
+          },
+          {
+            "name": "marker",
+            "value": "PD-L1"
+          },
+          {
+            "name": "unit",
+            "value": "Combined Positive Score (CPS)"
+          },
+          {
+            "name": "equality",
+            "value": ">="
+          },
+          {
+            "name": "value",
+            "value": 1
+          },
+          {
+            "name": "_present",
+            "value": true
+          }
+        ]
+      }
+    ],
+    "subjectVariant": {},
+    "conditionQualifier": {
+      "id": 25,
+      "conceptType": "Disease",
+      "name": "Head and Neck Squamous Cell Carcinoma",
+      "mappings": [],
+      "extensions": [
+        {
+          "name": "solid_tumor",
+          "value": true,
+          "description": "Boolean value for if this tumor type is categorized as a solid tumor."
+        }
+      ],
+      "primaryCoding": {
+        "id": "oncotree:HNSC",
+        "code": "HNSC",
+        "name": "Head and Neck Squamous Cell Carcinoma",
+        "system": "https://oncotree.mskcc.org",
+        "systemVersion": "oncotree_2021_11_02",
+        "iris": [
+          "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=HNSC"
+        ]
+      }
+    },
+    "objectTherapeutic": {
+      "id": 48,
+      "conceptType": "Drug",
+      "name": "Pembrolizumab",
+      "mappings": [
+        {
+          "relation": "relatedMatch",
+          "coding": {
+            "id": "rxcui:1547545",
+            "code": "1547545",
+            "name": "pembrolizumab",
+            "system": "RxNorm",
+            "systemVersion": "02-Mar-2026",
+            "iris": [
+              "https://mor.nlm.nih.gov/RxNav/search?searchBy=RXCUI&searchTerm=1547545"
+            ]
+          }
+        },
+        {
+          "relation": "relatedMatch",
+          "coding": {
+            "id": "omop:45775965",
+            "code": "45775965",
+            "name": "pembrolizumab",
+            "system": "OMOP",
+            "systemVersion": "v20260227",
+            "iris": [
+              "https://athena.ohdsi.org/search-terms/terms/45775965"
+            ]
+          }
+        },
+        {
+          "relation": "relatedMatch",
+          "coding": {
+            "id": "sctid:716125002",
+            "code": "716125002",
+            "name": "Pembrolizumab",
+            "system": "SNOMED",
+            "systemVersion": "2025-03-01",
+            "iris": [
+              "https://browser.ihtsdotools.org/?perspective=full&conceptId1=716125002&edition=MAIN/2025-03-01&release=&languages=en"
+            ]
+          }
+        },
+        {
+          "relation": "relatedMatch",
+          "coding": {
+            "id": "omop:37396350",
+            "code": "37396350",
+            "name": "Pembrolizumab",
+            "system": "OMOP",
+            "systemVersion": "v20260227",
+            "iris": [
+              "https://athena.ohdsi.org/search-terms/terms/37396350"
+            ]
+          }
+        }
+      ],
+      "extensions": [
+        {
+          "name": "therapy_strategy",
+          "value": [
+            "PD-1/PD-L1 inhibition"
+          ],
+          "description": "Associated therapeutic strategy or mechanism of action of the therapy."
+        },
+        {
+          "name": "therapy_type",
+          "value": "Immunotherapy",
+          "description": "Type of cancer treatment from cancer.gov: https://www.cancer.gov/about-cancer/treatment/types"
+        }
+      ],
+      "primaryCoding": {
+        "id": "ncit:C106432",
+        "code": "C106432",
+        "name": "Pembrolizumab",
+        "system": "https://evsexplore.semantics.cancer.gov",
+        "systemVersion": "25.01d",
+        "iris": [
+          "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C106432"
+        ]
+      }
+    }
+  },
+  "strength": {
+    "id": 0,
+    "conceptType": "Evidence",
+    "name": "Approval",
+    "mappings": [],
+    "primaryCoding": {
+      "id": "ncit:C25425",
+      "code": "C25425",
+      "name": "Approval",
+      "system": "https://evsexplore.semantics.cancer.gov",
+      "systemVersion": "25.01d",
+      "iris": [
+        "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C25425"
+      ]
+    }
+  }
+}

--- a/dereferenced/statements/2335.json
+++ b/dereferenced/statements/2335.json
@@ -1,0 +1,523 @@
+{
+  "id": 2335,
+  "type": "Statement",
+  "description": "Health Canada approved ribociclib in combination with an aromatase inhibitor for the adjuvant treatment of adult patients with hormone receptor (HR)-positive, human epidermal growth factor receptor 2 (HER2)-negative stage II-III early breast cancer at high risk of recurrence. This indication is based on NATALEE (LEE011 O12301C) was a randomized (1:1), open-label, multicenter study, where participants received goserelin and either letrozole or anastrozole, in addition to ribociclib.",
+  "contributions": [
+    {
+      "id": 0,
+      "type": "Contribution",
+      "description": "Initial access of FDA approvals",
+      "date": "2024-10-30",
+      "contributor": {
+        "id": "vanallenlab",
+        "type": "Agent",
+        "agentType": "contributor",
+        "name": "Van Allen lab",
+        "description": "Van Allen lab, Dana-Farber Cancer Institute"
+      }
+    }
+  ],
+  "reportedIn": [
+    {
+      "id": "doc:hc.kisqali",
+      "type": "Document",
+      "documentType": "Regulatory approval",
+      "name": "Kisqali (ribociclib) [product monograph]. HC.",
+      "title": null,
+      "aliases": [],
+      "description": "Novartis Pharmaceuticals Canada Inc. Kisqali (ribociclib) [product monograph]. Health Canada website. https://pdf.hres.ca/dpd_pm/00083872.PDF. Revised March 2026. Accessed April 2026.",
+      "urls": [
+        "https://pdf.hres.ca/dpd_pm/00083872.PDF",
+        "https://health-products.canada.ca/dpd-bdpp/info?lang=eng&code=96295"
+      ],
+      "doi": null,
+      "pmid": null,
+      "extensions": [
+        {
+          "name": "agent",
+          "value": {
+            "id": "hc",
+            "type": "Agent",
+            "agentType": "organization",
+            "name": "Health Canada",
+            "description": "Regulatory agency that approves drugs for sale and use in Canada."
+          },
+          "description": "The organization that published this document."
+        },
+        {
+          "name": "company",
+          "value": "Novartis Pharmaceuticals Canada Inc.",
+          "description": "The company that manufactures the cancer drug. Only applicable to market authorization documents."
+        },
+        {
+          "name": "drug_name_brand",
+          "value": "Kisqali",
+          "description": "The brand name of the cancer drug, per this document. Only applicable to market authorization documents."
+        },
+        {
+          "name": "drug_name_generic",
+          "value": "ribociclib",
+          "description": "The generic name of the cancer drug, per this document. Only applicable to market authorization documents."
+        },
+        {
+          "name": "first_publication_date",
+          "value": "2018-03-02",
+          "description": "The publication date for the initial version of this document."
+        },
+        {
+          "name": "identification_number",
+          "value": null,
+          "description": "Identification number used by the publishing organization."
+        },
+        {
+          "name": "publication_date",
+          "value": "2026-03-26",
+          "description": "The publication date for the document."
+        },
+        {
+          "name": "status",
+          "value": "Active",
+          "description": "Whether this document is Active or Deprecated within moalmanac-db."
+        }
+      ]
+    }
+  ],
+  "direction": "supports",
+  "indication": {
+    "id": "ind:hc.kisqali:2",
+    "indication": "KISQALI (ribociclib tablets) is indicated, in combination with an aromatase inhibitor for the adjuvant treatment of adult patients with hormone receptor (HR)-positive, human epidermal growth factor receptor 2 (HER2)-negative stage II-III early breast cancer at high risk of recurrence.",
+    "initial_approval_date": null,
+    "initial_approval_url": null,
+    "description": "Health Canada approved ribociclib in combination with an aromatase inhibitor for the adjuvant treatment of adult patients with hormone receptor (HR)-positive, human epidermal growth factor receptor 2 (HER2)-negative stage II-III early breast cancer at high risk of recurrence. This indication is based on NATALEE (LEE011 O12301C) was a randomized (1:1), open-label, multicenter study, where participants received goserelin and either letrozole or anastrozole, in addition to ribociclib.",
+    "raw_biomarkers": "HR+, HER2-negative",
+    "raw_cancer_type": "early breast cancer",
+    "raw_therapeutics": "Kisqali (ribociclib), aromatase inhibitor",
+    "document": {
+      "id": "doc:hc.kisqali",
+      "type": "Document",
+      "documentType": "Regulatory approval",
+      "name": "Kisqali (ribociclib) [product monograph]. HC.",
+      "title": null,
+      "aliases": [],
+      "description": "Novartis Pharmaceuticals Canada Inc. Kisqali (ribociclib) [product monograph]. Health Canada website. https://pdf.hres.ca/dpd_pm/00083872.PDF. Revised March 2026. Accessed April 2026.",
+      "urls": [
+        "https://pdf.hres.ca/dpd_pm/00083872.PDF",
+        "https://health-products.canada.ca/dpd-bdpp/info?lang=eng&code=96295"
+      ],
+      "doi": null,
+      "pmid": null,
+      "extensions": [
+        {
+          "name": "agent",
+          "value": {
+            "id": "hc",
+            "type": "Agent",
+            "agentType": "organization",
+            "name": "Health Canada",
+            "description": "Regulatory agency that approves drugs for sale and use in Canada."
+          },
+          "description": "The organization that published this document."
+        },
+        {
+          "name": "company",
+          "value": "Novartis Pharmaceuticals Canada Inc.",
+          "description": "The company that manufactures the cancer drug. Only applicable to market authorization documents."
+        },
+        {
+          "name": "drug_name_brand",
+          "value": "Kisqali",
+          "description": "The brand name of the cancer drug, per this document. Only applicable to market authorization documents."
+        },
+        {
+          "name": "drug_name_generic",
+          "value": "ribociclib",
+          "description": "The generic name of the cancer drug, per this document. Only applicable to market authorization documents."
+        },
+        {
+          "name": "first_publication_date",
+          "value": "2018-03-02",
+          "description": "The publication date for the initial version of this document."
+        },
+        {
+          "name": "identification_number",
+          "value": null,
+          "description": "Identification number used by the publishing organization."
+        },
+        {
+          "name": "publication_date",
+          "value": "2026-03-26",
+          "description": "The publication date for the document."
+        },
+        {
+          "name": "status",
+          "value": "Active",
+          "description": "Whether this document is Active or Deprecated within moalmanac-db."
+        }
+      ]
+    }
+  },
+  "proposition": {
+    "id": 499,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      {
+        "id": 1,
+        "type": "CategoricalVariant",
+        "name": "ER positive",
+        "extensions": [
+          {
+            "name": "biomarker_type",
+            "value": "Protein expression"
+          },
+          {
+            "name": "marker",
+            "value": "Estrogen receptor (ER)"
+          },
+          {
+            "name": "unit",
+            "value": "status"
+          },
+          {
+            "name": "equality",
+            "value": "="
+          },
+          {
+            "name": "value",
+            "value": "Positive"
+          },
+          {
+            "name": "_present",
+            "value": true
+          }
+        ]
+      },
+      {
+        "id": 2,
+        "type": "CategoricalVariant",
+        "name": "HER2-negative",
+        "extensions": [
+          {
+            "name": "biomarker_type",
+            "value": "Protein expression"
+          },
+          {
+            "name": "marker",
+            "value": "Human epidermal growth factor receptor 2 (HER2)"
+          },
+          {
+            "name": "unit",
+            "value": "status"
+          },
+          {
+            "name": "equality",
+            "value": "="
+          },
+          {
+            "name": "value",
+            "value": "Negative"
+          },
+          {
+            "name": "_present",
+            "value": true
+          }
+        ]
+      }
+    ],
+    "subjectVariant": {},
+    "conditionQualifier": {
+      "id": 9,
+      "conceptType": "Disease",
+      "name": "Invasive Breast Carcinoma",
+      "mappings": [],
+      "extensions": [
+        {
+          "name": "solid_tumor",
+          "value": true,
+          "description": "Boolean value for if this tumor type is categorized as a solid tumor."
+        }
+      ],
+      "primaryCoding": {
+        "id": "oncotree:BRCA",
+        "code": "BRCA",
+        "name": "Invasive Breast Carcinoma",
+        "system": "https://oncotree.mskcc.org",
+        "systemVersion": "oncotree_2021_11_02",
+        "iris": [
+          "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=BRCA"
+        ]
+      }
+    },
+    "objectTherapeutic": {
+      "id": 91,
+      "membershipOperator": "AND",
+      "therapies": [
+        {
+          "id": 36,
+          "conceptType": "Drug",
+          "name": "Anastrozole",
+          "mappings": [
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "rxcui:84857",
+                "code": "84857",
+                "name": "anastrozole",
+                "system": "RxNorm",
+                "systemVersion": "20250602",
+                "iris": [
+                  "https://mor.nlm.nih.gov/RxNav/search?searchBy=RXCUI&searchTerm=84857"
+                ]
+              }
+            },
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "omop:4297546",
+                "code": "4297546",
+                "name": "Anastrozole",
+                "system": "OMOP",
+                "systemVersion": "v20250827",
+                "iris": [
+                  "https://athena.ohdsi.org/search-terms/terms/4297546"
+                ]
+              }
+            },
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "sctid:386910003",
+                "code": "386910003",
+                "name": "Anastrozole",
+                "system": "SNOMED",
+                "systemVersion": "2026-03-01",
+                "iris": [
+                  "https://browser.ihtsdotools.org/?perspective=full&conceptId1=386910003&edition=MAIN/2026-03-01&release=&languages=en"
+                ]
+              }
+            },
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "omop:1348265",
+                "code": "1348265",
+                "name": "anastrozole",
+                "system": "OMOP",
+                "systemVersion": "v20250827",
+                "iris": [
+                  "https://athena.ohdsi.org/search-terms/terms/1348265"
+                ]
+              }
+            }
+          ],
+          "extensions": [
+            {
+              "name": "therapy_strategy",
+              "value": [
+                "Aromatase inhibition"
+              ],
+              "description": "Associated therapeutic strategy or mechanism of action of the therapy."
+            },
+            {
+              "name": "therapy_type",
+              "value": "Hormone therapy",
+              "description": "Type of cancer treatment from cancer.gov: https://www.cancer.gov/about-cancer/treatment/types"
+            }
+          ],
+          "primaryCoding": {
+            "id": "ncit:C1607",
+            "code": "C1607",
+            "name": "Anastrozole",
+            "system": "https://evsexplore.semantics.cancer.gov",
+            "systemVersion": "25.01d",
+            "iris": [
+              "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C1607"
+            ]
+          }
+        },
+        {
+          "id": 143,
+          "conceptType": "Drug",
+          "name": "Goserelin",
+          "mappings": [
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "rxcui:50610",
+                "code": "50610",
+                "name": "goserelin",
+                "system": "RxNorm",
+                "systemVersion": "02-Mar-2026",
+                "iris": [
+                  "https://mor.nlm.nih.gov/RxNav/search?searchBy=RXCUI&searchTerm=50610"
+                ]
+              }
+            },
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "omop:1366310",
+                "code": "1366310",
+                "name": "goserelin",
+                "system": "OMOP",
+                "systemVersion": "v20260227",
+                "iris": [
+                  "https://athena.ohdsi.org/search-terms/terms/1366310"
+                ]
+              }
+            },
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "sctid:108771008",
+                "code": "108771008",
+                "name": "Goserelin",
+                "system": "SNOMED",
+                "systemVersion": "2025-03-01",
+                "iris": [
+                  "https://browser.ihtsdotools.org/?perspective=full&conceptId1=108771008&edition=MAIN/2025-03-01&release=&languages=en"
+                ]
+              }
+            },
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "omop:4031929",
+                "code": "4031929",
+                "name": "Goserelin",
+                "system": "OMOP",
+                "systemVersion": "v20260227",
+                "iris": [
+                  "https://athena.ohdsi.org/search-terms/terms/4031929"
+                ]
+              }
+            }
+          ],
+          "extensions": [
+            {
+              "name": "therapy_strategy",
+              "value": [
+                "Gonadotropin-releasing hormone (GnRH) agonist"
+              ],
+              "description": "Associated therapeutic strategy or mechanism of action of the therapy."
+            },
+            {
+              "name": "therapy_type",
+              "value": "Hormone therapy",
+              "description": "Type of cancer treatment from cancer.gov: https://www.cancer.gov/about-cancer/treatment/types"
+            }
+          ],
+          "primaryCoding": {
+            "id": "ncit:C1374",
+            "code": "C1374",
+            "name": "Goserelin",
+            "system": "https://evsexplore.semantics.cancer.gov",
+            "systemVersion": "25.01d",
+            "iris": [
+              "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C1374"
+            ]
+          }
+        },
+        {
+          "id": 53,
+          "conceptType": "Drug",
+          "name": "Ribociclib",
+          "mappings": [
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "rxcui:1873916",
+                "code": "1873916",
+                "name": "ribociclib",
+                "system": "RxNorm",
+                "systemVersion": "02-Mar-2026",
+                "iris": [
+                  "https://mor.nlm.nih.gov/RxNav/search?searchBy=RXCUI&searchTerm=1873916"
+                ]
+              }
+            },
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "omop:1592911",
+                "code": "1592911",
+                "name": "ribociclib",
+                "system": "OMOP",
+                "systemVersion": "v20260227",
+                "iris": [
+                  "https://athena.ohdsi.org/search-terms/terms/1592911"
+                ]
+              }
+            },
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "sctid:732257004",
+                "code": "732257004",
+                "name": "Ribociclib",
+                "system": "SNOMED",
+                "systemVersion": "2025-03-01",
+                "iris": [
+                  "https://browser.ihtsdotools.org/?perspective=full&conceptId1=732257004&edition=MAIN/2025-03-01&release=&languages=en"
+                ]
+              }
+            },
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "omop:37115766",
+                "code": "37115766",
+                "name": "Ribociclib",
+                "system": "OMOP",
+                "systemVersion": "v20260227",
+                "iris": [
+                  "https://athena.ohdsi.org/search-terms/terms/37115766"
+                ]
+              }
+            }
+          ],
+          "extensions": [
+            {
+              "name": "therapy_strategy",
+              "value": [
+                "CDK4/6 inhibition"
+              ],
+              "description": "Associated therapeutic strategy or mechanism of action of the therapy."
+            },
+            {
+              "name": "therapy_type",
+              "value": "Targeted therapy",
+              "description": "Type of cancer treatment from cancer.gov: https://www.cancer.gov/about-cancer/treatment/types"
+            }
+          ],
+          "primaryCoding": {
+            "id": "ncit:C95701",
+            "code": "C95701",
+            "name": "Ribociclib",
+            "system": "https://evsexplore.semantics.cancer.gov",
+            "systemVersion": "25.01d",
+            "iris": [
+              "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C95701"
+            ]
+          }
+        }
+      ]
+    }
+  },
+  "strength": {
+    "id": 0,
+    "conceptType": "Evidence",
+    "name": "Approval",
+    "mappings": [],
+    "primaryCoding": {
+      "id": "ncit:C25425",
+      "code": "C25425",
+      "name": "Approval",
+      "system": "https://evsexplore.semantics.cancer.gov",
+      "systemVersion": "25.01d",
+      "iris": [
+        "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C25425"
+      ]
+    }
+  }
+}

--- a/dereferenced/statements/2336.json
+++ b/dereferenced/statements/2336.json
@@ -1,0 +1,523 @@
+{
+  "id": 2336,
+  "type": "Statement",
+  "description": "Health Canada approved ribociclib in combination with an aromatase inhibitor for the adjuvant treatment of adult patients with hormone receptor (HR)-positive, human epidermal growth factor receptor 2 (HER2)-negative stage II-III early breast cancer at high risk of recurrence. This indication is based on NATALEE (LEE011 O12301C) was a randomized (1:1), open-label, multicenter study, where participants received goserelin and either letrozole or anastrozole, in addition to ribociclib.",
+  "contributions": [
+    {
+      "id": 0,
+      "type": "Contribution",
+      "description": "Initial access of FDA approvals",
+      "date": "2024-10-30",
+      "contributor": {
+        "id": "vanallenlab",
+        "type": "Agent",
+        "agentType": "contributor",
+        "name": "Van Allen lab",
+        "description": "Van Allen lab, Dana-Farber Cancer Institute"
+      }
+    }
+  ],
+  "reportedIn": [
+    {
+      "id": "doc:hc.kisqali",
+      "type": "Document",
+      "documentType": "Regulatory approval",
+      "name": "Kisqali (ribociclib) [product monograph]. HC.",
+      "title": null,
+      "aliases": [],
+      "description": "Novartis Pharmaceuticals Canada Inc. Kisqali (ribociclib) [product monograph]. Health Canada website. https://pdf.hres.ca/dpd_pm/00083872.PDF. Revised March 2026. Accessed April 2026.",
+      "urls": [
+        "https://pdf.hres.ca/dpd_pm/00083872.PDF",
+        "https://health-products.canada.ca/dpd-bdpp/info?lang=eng&code=96295"
+      ],
+      "doi": null,
+      "pmid": null,
+      "extensions": [
+        {
+          "name": "agent",
+          "value": {
+            "id": "hc",
+            "type": "Agent",
+            "agentType": "organization",
+            "name": "Health Canada",
+            "description": "Regulatory agency that approves drugs for sale and use in Canada."
+          },
+          "description": "The organization that published this document."
+        },
+        {
+          "name": "company",
+          "value": "Novartis Pharmaceuticals Canada Inc.",
+          "description": "The company that manufactures the cancer drug. Only applicable to market authorization documents."
+        },
+        {
+          "name": "drug_name_brand",
+          "value": "Kisqali",
+          "description": "The brand name of the cancer drug, per this document. Only applicable to market authorization documents."
+        },
+        {
+          "name": "drug_name_generic",
+          "value": "ribociclib",
+          "description": "The generic name of the cancer drug, per this document. Only applicable to market authorization documents."
+        },
+        {
+          "name": "first_publication_date",
+          "value": "2018-03-02",
+          "description": "The publication date for the initial version of this document."
+        },
+        {
+          "name": "identification_number",
+          "value": null,
+          "description": "Identification number used by the publishing organization."
+        },
+        {
+          "name": "publication_date",
+          "value": "2026-03-26",
+          "description": "The publication date for the document."
+        },
+        {
+          "name": "status",
+          "value": "Active",
+          "description": "Whether this document is Active or Deprecated within moalmanac-db."
+        }
+      ]
+    }
+  ],
+  "direction": "supports",
+  "indication": {
+    "id": "ind:hc.kisqali:2",
+    "indication": "KISQALI (ribociclib tablets) is indicated, in combination with an aromatase inhibitor for the adjuvant treatment of adult patients with hormone receptor (HR)-positive, human epidermal growth factor receptor 2 (HER2)-negative stage II-III early breast cancer at high risk of recurrence.",
+    "initial_approval_date": null,
+    "initial_approval_url": null,
+    "description": "Health Canada approved ribociclib in combination with an aromatase inhibitor for the adjuvant treatment of adult patients with hormone receptor (HR)-positive, human epidermal growth factor receptor 2 (HER2)-negative stage II-III early breast cancer at high risk of recurrence. This indication is based on NATALEE (LEE011 O12301C) was a randomized (1:1), open-label, multicenter study, where participants received goserelin and either letrozole or anastrozole, in addition to ribociclib.",
+    "raw_biomarkers": "HR+, HER2-negative",
+    "raw_cancer_type": "early breast cancer",
+    "raw_therapeutics": "Kisqali (ribociclib), aromatase inhibitor",
+    "document": {
+      "id": "doc:hc.kisqali",
+      "type": "Document",
+      "documentType": "Regulatory approval",
+      "name": "Kisqali (ribociclib) [product monograph]. HC.",
+      "title": null,
+      "aliases": [],
+      "description": "Novartis Pharmaceuticals Canada Inc. Kisqali (ribociclib) [product monograph]. Health Canada website. https://pdf.hres.ca/dpd_pm/00083872.PDF. Revised March 2026. Accessed April 2026.",
+      "urls": [
+        "https://pdf.hres.ca/dpd_pm/00083872.PDF",
+        "https://health-products.canada.ca/dpd-bdpp/info?lang=eng&code=96295"
+      ],
+      "doi": null,
+      "pmid": null,
+      "extensions": [
+        {
+          "name": "agent",
+          "value": {
+            "id": "hc",
+            "type": "Agent",
+            "agentType": "organization",
+            "name": "Health Canada",
+            "description": "Regulatory agency that approves drugs for sale and use in Canada."
+          },
+          "description": "The organization that published this document."
+        },
+        {
+          "name": "company",
+          "value": "Novartis Pharmaceuticals Canada Inc.",
+          "description": "The company that manufactures the cancer drug. Only applicable to market authorization documents."
+        },
+        {
+          "name": "drug_name_brand",
+          "value": "Kisqali",
+          "description": "The brand name of the cancer drug, per this document. Only applicable to market authorization documents."
+        },
+        {
+          "name": "drug_name_generic",
+          "value": "ribociclib",
+          "description": "The generic name of the cancer drug, per this document. Only applicable to market authorization documents."
+        },
+        {
+          "name": "first_publication_date",
+          "value": "2018-03-02",
+          "description": "The publication date for the initial version of this document."
+        },
+        {
+          "name": "identification_number",
+          "value": null,
+          "description": "Identification number used by the publishing organization."
+        },
+        {
+          "name": "publication_date",
+          "value": "2026-03-26",
+          "description": "The publication date for the document."
+        },
+        {
+          "name": "status",
+          "value": "Active",
+          "description": "Whether this document is Active or Deprecated within moalmanac-db."
+        }
+      ]
+    }
+  },
+  "proposition": {
+    "id": 500,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      {
+        "id": 2,
+        "type": "CategoricalVariant",
+        "name": "HER2-negative",
+        "extensions": [
+          {
+            "name": "biomarker_type",
+            "value": "Protein expression"
+          },
+          {
+            "name": "marker",
+            "value": "Human epidermal growth factor receptor 2 (HER2)"
+          },
+          {
+            "name": "unit",
+            "value": "status"
+          },
+          {
+            "name": "equality",
+            "value": "="
+          },
+          {
+            "name": "value",
+            "value": "Negative"
+          },
+          {
+            "name": "_present",
+            "value": true
+          }
+        ]
+      },
+      {
+        "id": 3,
+        "type": "CategoricalVariant",
+        "name": "PR positive",
+        "extensions": [
+          {
+            "name": "biomarker_type",
+            "value": "Protein expression"
+          },
+          {
+            "name": "marker",
+            "value": "Progesterone receptor (PR)"
+          },
+          {
+            "name": "unit",
+            "value": "status"
+          },
+          {
+            "name": "equality",
+            "value": "="
+          },
+          {
+            "name": "value",
+            "value": "Positive"
+          },
+          {
+            "name": "_present",
+            "value": true
+          }
+        ]
+      }
+    ],
+    "subjectVariant": {},
+    "conditionQualifier": {
+      "id": 9,
+      "conceptType": "Disease",
+      "name": "Invasive Breast Carcinoma",
+      "mappings": [],
+      "extensions": [
+        {
+          "name": "solid_tumor",
+          "value": true,
+          "description": "Boolean value for if this tumor type is categorized as a solid tumor."
+        }
+      ],
+      "primaryCoding": {
+        "id": "oncotree:BRCA",
+        "code": "BRCA",
+        "name": "Invasive Breast Carcinoma",
+        "system": "https://oncotree.mskcc.org",
+        "systemVersion": "oncotree_2021_11_02",
+        "iris": [
+          "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=BRCA"
+        ]
+      }
+    },
+    "objectTherapeutic": {
+      "id": 91,
+      "membershipOperator": "AND",
+      "therapies": [
+        {
+          "id": 36,
+          "conceptType": "Drug",
+          "name": "Anastrozole",
+          "mappings": [
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "rxcui:84857",
+                "code": "84857",
+                "name": "anastrozole",
+                "system": "RxNorm",
+                "systemVersion": "20250602",
+                "iris": [
+                  "https://mor.nlm.nih.gov/RxNav/search?searchBy=RXCUI&searchTerm=84857"
+                ]
+              }
+            },
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "omop:4297546",
+                "code": "4297546",
+                "name": "Anastrozole",
+                "system": "OMOP",
+                "systemVersion": "v20250827",
+                "iris": [
+                  "https://athena.ohdsi.org/search-terms/terms/4297546"
+                ]
+              }
+            },
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "sctid:386910003",
+                "code": "386910003",
+                "name": "Anastrozole",
+                "system": "SNOMED",
+                "systemVersion": "2026-03-01",
+                "iris": [
+                  "https://browser.ihtsdotools.org/?perspective=full&conceptId1=386910003&edition=MAIN/2026-03-01&release=&languages=en"
+                ]
+              }
+            },
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "omop:1348265",
+                "code": "1348265",
+                "name": "anastrozole",
+                "system": "OMOP",
+                "systemVersion": "v20250827",
+                "iris": [
+                  "https://athena.ohdsi.org/search-terms/terms/1348265"
+                ]
+              }
+            }
+          ],
+          "extensions": [
+            {
+              "name": "therapy_strategy",
+              "value": [
+                "Aromatase inhibition"
+              ],
+              "description": "Associated therapeutic strategy or mechanism of action of the therapy."
+            },
+            {
+              "name": "therapy_type",
+              "value": "Hormone therapy",
+              "description": "Type of cancer treatment from cancer.gov: https://www.cancer.gov/about-cancer/treatment/types"
+            }
+          ],
+          "primaryCoding": {
+            "id": "ncit:C1607",
+            "code": "C1607",
+            "name": "Anastrozole",
+            "system": "https://evsexplore.semantics.cancer.gov",
+            "systemVersion": "25.01d",
+            "iris": [
+              "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C1607"
+            ]
+          }
+        },
+        {
+          "id": 143,
+          "conceptType": "Drug",
+          "name": "Goserelin",
+          "mappings": [
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "rxcui:50610",
+                "code": "50610",
+                "name": "goserelin",
+                "system": "RxNorm",
+                "systemVersion": "02-Mar-2026",
+                "iris": [
+                  "https://mor.nlm.nih.gov/RxNav/search?searchBy=RXCUI&searchTerm=50610"
+                ]
+              }
+            },
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "omop:1366310",
+                "code": "1366310",
+                "name": "goserelin",
+                "system": "OMOP",
+                "systemVersion": "v20260227",
+                "iris": [
+                  "https://athena.ohdsi.org/search-terms/terms/1366310"
+                ]
+              }
+            },
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "sctid:108771008",
+                "code": "108771008",
+                "name": "Goserelin",
+                "system": "SNOMED",
+                "systemVersion": "2025-03-01",
+                "iris": [
+                  "https://browser.ihtsdotools.org/?perspective=full&conceptId1=108771008&edition=MAIN/2025-03-01&release=&languages=en"
+                ]
+              }
+            },
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "omop:4031929",
+                "code": "4031929",
+                "name": "Goserelin",
+                "system": "OMOP",
+                "systemVersion": "v20260227",
+                "iris": [
+                  "https://athena.ohdsi.org/search-terms/terms/4031929"
+                ]
+              }
+            }
+          ],
+          "extensions": [
+            {
+              "name": "therapy_strategy",
+              "value": [
+                "Gonadotropin-releasing hormone (GnRH) agonist"
+              ],
+              "description": "Associated therapeutic strategy or mechanism of action of the therapy."
+            },
+            {
+              "name": "therapy_type",
+              "value": "Hormone therapy",
+              "description": "Type of cancer treatment from cancer.gov: https://www.cancer.gov/about-cancer/treatment/types"
+            }
+          ],
+          "primaryCoding": {
+            "id": "ncit:C1374",
+            "code": "C1374",
+            "name": "Goserelin",
+            "system": "https://evsexplore.semantics.cancer.gov",
+            "systemVersion": "25.01d",
+            "iris": [
+              "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C1374"
+            ]
+          }
+        },
+        {
+          "id": 53,
+          "conceptType": "Drug",
+          "name": "Ribociclib",
+          "mappings": [
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "rxcui:1873916",
+                "code": "1873916",
+                "name": "ribociclib",
+                "system": "RxNorm",
+                "systemVersion": "02-Mar-2026",
+                "iris": [
+                  "https://mor.nlm.nih.gov/RxNav/search?searchBy=RXCUI&searchTerm=1873916"
+                ]
+              }
+            },
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "omop:1592911",
+                "code": "1592911",
+                "name": "ribociclib",
+                "system": "OMOP",
+                "systemVersion": "v20260227",
+                "iris": [
+                  "https://athena.ohdsi.org/search-terms/terms/1592911"
+                ]
+              }
+            },
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "sctid:732257004",
+                "code": "732257004",
+                "name": "Ribociclib",
+                "system": "SNOMED",
+                "systemVersion": "2025-03-01",
+                "iris": [
+                  "https://browser.ihtsdotools.org/?perspective=full&conceptId1=732257004&edition=MAIN/2025-03-01&release=&languages=en"
+                ]
+              }
+            },
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "omop:37115766",
+                "code": "37115766",
+                "name": "Ribociclib",
+                "system": "OMOP",
+                "systemVersion": "v20260227",
+                "iris": [
+                  "https://athena.ohdsi.org/search-terms/terms/37115766"
+                ]
+              }
+            }
+          ],
+          "extensions": [
+            {
+              "name": "therapy_strategy",
+              "value": [
+                "CDK4/6 inhibition"
+              ],
+              "description": "Associated therapeutic strategy or mechanism of action of the therapy."
+            },
+            {
+              "name": "therapy_type",
+              "value": "Targeted therapy",
+              "description": "Type of cancer treatment from cancer.gov: https://www.cancer.gov/about-cancer/treatment/types"
+            }
+          ],
+          "primaryCoding": {
+            "id": "ncit:C95701",
+            "code": "C95701",
+            "name": "Ribociclib",
+            "system": "https://evsexplore.semantics.cancer.gov",
+            "systemVersion": "25.01d",
+            "iris": [
+              "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C95701"
+            ]
+          }
+        }
+      ]
+    }
+  },
+  "strength": {
+    "id": 0,
+    "conceptType": "Evidence",
+    "name": "Approval",
+    "mappings": [],
+    "primaryCoding": {
+      "id": "ncit:C25425",
+      "code": "C25425",
+      "name": "Approval",
+      "system": "https://evsexplore.semantics.cancer.gov",
+      "systemVersion": "25.01d",
+      "iris": [
+        "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C25425"
+      ]
+    }
+  }
+}

--- a/dereferenced/statements/2337.json
+++ b/dereferenced/statements/2337.json
@@ -1,0 +1,554 @@
+{
+  "id": 2337,
+  "type": "Statement",
+  "description": "Health Canada approved ribociclib in combination with an aromatase inhibitor for the adjuvant treatment of adult patients with hormone receptor (HR)-positive, human epidermal growth factor receptor 2 (HER2)-negative stage II-III early breast cancer at high risk of recurrence. This indication is based on NATALEE (LEE011 O12301C) was a randomized (1:1), open-label, multicenter study, where participants received goserelin and either letrozole or anastrozole, in addition to ribociclib.",
+  "contributions": [
+    {
+      "id": 0,
+      "type": "Contribution",
+      "description": "Initial access of FDA approvals",
+      "date": "2024-10-30",
+      "contributor": {
+        "id": "vanallenlab",
+        "type": "Agent",
+        "agentType": "contributor",
+        "name": "Van Allen lab",
+        "description": "Van Allen lab, Dana-Farber Cancer Institute"
+      }
+    }
+  ],
+  "reportedIn": [
+    {
+      "id": "doc:hc.kisqali",
+      "type": "Document",
+      "documentType": "Regulatory approval",
+      "name": "Kisqali (ribociclib) [product monograph]. HC.",
+      "title": null,
+      "aliases": [],
+      "description": "Novartis Pharmaceuticals Canada Inc. Kisqali (ribociclib) [product monograph]. Health Canada website. https://pdf.hres.ca/dpd_pm/00083872.PDF. Revised March 2026. Accessed April 2026.",
+      "urls": [
+        "https://pdf.hres.ca/dpd_pm/00083872.PDF",
+        "https://health-products.canada.ca/dpd-bdpp/info?lang=eng&code=96295"
+      ],
+      "doi": null,
+      "pmid": null,
+      "extensions": [
+        {
+          "name": "agent",
+          "value": {
+            "id": "hc",
+            "type": "Agent",
+            "agentType": "organization",
+            "name": "Health Canada",
+            "description": "Regulatory agency that approves drugs for sale and use in Canada."
+          },
+          "description": "The organization that published this document."
+        },
+        {
+          "name": "company",
+          "value": "Novartis Pharmaceuticals Canada Inc.",
+          "description": "The company that manufactures the cancer drug. Only applicable to market authorization documents."
+        },
+        {
+          "name": "drug_name_brand",
+          "value": "Kisqali",
+          "description": "The brand name of the cancer drug, per this document. Only applicable to market authorization documents."
+        },
+        {
+          "name": "drug_name_generic",
+          "value": "ribociclib",
+          "description": "The generic name of the cancer drug, per this document. Only applicable to market authorization documents."
+        },
+        {
+          "name": "first_publication_date",
+          "value": "2018-03-02",
+          "description": "The publication date for the initial version of this document."
+        },
+        {
+          "name": "identification_number",
+          "value": null,
+          "description": "Identification number used by the publishing organization."
+        },
+        {
+          "name": "publication_date",
+          "value": "2026-03-26",
+          "description": "The publication date for the document."
+        },
+        {
+          "name": "status",
+          "value": "Active",
+          "description": "Whether this document is Active or Deprecated within moalmanac-db."
+        }
+      ]
+    }
+  ],
+  "direction": "supports",
+  "indication": {
+    "id": "ind:hc.kisqali:2",
+    "indication": "KISQALI (ribociclib tablets) is indicated, in combination with an aromatase inhibitor for the adjuvant treatment of adult patients with hormone receptor (HR)-positive, human epidermal growth factor receptor 2 (HER2)-negative stage II-III early breast cancer at high risk of recurrence.",
+    "initial_approval_date": null,
+    "initial_approval_url": null,
+    "description": "Health Canada approved ribociclib in combination with an aromatase inhibitor for the adjuvant treatment of adult patients with hormone receptor (HR)-positive, human epidermal growth factor receptor 2 (HER2)-negative stage II-III early breast cancer at high risk of recurrence. This indication is based on NATALEE (LEE011 O12301C) was a randomized (1:1), open-label, multicenter study, where participants received goserelin and either letrozole or anastrozole, in addition to ribociclib.",
+    "raw_biomarkers": "HR+, HER2-negative",
+    "raw_cancer_type": "early breast cancer",
+    "raw_therapeutics": "Kisqali (ribociclib), aromatase inhibitor",
+    "document": {
+      "id": "doc:hc.kisqali",
+      "type": "Document",
+      "documentType": "Regulatory approval",
+      "name": "Kisqali (ribociclib) [product monograph]. HC.",
+      "title": null,
+      "aliases": [],
+      "description": "Novartis Pharmaceuticals Canada Inc. Kisqali (ribociclib) [product monograph]. Health Canada website. https://pdf.hres.ca/dpd_pm/00083872.PDF. Revised March 2026. Accessed April 2026.",
+      "urls": [
+        "https://pdf.hres.ca/dpd_pm/00083872.PDF",
+        "https://health-products.canada.ca/dpd-bdpp/info?lang=eng&code=96295"
+      ],
+      "doi": null,
+      "pmid": null,
+      "extensions": [
+        {
+          "name": "agent",
+          "value": {
+            "id": "hc",
+            "type": "Agent",
+            "agentType": "organization",
+            "name": "Health Canada",
+            "description": "Regulatory agency that approves drugs for sale and use in Canada."
+          },
+          "description": "The organization that published this document."
+        },
+        {
+          "name": "company",
+          "value": "Novartis Pharmaceuticals Canada Inc.",
+          "description": "The company that manufactures the cancer drug. Only applicable to market authorization documents."
+        },
+        {
+          "name": "drug_name_brand",
+          "value": "Kisqali",
+          "description": "The brand name of the cancer drug, per this document. Only applicable to market authorization documents."
+        },
+        {
+          "name": "drug_name_generic",
+          "value": "ribociclib",
+          "description": "The generic name of the cancer drug, per this document. Only applicable to market authorization documents."
+        },
+        {
+          "name": "first_publication_date",
+          "value": "2018-03-02",
+          "description": "The publication date for the initial version of this document."
+        },
+        {
+          "name": "identification_number",
+          "value": null,
+          "description": "Identification number used by the publishing organization."
+        },
+        {
+          "name": "publication_date",
+          "value": "2026-03-26",
+          "description": "The publication date for the document."
+        },
+        {
+          "name": "status",
+          "value": "Active",
+          "description": "Whether this document is Active or Deprecated within moalmanac-db."
+        }
+      ]
+    }
+  },
+  "proposition": {
+    "id": 501,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      {
+        "id": 1,
+        "type": "CategoricalVariant",
+        "name": "ER positive",
+        "extensions": [
+          {
+            "name": "biomarker_type",
+            "value": "Protein expression"
+          },
+          {
+            "name": "marker",
+            "value": "Estrogen receptor (ER)"
+          },
+          {
+            "name": "unit",
+            "value": "status"
+          },
+          {
+            "name": "equality",
+            "value": "="
+          },
+          {
+            "name": "value",
+            "value": "Positive"
+          },
+          {
+            "name": "_present",
+            "value": true
+          }
+        ]
+      },
+      {
+        "id": 2,
+        "type": "CategoricalVariant",
+        "name": "HER2-negative",
+        "extensions": [
+          {
+            "name": "biomarker_type",
+            "value": "Protein expression"
+          },
+          {
+            "name": "marker",
+            "value": "Human epidermal growth factor receptor 2 (HER2)"
+          },
+          {
+            "name": "unit",
+            "value": "status"
+          },
+          {
+            "name": "equality",
+            "value": "="
+          },
+          {
+            "name": "value",
+            "value": "Negative"
+          },
+          {
+            "name": "_present",
+            "value": true
+          }
+        ]
+      },
+      {
+        "id": 3,
+        "type": "CategoricalVariant",
+        "name": "PR positive",
+        "extensions": [
+          {
+            "name": "biomarker_type",
+            "value": "Protein expression"
+          },
+          {
+            "name": "marker",
+            "value": "Progesterone receptor (PR)"
+          },
+          {
+            "name": "unit",
+            "value": "status"
+          },
+          {
+            "name": "equality",
+            "value": "="
+          },
+          {
+            "name": "value",
+            "value": "Positive"
+          },
+          {
+            "name": "_present",
+            "value": true
+          }
+        ]
+      }
+    ],
+    "subjectVariant": {},
+    "conditionQualifier": {
+      "id": 9,
+      "conceptType": "Disease",
+      "name": "Invasive Breast Carcinoma",
+      "mappings": [],
+      "extensions": [
+        {
+          "name": "solid_tumor",
+          "value": true,
+          "description": "Boolean value for if this tumor type is categorized as a solid tumor."
+        }
+      ],
+      "primaryCoding": {
+        "id": "oncotree:BRCA",
+        "code": "BRCA",
+        "name": "Invasive Breast Carcinoma",
+        "system": "https://oncotree.mskcc.org",
+        "systemVersion": "oncotree_2021_11_02",
+        "iris": [
+          "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=BRCA"
+        ]
+      }
+    },
+    "objectTherapeutic": {
+      "id": 91,
+      "membershipOperator": "AND",
+      "therapies": [
+        {
+          "id": 36,
+          "conceptType": "Drug",
+          "name": "Anastrozole",
+          "mappings": [
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "rxcui:84857",
+                "code": "84857",
+                "name": "anastrozole",
+                "system": "RxNorm",
+                "systemVersion": "20250602",
+                "iris": [
+                  "https://mor.nlm.nih.gov/RxNav/search?searchBy=RXCUI&searchTerm=84857"
+                ]
+              }
+            },
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "omop:4297546",
+                "code": "4297546",
+                "name": "Anastrozole",
+                "system": "OMOP",
+                "systemVersion": "v20250827",
+                "iris": [
+                  "https://athena.ohdsi.org/search-terms/terms/4297546"
+                ]
+              }
+            },
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "sctid:386910003",
+                "code": "386910003",
+                "name": "Anastrozole",
+                "system": "SNOMED",
+                "systemVersion": "2026-03-01",
+                "iris": [
+                  "https://browser.ihtsdotools.org/?perspective=full&conceptId1=386910003&edition=MAIN/2026-03-01&release=&languages=en"
+                ]
+              }
+            },
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "omop:1348265",
+                "code": "1348265",
+                "name": "anastrozole",
+                "system": "OMOP",
+                "systemVersion": "v20250827",
+                "iris": [
+                  "https://athena.ohdsi.org/search-terms/terms/1348265"
+                ]
+              }
+            }
+          ],
+          "extensions": [
+            {
+              "name": "therapy_strategy",
+              "value": [
+                "Aromatase inhibition"
+              ],
+              "description": "Associated therapeutic strategy or mechanism of action of the therapy."
+            },
+            {
+              "name": "therapy_type",
+              "value": "Hormone therapy",
+              "description": "Type of cancer treatment from cancer.gov: https://www.cancer.gov/about-cancer/treatment/types"
+            }
+          ],
+          "primaryCoding": {
+            "id": "ncit:C1607",
+            "code": "C1607",
+            "name": "Anastrozole",
+            "system": "https://evsexplore.semantics.cancer.gov",
+            "systemVersion": "25.01d",
+            "iris": [
+              "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C1607"
+            ]
+          }
+        },
+        {
+          "id": 143,
+          "conceptType": "Drug",
+          "name": "Goserelin",
+          "mappings": [
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "rxcui:50610",
+                "code": "50610",
+                "name": "goserelin",
+                "system": "RxNorm",
+                "systemVersion": "02-Mar-2026",
+                "iris": [
+                  "https://mor.nlm.nih.gov/RxNav/search?searchBy=RXCUI&searchTerm=50610"
+                ]
+              }
+            },
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "omop:1366310",
+                "code": "1366310",
+                "name": "goserelin",
+                "system": "OMOP",
+                "systemVersion": "v20260227",
+                "iris": [
+                  "https://athena.ohdsi.org/search-terms/terms/1366310"
+                ]
+              }
+            },
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "sctid:108771008",
+                "code": "108771008",
+                "name": "Goserelin",
+                "system": "SNOMED",
+                "systemVersion": "2025-03-01",
+                "iris": [
+                  "https://browser.ihtsdotools.org/?perspective=full&conceptId1=108771008&edition=MAIN/2025-03-01&release=&languages=en"
+                ]
+              }
+            },
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "omop:4031929",
+                "code": "4031929",
+                "name": "Goserelin",
+                "system": "OMOP",
+                "systemVersion": "v20260227",
+                "iris": [
+                  "https://athena.ohdsi.org/search-terms/terms/4031929"
+                ]
+              }
+            }
+          ],
+          "extensions": [
+            {
+              "name": "therapy_strategy",
+              "value": [
+                "Gonadotropin-releasing hormone (GnRH) agonist"
+              ],
+              "description": "Associated therapeutic strategy or mechanism of action of the therapy."
+            },
+            {
+              "name": "therapy_type",
+              "value": "Hormone therapy",
+              "description": "Type of cancer treatment from cancer.gov: https://www.cancer.gov/about-cancer/treatment/types"
+            }
+          ],
+          "primaryCoding": {
+            "id": "ncit:C1374",
+            "code": "C1374",
+            "name": "Goserelin",
+            "system": "https://evsexplore.semantics.cancer.gov",
+            "systemVersion": "25.01d",
+            "iris": [
+              "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C1374"
+            ]
+          }
+        },
+        {
+          "id": 53,
+          "conceptType": "Drug",
+          "name": "Ribociclib",
+          "mappings": [
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "rxcui:1873916",
+                "code": "1873916",
+                "name": "ribociclib",
+                "system": "RxNorm",
+                "systemVersion": "02-Mar-2026",
+                "iris": [
+                  "https://mor.nlm.nih.gov/RxNav/search?searchBy=RXCUI&searchTerm=1873916"
+                ]
+              }
+            },
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "omop:1592911",
+                "code": "1592911",
+                "name": "ribociclib",
+                "system": "OMOP",
+                "systemVersion": "v20260227",
+                "iris": [
+                  "https://athena.ohdsi.org/search-terms/terms/1592911"
+                ]
+              }
+            },
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "sctid:732257004",
+                "code": "732257004",
+                "name": "Ribociclib",
+                "system": "SNOMED",
+                "systemVersion": "2025-03-01",
+                "iris": [
+                  "https://browser.ihtsdotools.org/?perspective=full&conceptId1=732257004&edition=MAIN/2025-03-01&release=&languages=en"
+                ]
+              }
+            },
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "omop:37115766",
+                "code": "37115766",
+                "name": "Ribociclib",
+                "system": "OMOP",
+                "systemVersion": "v20260227",
+                "iris": [
+                  "https://athena.ohdsi.org/search-terms/terms/37115766"
+                ]
+              }
+            }
+          ],
+          "extensions": [
+            {
+              "name": "therapy_strategy",
+              "value": [
+                "CDK4/6 inhibition"
+              ],
+              "description": "Associated therapeutic strategy or mechanism of action of the therapy."
+            },
+            {
+              "name": "therapy_type",
+              "value": "Targeted therapy",
+              "description": "Type of cancer treatment from cancer.gov: https://www.cancer.gov/about-cancer/treatment/types"
+            }
+          ],
+          "primaryCoding": {
+            "id": "ncit:C95701",
+            "code": "C95701",
+            "name": "Ribociclib",
+            "system": "https://evsexplore.semantics.cancer.gov",
+            "systemVersion": "25.01d",
+            "iris": [
+              "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C95701"
+            ]
+          }
+        }
+      ]
+    }
+  },
+  "strength": {
+    "id": 0,
+    "conceptType": "Evidence",
+    "name": "Approval",
+    "mappings": [],
+    "primaryCoding": {
+      "id": "ncit:C25425",
+      "code": "C25425",
+      "name": "Approval",
+      "system": "https://evsexplore.semantics.cancer.gov",
+      "systemVersion": "25.01d",
+      "iris": [
+        "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C25425"
+      ]
+    }
+  }
+}

--- a/dereferenced/statements/2338.json
+++ b/dereferenced/statements/2338.json
@@ -1,0 +1,523 @@
+{
+  "id": 2338,
+  "type": "Statement",
+  "description": "Health Canada approved ribociclib in combination with an aromatase inhibitor for the adjuvant treatment of adult patients with hormone receptor (HR)-positive, human epidermal growth factor receptor 2 (HER2)-negative stage II-III early breast cancer at high risk of recurrence. This indication is based on NATALEE (LEE011 O12301C) was a randomized (1:1), open-label, multicenter study, where participants received goserelin and either letrozole or anastrozole, in addition to ribociclib.",
+  "contributions": [
+    {
+      "id": 0,
+      "type": "Contribution",
+      "description": "Initial access of FDA approvals",
+      "date": "2024-10-30",
+      "contributor": {
+        "id": "vanallenlab",
+        "type": "Agent",
+        "agentType": "contributor",
+        "name": "Van Allen lab",
+        "description": "Van Allen lab, Dana-Farber Cancer Institute"
+      }
+    }
+  ],
+  "reportedIn": [
+    {
+      "id": "doc:hc.kisqali",
+      "type": "Document",
+      "documentType": "Regulatory approval",
+      "name": "Kisqali (ribociclib) [product monograph]. HC.",
+      "title": null,
+      "aliases": [],
+      "description": "Novartis Pharmaceuticals Canada Inc. Kisqali (ribociclib) [product monograph]. Health Canada website. https://pdf.hres.ca/dpd_pm/00083872.PDF. Revised March 2026. Accessed April 2026.",
+      "urls": [
+        "https://pdf.hres.ca/dpd_pm/00083872.PDF",
+        "https://health-products.canada.ca/dpd-bdpp/info?lang=eng&code=96295"
+      ],
+      "doi": null,
+      "pmid": null,
+      "extensions": [
+        {
+          "name": "agent",
+          "value": {
+            "id": "hc",
+            "type": "Agent",
+            "agentType": "organization",
+            "name": "Health Canada",
+            "description": "Regulatory agency that approves drugs for sale and use in Canada."
+          },
+          "description": "The organization that published this document."
+        },
+        {
+          "name": "company",
+          "value": "Novartis Pharmaceuticals Canada Inc.",
+          "description": "The company that manufactures the cancer drug. Only applicable to market authorization documents."
+        },
+        {
+          "name": "drug_name_brand",
+          "value": "Kisqali",
+          "description": "The brand name of the cancer drug, per this document. Only applicable to market authorization documents."
+        },
+        {
+          "name": "drug_name_generic",
+          "value": "ribociclib",
+          "description": "The generic name of the cancer drug, per this document. Only applicable to market authorization documents."
+        },
+        {
+          "name": "first_publication_date",
+          "value": "2018-03-02",
+          "description": "The publication date for the initial version of this document."
+        },
+        {
+          "name": "identification_number",
+          "value": null,
+          "description": "Identification number used by the publishing organization."
+        },
+        {
+          "name": "publication_date",
+          "value": "2026-03-26",
+          "description": "The publication date for the document."
+        },
+        {
+          "name": "status",
+          "value": "Active",
+          "description": "Whether this document is Active or Deprecated within moalmanac-db."
+        }
+      ]
+    }
+  ],
+  "direction": "supports",
+  "indication": {
+    "id": "ind:hc.kisqali:2",
+    "indication": "KISQALI (ribociclib tablets) is indicated, in combination with an aromatase inhibitor for the adjuvant treatment of adult patients with hormone receptor (HR)-positive, human epidermal growth factor receptor 2 (HER2)-negative stage II-III early breast cancer at high risk of recurrence.",
+    "initial_approval_date": null,
+    "initial_approval_url": null,
+    "description": "Health Canada approved ribociclib in combination with an aromatase inhibitor for the adjuvant treatment of adult patients with hormone receptor (HR)-positive, human epidermal growth factor receptor 2 (HER2)-negative stage II-III early breast cancer at high risk of recurrence. This indication is based on NATALEE (LEE011 O12301C) was a randomized (1:1), open-label, multicenter study, where participants received goserelin and either letrozole or anastrozole, in addition to ribociclib.",
+    "raw_biomarkers": "HR+, HER2-negative",
+    "raw_cancer_type": "early breast cancer",
+    "raw_therapeutics": "Kisqali (ribociclib), aromatase inhibitor",
+    "document": {
+      "id": "doc:hc.kisqali",
+      "type": "Document",
+      "documentType": "Regulatory approval",
+      "name": "Kisqali (ribociclib) [product monograph]. HC.",
+      "title": null,
+      "aliases": [],
+      "description": "Novartis Pharmaceuticals Canada Inc. Kisqali (ribociclib) [product monograph]. Health Canada website. https://pdf.hres.ca/dpd_pm/00083872.PDF. Revised March 2026. Accessed April 2026.",
+      "urls": [
+        "https://pdf.hres.ca/dpd_pm/00083872.PDF",
+        "https://health-products.canada.ca/dpd-bdpp/info?lang=eng&code=96295"
+      ],
+      "doi": null,
+      "pmid": null,
+      "extensions": [
+        {
+          "name": "agent",
+          "value": {
+            "id": "hc",
+            "type": "Agent",
+            "agentType": "organization",
+            "name": "Health Canada",
+            "description": "Regulatory agency that approves drugs for sale and use in Canada."
+          },
+          "description": "The organization that published this document."
+        },
+        {
+          "name": "company",
+          "value": "Novartis Pharmaceuticals Canada Inc.",
+          "description": "The company that manufactures the cancer drug. Only applicable to market authorization documents."
+        },
+        {
+          "name": "drug_name_brand",
+          "value": "Kisqali",
+          "description": "The brand name of the cancer drug, per this document. Only applicable to market authorization documents."
+        },
+        {
+          "name": "drug_name_generic",
+          "value": "ribociclib",
+          "description": "The generic name of the cancer drug, per this document. Only applicable to market authorization documents."
+        },
+        {
+          "name": "first_publication_date",
+          "value": "2018-03-02",
+          "description": "The publication date for the initial version of this document."
+        },
+        {
+          "name": "identification_number",
+          "value": null,
+          "description": "Identification number used by the publishing organization."
+        },
+        {
+          "name": "publication_date",
+          "value": "2026-03-26",
+          "description": "The publication date for the document."
+        },
+        {
+          "name": "status",
+          "value": "Active",
+          "description": "Whether this document is Active or Deprecated within moalmanac-db."
+        }
+      ]
+    }
+  },
+  "proposition": {
+    "id": 502,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      {
+        "id": 1,
+        "type": "CategoricalVariant",
+        "name": "ER positive",
+        "extensions": [
+          {
+            "name": "biomarker_type",
+            "value": "Protein expression"
+          },
+          {
+            "name": "marker",
+            "value": "Estrogen receptor (ER)"
+          },
+          {
+            "name": "unit",
+            "value": "status"
+          },
+          {
+            "name": "equality",
+            "value": "="
+          },
+          {
+            "name": "value",
+            "value": "Positive"
+          },
+          {
+            "name": "_present",
+            "value": true
+          }
+        ]
+      },
+      {
+        "id": 2,
+        "type": "CategoricalVariant",
+        "name": "HER2-negative",
+        "extensions": [
+          {
+            "name": "biomarker_type",
+            "value": "Protein expression"
+          },
+          {
+            "name": "marker",
+            "value": "Human epidermal growth factor receptor 2 (HER2)"
+          },
+          {
+            "name": "unit",
+            "value": "status"
+          },
+          {
+            "name": "equality",
+            "value": "="
+          },
+          {
+            "name": "value",
+            "value": "Negative"
+          },
+          {
+            "name": "_present",
+            "value": true
+          }
+        ]
+      }
+    ],
+    "subjectVariant": {},
+    "conditionQualifier": {
+      "id": 9,
+      "conceptType": "Disease",
+      "name": "Invasive Breast Carcinoma",
+      "mappings": [],
+      "extensions": [
+        {
+          "name": "solid_tumor",
+          "value": true,
+          "description": "Boolean value for if this tumor type is categorized as a solid tumor."
+        }
+      ],
+      "primaryCoding": {
+        "id": "oncotree:BRCA",
+        "code": "BRCA",
+        "name": "Invasive Breast Carcinoma",
+        "system": "https://oncotree.mskcc.org",
+        "systemVersion": "oncotree_2021_11_02",
+        "iris": [
+          "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=BRCA"
+        ]
+      }
+    },
+    "objectTherapeutic": {
+      "id": 92,
+      "membershipOperator": "AND",
+      "therapies": [
+        {
+          "id": 143,
+          "conceptType": "Drug",
+          "name": "Goserelin",
+          "mappings": [
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "rxcui:50610",
+                "code": "50610",
+                "name": "goserelin",
+                "system": "RxNorm",
+                "systemVersion": "02-Mar-2026",
+                "iris": [
+                  "https://mor.nlm.nih.gov/RxNav/search?searchBy=RXCUI&searchTerm=50610"
+                ]
+              }
+            },
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "omop:1366310",
+                "code": "1366310",
+                "name": "goserelin",
+                "system": "OMOP",
+                "systemVersion": "v20260227",
+                "iris": [
+                  "https://athena.ohdsi.org/search-terms/terms/1366310"
+                ]
+              }
+            },
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "sctid:108771008",
+                "code": "108771008",
+                "name": "Goserelin",
+                "system": "SNOMED",
+                "systemVersion": "2025-03-01",
+                "iris": [
+                  "https://browser.ihtsdotools.org/?perspective=full&conceptId1=108771008&edition=MAIN/2025-03-01&release=&languages=en"
+                ]
+              }
+            },
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "omop:4031929",
+                "code": "4031929",
+                "name": "Goserelin",
+                "system": "OMOP",
+                "systemVersion": "v20260227",
+                "iris": [
+                  "https://athena.ohdsi.org/search-terms/terms/4031929"
+                ]
+              }
+            }
+          ],
+          "extensions": [
+            {
+              "name": "therapy_strategy",
+              "value": [
+                "Gonadotropin-releasing hormone (GnRH) agonist"
+              ],
+              "description": "Associated therapeutic strategy or mechanism of action of the therapy."
+            },
+            {
+              "name": "therapy_type",
+              "value": "Hormone therapy",
+              "description": "Type of cancer treatment from cancer.gov: https://www.cancer.gov/about-cancer/treatment/types"
+            }
+          ],
+          "primaryCoding": {
+            "id": "ncit:C1374",
+            "code": "C1374",
+            "name": "Goserelin",
+            "system": "https://evsexplore.semantics.cancer.gov",
+            "systemVersion": "25.01d",
+            "iris": [
+              "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C1374"
+            ]
+          }
+        },
+        {
+          "id": 40,
+          "conceptType": "Drug",
+          "name": "Letrozole",
+          "mappings": [
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "rxcui:72965",
+                "code": "72965",
+                "name": "letrozole",
+                "system": "RxNorm",
+                "systemVersion": "20250602",
+                "iris": [
+                  "https://mor.nlm.nih.gov/RxNav/search?searchBy=RXCUI&searchTerm=72965"
+                ]
+              }
+            },
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "omop:4297547",
+                "code": "4297547",
+                "name": "Letrozole",
+                "system": "OMOP",
+                "systemVersion": "v20250827",
+                "iris": [
+                  "https://athena.ohdsi.org/search-terms/terms/4297547"
+                ]
+              }
+            },
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "sctid:386911004",
+                "code": "386911004",
+                "name": "Letrozole",
+                "system": "SNOMED",
+                "systemVersion": "2026-03-01",
+                "iris": [
+                  "https://browser.ihtsdotools.org/?perspective=full&conceptId1=386911004&edition=MAIN/2026-03-01&release=&languages=en"
+                ]
+              }
+            },
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "omop:1315946",
+                "code": "1315946",
+                "name": "letrozole",
+                "system": "OMOP",
+                "systemVersion": "v20250827",
+                "iris": [
+                  "https://athena.ohdsi.org/search-terms/terms/1315946"
+                ]
+              }
+            }
+          ],
+          "extensions": [
+            {
+              "name": "therapy_strategy",
+              "value": [
+                "Aromatase inhibition"
+              ],
+              "description": "Associated therapeutic strategy or mechanism of action of the therapy."
+            },
+            {
+              "name": "therapy_type",
+              "value": "Hormone therapy",
+              "description": "Type of cancer treatment from cancer.gov: https://www.cancer.gov/about-cancer/treatment/types"
+            }
+          ],
+          "primaryCoding": {
+            "id": "ncit:C1527",
+            "code": "C1527",
+            "name": "Letrozole",
+            "system": "https://evsexplore.semantics.cancer.gov",
+            "systemVersion": "25.01d",
+            "iris": [
+              "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C1527"
+            ]
+          }
+        },
+        {
+          "id": 53,
+          "conceptType": "Drug",
+          "name": "Ribociclib",
+          "mappings": [
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "rxcui:1873916",
+                "code": "1873916",
+                "name": "ribociclib",
+                "system": "RxNorm",
+                "systemVersion": "02-Mar-2026",
+                "iris": [
+                  "https://mor.nlm.nih.gov/RxNav/search?searchBy=RXCUI&searchTerm=1873916"
+                ]
+              }
+            },
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "omop:1592911",
+                "code": "1592911",
+                "name": "ribociclib",
+                "system": "OMOP",
+                "systemVersion": "v20260227",
+                "iris": [
+                  "https://athena.ohdsi.org/search-terms/terms/1592911"
+                ]
+              }
+            },
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "sctid:732257004",
+                "code": "732257004",
+                "name": "Ribociclib",
+                "system": "SNOMED",
+                "systemVersion": "2025-03-01",
+                "iris": [
+                  "https://browser.ihtsdotools.org/?perspective=full&conceptId1=732257004&edition=MAIN/2025-03-01&release=&languages=en"
+                ]
+              }
+            },
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "omop:37115766",
+                "code": "37115766",
+                "name": "Ribociclib",
+                "system": "OMOP",
+                "systemVersion": "v20260227",
+                "iris": [
+                  "https://athena.ohdsi.org/search-terms/terms/37115766"
+                ]
+              }
+            }
+          ],
+          "extensions": [
+            {
+              "name": "therapy_strategy",
+              "value": [
+                "CDK4/6 inhibition"
+              ],
+              "description": "Associated therapeutic strategy or mechanism of action of the therapy."
+            },
+            {
+              "name": "therapy_type",
+              "value": "Targeted therapy",
+              "description": "Type of cancer treatment from cancer.gov: https://www.cancer.gov/about-cancer/treatment/types"
+            }
+          ],
+          "primaryCoding": {
+            "id": "ncit:C95701",
+            "code": "C95701",
+            "name": "Ribociclib",
+            "system": "https://evsexplore.semantics.cancer.gov",
+            "systemVersion": "25.01d",
+            "iris": [
+              "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C95701"
+            ]
+          }
+        }
+      ]
+    }
+  },
+  "strength": {
+    "id": 0,
+    "conceptType": "Evidence",
+    "name": "Approval",
+    "mappings": [],
+    "primaryCoding": {
+      "id": "ncit:C25425",
+      "code": "C25425",
+      "name": "Approval",
+      "system": "https://evsexplore.semantics.cancer.gov",
+      "systemVersion": "25.01d",
+      "iris": [
+        "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C25425"
+      ]
+    }
+  }
+}

--- a/dereferenced/statements/2339.json
+++ b/dereferenced/statements/2339.json
@@ -1,0 +1,523 @@
+{
+  "id": 2339,
+  "type": "Statement",
+  "description": "Health Canada approved ribociclib in combination with an aromatase inhibitor for the adjuvant treatment of adult patients with hormone receptor (HR)-positive, human epidermal growth factor receptor 2 (HER2)-negative stage II-III early breast cancer at high risk of recurrence. This indication is based on NATALEE (LEE011 O12301C) was a randomized (1:1), open-label, multicenter study, where participants received goserelin and either letrozole or anastrozole, in addition to ribociclib.",
+  "contributions": [
+    {
+      "id": 0,
+      "type": "Contribution",
+      "description": "Initial access of FDA approvals",
+      "date": "2024-10-30",
+      "contributor": {
+        "id": "vanallenlab",
+        "type": "Agent",
+        "agentType": "contributor",
+        "name": "Van Allen lab",
+        "description": "Van Allen lab, Dana-Farber Cancer Institute"
+      }
+    }
+  ],
+  "reportedIn": [
+    {
+      "id": "doc:hc.kisqali",
+      "type": "Document",
+      "documentType": "Regulatory approval",
+      "name": "Kisqali (ribociclib) [product monograph]. HC.",
+      "title": null,
+      "aliases": [],
+      "description": "Novartis Pharmaceuticals Canada Inc. Kisqali (ribociclib) [product monograph]. Health Canada website. https://pdf.hres.ca/dpd_pm/00083872.PDF. Revised March 2026. Accessed April 2026.",
+      "urls": [
+        "https://pdf.hres.ca/dpd_pm/00083872.PDF",
+        "https://health-products.canada.ca/dpd-bdpp/info?lang=eng&code=96295"
+      ],
+      "doi": null,
+      "pmid": null,
+      "extensions": [
+        {
+          "name": "agent",
+          "value": {
+            "id": "hc",
+            "type": "Agent",
+            "agentType": "organization",
+            "name": "Health Canada",
+            "description": "Regulatory agency that approves drugs for sale and use in Canada."
+          },
+          "description": "The organization that published this document."
+        },
+        {
+          "name": "company",
+          "value": "Novartis Pharmaceuticals Canada Inc.",
+          "description": "The company that manufactures the cancer drug. Only applicable to market authorization documents."
+        },
+        {
+          "name": "drug_name_brand",
+          "value": "Kisqali",
+          "description": "The brand name of the cancer drug, per this document. Only applicable to market authorization documents."
+        },
+        {
+          "name": "drug_name_generic",
+          "value": "ribociclib",
+          "description": "The generic name of the cancer drug, per this document. Only applicable to market authorization documents."
+        },
+        {
+          "name": "first_publication_date",
+          "value": "2018-03-02",
+          "description": "The publication date for the initial version of this document."
+        },
+        {
+          "name": "identification_number",
+          "value": null,
+          "description": "Identification number used by the publishing organization."
+        },
+        {
+          "name": "publication_date",
+          "value": "2026-03-26",
+          "description": "The publication date for the document."
+        },
+        {
+          "name": "status",
+          "value": "Active",
+          "description": "Whether this document is Active or Deprecated within moalmanac-db."
+        }
+      ]
+    }
+  ],
+  "direction": "supports",
+  "indication": {
+    "id": "ind:hc.kisqali:2",
+    "indication": "KISQALI (ribociclib tablets) is indicated, in combination with an aromatase inhibitor for the adjuvant treatment of adult patients with hormone receptor (HR)-positive, human epidermal growth factor receptor 2 (HER2)-negative stage II-III early breast cancer at high risk of recurrence.",
+    "initial_approval_date": null,
+    "initial_approval_url": null,
+    "description": "Health Canada approved ribociclib in combination with an aromatase inhibitor for the adjuvant treatment of adult patients with hormone receptor (HR)-positive, human epidermal growth factor receptor 2 (HER2)-negative stage II-III early breast cancer at high risk of recurrence. This indication is based on NATALEE (LEE011 O12301C) was a randomized (1:1), open-label, multicenter study, where participants received goserelin and either letrozole or anastrozole, in addition to ribociclib.",
+    "raw_biomarkers": "HR+, HER2-negative",
+    "raw_cancer_type": "early breast cancer",
+    "raw_therapeutics": "Kisqali (ribociclib), aromatase inhibitor",
+    "document": {
+      "id": "doc:hc.kisqali",
+      "type": "Document",
+      "documentType": "Regulatory approval",
+      "name": "Kisqali (ribociclib) [product monograph]. HC.",
+      "title": null,
+      "aliases": [],
+      "description": "Novartis Pharmaceuticals Canada Inc. Kisqali (ribociclib) [product monograph]. Health Canada website. https://pdf.hres.ca/dpd_pm/00083872.PDF. Revised March 2026. Accessed April 2026.",
+      "urls": [
+        "https://pdf.hres.ca/dpd_pm/00083872.PDF",
+        "https://health-products.canada.ca/dpd-bdpp/info?lang=eng&code=96295"
+      ],
+      "doi": null,
+      "pmid": null,
+      "extensions": [
+        {
+          "name": "agent",
+          "value": {
+            "id": "hc",
+            "type": "Agent",
+            "agentType": "organization",
+            "name": "Health Canada",
+            "description": "Regulatory agency that approves drugs for sale and use in Canada."
+          },
+          "description": "The organization that published this document."
+        },
+        {
+          "name": "company",
+          "value": "Novartis Pharmaceuticals Canada Inc.",
+          "description": "The company that manufactures the cancer drug. Only applicable to market authorization documents."
+        },
+        {
+          "name": "drug_name_brand",
+          "value": "Kisqali",
+          "description": "The brand name of the cancer drug, per this document. Only applicable to market authorization documents."
+        },
+        {
+          "name": "drug_name_generic",
+          "value": "ribociclib",
+          "description": "The generic name of the cancer drug, per this document. Only applicable to market authorization documents."
+        },
+        {
+          "name": "first_publication_date",
+          "value": "2018-03-02",
+          "description": "The publication date for the initial version of this document."
+        },
+        {
+          "name": "identification_number",
+          "value": null,
+          "description": "Identification number used by the publishing organization."
+        },
+        {
+          "name": "publication_date",
+          "value": "2026-03-26",
+          "description": "The publication date for the document."
+        },
+        {
+          "name": "status",
+          "value": "Active",
+          "description": "Whether this document is Active or Deprecated within moalmanac-db."
+        }
+      ]
+    }
+  },
+  "proposition": {
+    "id": 503,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      {
+        "id": 2,
+        "type": "CategoricalVariant",
+        "name": "HER2-negative",
+        "extensions": [
+          {
+            "name": "biomarker_type",
+            "value": "Protein expression"
+          },
+          {
+            "name": "marker",
+            "value": "Human epidermal growth factor receptor 2 (HER2)"
+          },
+          {
+            "name": "unit",
+            "value": "status"
+          },
+          {
+            "name": "equality",
+            "value": "="
+          },
+          {
+            "name": "value",
+            "value": "Negative"
+          },
+          {
+            "name": "_present",
+            "value": true
+          }
+        ]
+      },
+      {
+        "id": 3,
+        "type": "CategoricalVariant",
+        "name": "PR positive",
+        "extensions": [
+          {
+            "name": "biomarker_type",
+            "value": "Protein expression"
+          },
+          {
+            "name": "marker",
+            "value": "Progesterone receptor (PR)"
+          },
+          {
+            "name": "unit",
+            "value": "status"
+          },
+          {
+            "name": "equality",
+            "value": "="
+          },
+          {
+            "name": "value",
+            "value": "Positive"
+          },
+          {
+            "name": "_present",
+            "value": true
+          }
+        ]
+      }
+    ],
+    "subjectVariant": {},
+    "conditionQualifier": {
+      "id": 9,
+      "conceptType": "Disease",
+      "name": "Invasive Breast Carcinoma",
+      "mappings": [],
+      "extensions": [
+        {
+          "name": "solid_tumor",
+          "value": true,
+          "description": "Boolean value for if this tumor type is categorized as a solid tumor."
+        }
+      ],
+      "primaryCoding": {
+        "id": "oncotree:BRCA",
+        "code": "BRCA",
+        "name": "Invasive Breast Carcinoma",
+        "system": "https://oncotree.mskcc.org",
+        "systemVersion": "oncotree_2021_11_02",
+        "iris": [
+          "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=BRCA"
+        ]
+      }
+    },
+    "objectTherapeutic": {
+      "id": 92,
+      "membershipOperator": "AND",
+      "therapies": [
+        {
+          "id": 143,
+          "conceptType": "Drug",
+          "name": "Goserelin",
+          "mappings": [
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "rxcui:50610",
+                "code": "50610",
+                "name": "goserelin",
+                "system": "RxNorm",
+                "systemVersion": "02-Mar-2026",
+                "iris": [
+                  "https://mor.nlm.nih.gov/RxNav/search?searchBy=RXCUI&searchTerm=50610"
+                ]
+              }
+            },
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "omop:1366310",
+                "code": "1366310",
+                "name": "goserelin",
+                "system": "OMOP",
+                "systemVersion": "v20260227",
+                "iris": [
+                  "https://athena.ohdsi.org/search-terms/terms/1366310"
+                ]
+              }
+            },
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "sctid:108771008",
+                "code": "108771008",
+                "name": "Goserelin",
+                "system": "SNOMED",
+                "systemVersion": "2025-03-01",
+                "iris": [
+                  "https://browser.ihtsdotools.org/?perspective=full&conceptId1=108771008&edition=MAIN/2025-03-01&release=&languages=en"
+                ]
+              }
+            },
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "omop:4031929",
+                "code": "4031929",
+                "name": "Goserelin",
+                "system": "OMOP",
+                "systemVersion": "v20260227",
+                "iris": [
+                  "https://athena.ohdsi.org/search-terms/terms/4031929"
+                ]
+              }
+            }
+          ],
+          "extensions": [
+            {
+              "name": "therapy_strategy",
+              "value": [
+                "Gonadotropin-releasing hormone (GnRH) agonist"
+              ],
+              "description": "Associated therapeutic strategy or mechanism of action of the therapy."
+            },
+            {
+              "name": "therapy_type",
+              "value": "Hormone therapy",
+              "description": "Type of cancer treatment from cancer.gov: https://www.cancer.gov/about-cancer/treatment/types"
+            }
+          ],
+          "primaryCoding": {
+            "id": "ncit:C1374",
+            "code": "C1374",
+            "name": "Goserelin",
+            "system": "https://evsexplore.semantics.cancer.gov",
+            "systemVersion": "25.01d",
+            "iris": [
+              "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C1374"
+            ]
+          }
+        },
+        {
+          "id": 40,
+          "conceptType": "Drug",
+          "name": "Letrozole",
+          "mappings": [
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "rxcui:72965",
+                "code": "72965",
+                "name": "letrozole",
+                "system": "RxNorm",
+                "systemVersion": "20250602",
+                "iris": [
+                  "https://mor.nlm.nih.gov/RxNav/search?searchBy=RXCUI&searchTerm=72965"
+                ]
+              }
+            },
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "omop:4297547",
+                "code": "4297547",
+                "name": "Letrozole",
+                "system": "OMOP",
+                "systemVersion": "v20250827",
+                "iris": [
+                  "https://athena.ohdsi.org/search-terms/terms/4297547"
+                ]
+              }
+            },
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "sctid:386911004",
+                "code": "386911004",
+                "name": "Letrozole",
+                "system": "SNOMED",
+                "systemVersion": "2026-03-01",
+                "iris": [
+                  "https://browser.ihtsdotools.org/?perspective=full&conceptId1=386911004&edition=MAIN/2026-03-01&release=&languages=en"
+                ]
+              }
+            },
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "omop:1315946",
+                "code": "1315946",
+                "name": "letrozole",
+                "system": "OMOP",
+                "systemVersion": "v20250827",
+                "iris": [
+                  "https://athena.ohdsi.org/search-terms/terms/1315946"
+                ]
+              }
+            }
+          ],
+          "extensions": [
+            {
+              "name": "therapy_strategy",
+              "value": [
+                "Aromatase inhibition"
+              ],
+              "description": "Associated therapeutic strategy or mechanism of action of the therapy."
+            },
+            {
+              "name": "therapy_type",
+              "value": "Hormone therapy",
+              "description": "Type of cancer treatment from cancer.gov: https://www.cancer.gov/about-cancer/treatment/types"
+            }
+          ],
+          "primaryCoding": {
+            "id": "ncit:C1527",
+            "code": "C1527",
+            "name": "Letrozole",
+            "system": "https://evsexplore.semantics.cancer.gov",
+            "systemVersion": "25.01d",
+            "iris": [
+              "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C1527"
+            ]
+          }
+        },
+        {
+          "id": 53,
+          "conceptType": "Drug",
+          "name": "Ribociclib",
+          "mappings": [
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "rxcui:1873916",
+                "code": "1873916",
+                "name": "ribociclib",
+                "system": "RxNorm",
+                "systemVersion": "02-Mar-2026",
+                "iris": [
+                  "https://mor.nlm.nih.gov/RxNav/search?searchBy=RXCUI&searchTerm=1873916"
+                ]
+              }
+            },
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "omop:1592911",
+                "code": "1592911",
+                "name": "ribociclib",
+                "system": "OMOP",
+                "systemVersion": "v20260227",
+                "iris": [
+                  "https://athena.ohdsi.org/search-terms/terms/1592911"
+                ]
+              }
+            },
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "sctid:732257004",
+                "code": "732257004",
+                "name": "Ribociclib",
+                "system": "SNOMED",
+                "systemVersion": "2025-03-01",
+                "iris": [
+                  "https://browser.ihtsdotools.org/?perspective=full&conceptId1=732257004&edition=MAIN/2025-03-01&release=&languages=en"
+                ]
+              }
+            },
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "omop:37115766",
+                "code": "37115766",
+                "name": "Ribociclib",
+                "system": "OMOP",
+                "systemVersion": "v20260227",
+                "iris": [
+                  "https://athena.ohdsi.org/search-terms/terms/37115766"
+                ]
+              }
+            }
+          ],
+          "extensions": [
+            {
+              "name": "therapy_strategy",
+              "value": [
+                "CDK4/6 inhibition"
+              ],
+              "description": "Associated therapeutic strategy or mechanism of action of the therapy."
+            },
+            {
+              "name": "therapy_type",
+              "value": "Targeted therapy",
+              "description": "Type of cancer treatment from cancer.gov: https://www.cancer.gov/about-cancer/treatment/types"
+            }
+          ],
+          "primaryCoding": {
+            "id": "ncit:C95701",
+            "code": "C95701",
+            "name": "Ribociclib",
+            "system": "https://evsexplore.semantics.cancer.gov",
+            "systemVersion": "25.01d",
+            "iris": [
+              "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C95701"
+            ]
+          }
+        }
+      ]
+    }
+  },
+  "strength": {
+    "id": 0,
+    "conceptType": "Evidence",
+    "name": "Approval",
+    "mappings": [],
+    "primaryCoding": {
+      "id": "ncit:C25425",
+      "code": "C25425",
+      "name": "Approval",
+      "system": "https://evsexplore.semantics.cancer.gov",
+      "systemVersion": "25.01d",
+      "iris": [
+        "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C25425"
+      ]
+    }
+  }
+}

--- a/dereferenced/statements/2340.json
+++ b/dereferenced/statements/2340.json
@@ -1,0 +1,554 @@
+{
+  "id": 2340,
+  "type": "Statement",
+  "description": "Health Canada approved ribociclib in combination with an aromatase inhibitor for the adjuvant treatment of adult patients with hormone receptor (HR)-positive, human epidermal growth factor receptor 2 (HER2)-negative stage II-III early breast cancer at high risk of recurrence. This indication is based on NATALEE (LEE011 O12301C) was a randomized (1:1), open-label, multicenter study, where participants received goserelin and either letrozole or anastrozole, in addition to ribociclib.",
+  "contributions": [
+    {
+      "id": 0,
+      "type": "Contribution",
+      "description": "Initial access of FDA approvals",
+      "date": "2024-10-30",
+      "contributor": {
+        "id": "vanallenlab",
+        "type": "Agent",
+        "agentType": "contributor",
+        "name": "Van Allen lab",
+        "description": "Van Allen lab, Dana-Farber Cancer Institute"
+      }
+    }
+  ],
+  "reportedIn": [
+    {
+      "id": "doc:hc.kisqali",
+      "type": "Document",
+      "documentType": "Regulatory approval",
+      "name": "Kisqali (ribociclib) [product monograph]. HC.",
+      "title": null,
+      "aliases": [],
+      "description": "Novartis Pharmaceuticals Canada Inc. Kisqali (ribociclib) [product monograph]. Health Canada website. https://pdf.hres.ca/dpd_pm/00083872.PDF. Revised March 2026. Accessed April 2026.",
+      "urls": [
+        "https://pdf.hres.ca/dpd_pm/00083872.PDF",
+        "https://health-products.canada.ca/dpd-bdpp/info?lang=eng&code=96295"
+      ],
+      "doi": null,
+      "pmid": null,
+      "extensions": [
+        {
+          "name": "agent",
+          "value": {
+            "id": "hc",
+            "type": "Agent",
+            "agentType": "organization",
+            "name": "Health Canada",
+            "description": "Regulatory agency that approves drugs for sale and use in Canada."
+          },
+          "description": "The organization that published this document."
+        },
+        {
+          "name": "company",
+          "value": "Novartis Pharmaceuticals Canada Inc.",
+          "description": "The company that manufactures the cancer drug. Only applicable to market authorization documents."
+        },
+        {
+          "name": "drug_name_brand",
+          "value": "Kisqali",
+          "description": "The brand name of the cancer drug, per this document. Only applicable to market authorization documents."
+        },
+        {
+          "name": "drug_name_generic",
+          "value": "ribociclib",
+          "description": "The generic name of the cancer drug, per this document. Only applicable to market authorization documents."
+        },
+        {
+          "name": "first_publication_date",
+          "value": "2018-03-02",
+          "description": "The publication date for the initial version of this document."
+        },
+        {
+          "name": "identification_number",
+          "value": null,
+          "description": "Identification number used by the publishing organization."
+        },
+        {
+          "name": "publication_date",
+          "value": "2026-03-26",
+          "description": "The publication date for the document."
+        },
+        {
+          "name": "status",
+          "value": "Active",
+          "description": "Whether this document is Active or Deprecated within moalmanac-db."
+        }
+      ]
+    }
+  ],
+  "direction": "supports",
+  "indication": {
+    "id": "ind:hc.kisqali:2",
+    "indication": "KISQALI (ribociclib tablets) is indicated, in combination with an aromatase inhibitor for the adjuvant treatment of adult patients with hormone receptor (HR)-positive, human epidermal growth factor receptor 2 (HER2)-negative stage II-III early breast cancer at high risk of recurrence.",
+    "initial_approval_date": null,
+    "initial_approval_url": null,
+    "description": "Health Canada approved ribociclib in combination with an aromatase inhibitor for the adjuvant treatment of adult patients with hormone receptor (HR)-positive, human epidermal growth factor receptor 2 (HER2)-negative stage II-III early breast cancer at high risk of recurrence. This indication is based on NATALEE (LEE011 O12301C) was a randomized (1:1), open-label, multicenter study, where participants received goserelin and either letrozole or anastrozole, in addition to ribociclib.",
+    "raw_biomarkers": "HR+, HER2-negative",
+    "raw_cancer_type": "early breast cancer",
+    "raw_therapeutics": "Kisqali (ribociclib), aromatase inhibitor",
+    "document": {
+      "id": "doc:hc.kisqali",
+      "type": "Document",
+      "documentType": "Regulatory approval",
+      "name": "Kisqali (ribociclib) [product monograph]. HC.",
+      "title": null,
+      "aliases": [],
+      "description": "Novartis Pharmaceuticals Canada Inc. Kisqali (ribociclib) [product monograph]. Health Canada website. https://pdf.hres.ca/dpd_pm/00083872.PDF. Revised March 2026. Accessed April 2026.",
+      "urls": [
+        "https://pdf.hres.ca/dpd_pm/00083872.PDF",
+        "https://health-products.canada.ca/dpd-bdpp/info?lang=eng&code=96295"
+      ],
+      "doi": null,
+      "pmid": null,
+      "extensions": [
+        {
+          "name": "agent",
+          "value": {
+            "id": "hc",
+            "type": "Agent",
+            "agentType": "organization",
+            "name": "Health Canada",
+            "description": "Regulatory agency that approves drugs for sale and use in Canada."
+          },
+          "description": "The organization that published this document."
+        },
+        {
+          "name": "company",
+          "value": "Novartis Pharmaceuticals Canada Inc.",
+          "description": "The company that manufactures the cancer drug. Only applicable to market authorization documents."
+        },
+        {
+          "name": "drug_name_brand",
+          "value": "Kisqali",
+          "description": "The brand name of the cancer drug, per this document. Only applicable to market authorization documents."
+        },
+        {
+          "name": "drug_name_generic",
+          "value": "ribociclib",
+          "description": "The generic name of the cancer drug, per this document. Only applicable to market authorization documents."
+        },
+        {
+          "name": "first_publication_date",
+          "value": "2018-03-02",
+          "description": "The publication date for the initial version of this document."
+        },
+        {
+          "name": "identification_number",
+          "value": null,
+          "description": "Identification number used by the publishing organization."
+        },
+        {
+          "name": "publication_date",
+          "value": "2026-03-26",
+          "description": "The publication date for the document."
+        },
+        {
+          "name": "status",
+          "value": "Active",
+          "description": "Whether this document is Active or Deprecated within moalmanac-db."
+        }
+      ]
+    }
+  },
+  "proposition": {
+    "id": 504,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      {
+        "id": 1,
+        "type": "CategoricalVariant",
+        "name": "ER positive",
+        "extensions": [
+          {
+            "name": "biomarker_type",
+            "value": "Protein expression"
+          },
+          {
+            "name": "marker",
+            "value": "Estrogen receptor (ER)"
+          },
+          {
+            "name": "unit",
+            "value": "status"
+          },
+          {
+            "name": "equality",
+            "value": "="
+          },
+          {
+            "name": "value",
+            "value": "Positive"
+          },
+          {
+            "name": "_present",
+            "value": true
+          }
+        ]
+      },
+      {
+        "id": 2,
+        "type": "CategoricalVariant",
+        "name": "HER2-negative",
+        "extensions": [
+          {
+            "name": "biomarker_type",
+            "value": "Protein expression"
+          },
+          {
+            "name": "marker",
+            "value": "Human epidermal growth factor receptor 2 (HER2)"
+          },
+          {
+            "name": "unit",
+            "value": "status"
+          },
+          {
+            "name": "equality",
+            "value": "="
+          },
+          {
+            "name": "value",
+            "value": "Negative"
+          },
+          {
+            "name": "_present",
+            "value": true
+          }
+        ]
+      },
+      {
+        "id": 3,
+        "type": "CategoricalVariant",
+        "name": "PR positive",
+        "extensions": [
+          {
+            "name": "biomarker_type",
+            "value": "Protein expression"
+          },
+          {
+            "name": "marker",
+            "value": "Progesterone receptor (PR)"
+          },
+          {
+            "name": "unit",
+            "value": "status"
+          },
+          {
+            "name": "equality",
+            "value": "="
+          },
+          {
+            "name": "value",
+            "value": "Positive"
+          },
+          {
+            "name": "_present",
+            "value": true
+          }
+        ]
+      }
+    ],
+    "subjectVariant": {},
+    "conditionQualifier": {
+      "id": 9,
+      "conceptType": "Disease",
+      "name": "Invasive Breast Carcinoma",
+      "mappings": [],
+      "extensions": [
+        {
+          "name": "solid_tumor",
+          "value": true,
+          "description": "Boolean value for if this tumor type is categorized as a solid tumor."
+        }
+      ],
+      "primaryCoding": {
+        "id": "oncotree:BRCA",
+        "code": "BRCA",
+        "name": "Invasive Breast Carcinoma",
+        "system": "https://oncotree.mskcc.org",
+        "systemVersion": "oncotree_2021_11_02",
+        "iris": [
+          "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=BRCA"
+        ]
+      }
+    },
+    "objectTherapeutic": {
+      "id": 92,
+      "membershipOperator": "AND",
+      "therapies": [
+        {
+          "id": 143,
+          "conceptType": "Drug",
+          "name": "Goserelin",
+          "mappings": [
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "rxcui:50610",
+                "code": "50610",
+                "name": "goserelin",
+                "system": "RxNorm",
+                "systemVersion": "02-Mar-2026",
+                "iris": [
+                  "https://mor.nlm.nih.gov/RxNav/search?searchBy=RXCUI&searchTerm=50610"
+                ]
+              }
+            },
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "omop:1366310",
+                "code": "1366310",
+                "name": "goserelin",
+                "system": "OMOP",
+                "systemVersion": "v20260227",
+                "iris": [
+                  "https://athena.ohdsi.org/search-terms/terms/1366310"
+                ]
+              }
+            },
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "sctid:108771008",
+                "code": "108771008",
+                "name": "Goserelin",
+                "system": "SNOMED",
+                "systemVersion": "2025-03-01",
+                "iris": [
+                  "https://browser.ihtsdotools.org/?perspective=full&conceptId1=108771008&edition=MAIN/2025-03-01&release=&languages=en"
+                ]
+              }
+            },
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "omop:4031929",
+                "code": "4031929",
+                "name": "Goserelin",
+                "system": "OMOP",
+                "systemVersion": "v20260227",
+                "iris": [
+                  "https://athena.ohdsi.org/search-terms/terms/4031929"
+                ]
+              }
+            }
+          ],
+          "extensions": [
+            {
+              "name": "therapy_strategy",
+              "value": [
+                "Gonadotropin-releasing hormone (GnRH) agonist"
+              ],
+              "description": "Associated therapeutic strategy or mechanism of action of the therapy."
+            },
+            {
+              "name": "therapy_type",
+              "value": "Hormone therapy",
+              "description": "Type of cancer treatment from cancer.gov: https://www.cancer.gov/about-cancer/treatment/types"
+            }
+          ],
+          "primaryCoding": {
+            "id": "ncit:C1374",
+            "code": "C1374",
+            "name": "Goserelin",
+            "system": "https://evsexplore.semantics.cancer.gov",
+            "systemVersion": "25.01d",
+            "iris": [
+              "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C1374"
+            ]
+          }
+        },
+        {
+          "id": 40,
+          "conceptType": "Drug",
+          "name": "Letrozole",
+          "mappings": [
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "rxcui:72965",
+                "code": "72965",
+                "name": "letrozole",
+                "system": "RxNorm",
+                "systemVersion": "20250602",
+                "iris": [
+                  "https://mor.nlm.nih.gov/RxNav/search?searchBy=RXCUI&searchTerm=72965"
+                ]
+              }
+            },
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "omop:4297547",
+                "code": "4297547",
+                "name": "Letrozole",
+                "system": "OMOP",
+                "systemVersion": "v20250827",
+                "iris": [
+                  "https://athena.ohdsi.org/search-terms/terms/4297547"
+                ]
+              }
+            },
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "sctid:386911004",
+                "code": "386911004",
+                "name": "Letrozole",
+                "system": "SNOMED",
+                "systemVersion": "2026-03-01",
+                "iris": [
+                  "https://browser.ihtsdotools.org/?perspective=full&conceptId1=386911004&edition=MAIN/2026-03-01&release=&languages=en"
+                ]
+              }
+            },
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "omop:1315946",
+                "code": "1315946",
+                "name": "letrozole",
+                "system": "OMOP",
+                "systemVersion": "v20250827",
+                "iris": [
+                  "https://athena.ohdsi.org/search-terms/terms/1315946"
+                ]
+              }
+            }
+          ],
+          "extensions": [
+            {
+              "name": "therapy_strategy",
+              "value": [
+                "Aromatase inhibition"
+              ],
+              "description": "Associated therapeutic strategy or mechanism of action of the therapy."
+            },
+            {
+              "name": "therapy_type",
+              "value": "Hormone therapy",
+              "description": "Type of cancer treatment from cancer.gov: https://www.cancer.gov/about-cancer/treatment/types"
+            }
+          ],
+          "primaryCoding": {
+            "id": "ncit:C1527",
+            "code": "C1527",
+            "name": "Letrozole",
+            "system": "https://evsexplore.semantics.cancer.gov",
+            "systemVersion": "25.01d",
+            "iris": [
+              "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C1527"
+            ]
+          }
+        },
+        {
+          "id": 53,
+          "conceptType": "Drug",
+          "name": "Ribociclib",
+          "mappings": [
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "rxcui:1873916",
+                "code": "1873916",
+                "name": "ribociclib",
+                "system": "RxNorm",
+                "systemVersion": "02-Mar-2026",
+                "iris": [
+                  "https://mor.nlm.nih.gov/RxNav/search?searchBy=RXCUI&searchTerm=1873916"
+                ]
+              }
+            },
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "omop:1592911",
+                "code": "1592911",
+                "name": "ribociclib",
+                "system": "OMOP",
+                "systemVersion": "v20260227",
+                "iris": [
+                  "https://athena.ohdsi.org/search-terms/terms/1592911"
+                ]
+              }
+            },
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "sctid:732257004",
+                "code": "732257004",
+                "name": "Ribociclib",
+                "system": "SNOMED",
+                "systemVersion": "2025-03-01",
+                "iris": [
+                  "https://browser.ihtsdotools.org/?perspective=full&conceptId1=732257004&edition=MAIN/2025-03-01&release=&languages=en"
+                ]
+              }
+            },
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "omop:37115766",
+                "code": "37115766",
+                "name": "Ribociclib",
+                "system": "OMOP",
+                "systemVersion": "v20260227",
+                "iris": [
+                  "https://athena.ohdsi.org/search-terms/terms/37115766"
+                ]
+              }
+            }
+          ],
+          "extensions": [
+            {
+              "name": "therapy_strategy",
+              "value": [
+                "CDK4/6 inhibition"
+              ],
+              "description": "Associated therapeutic strategy or mechanism of action of the therapy."
+            },
+            {
+              "name": "therapy_type",
+              "value": "Targeted therapy",
+              "description": "Type of cancer treatment from cancer.gov: https://www.cancer.gov/about-cancer/treatment/types"
+            }
+          ],
+          "primaryCoding": {
+            "id": "ncit:C95701",
+            "code": "C95701",
+            "name": "Ribociclib",
+            "system": "https://evsexplore.semantics.cancer.gov",
+            "systemVersion": "25.01d",
+            "iris": [
+              "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C95701"
+            ]
+          }
+        }
+      ]
+    }
+  },
+  "strength": {
+    "id": 0,
+    "conceptType": "Evidence",
+    "name": "Approval",
+    "mappings": [],
+    "primaryCoding": {
+      "id": "ncit:C25425",
+      "code": "C25425",
+      "name": "Approval",
+      "system": "https://evsexplore.semantics.cancer.gov",
+      "systemVersion": "25.01d",
+      "iris": [
+        "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C25425"
+      ]
+    }
+  }
+}

--- a/dereferenced/statements/2341.json
+++ b/dereferenced/statements/2341.json
@@ -1,0 +1,611 @@
+{
+  "id": 2341,
+  "type": "Statement",
+  "description": "Health Canada approved nivolumab in combination with platinum-doublet chemotherapy, the neoadjuvant treatment of adult patients with resectable Stage II (>4 cm), IIIA, IIIB (T3-4N2) NSCLC and no known epidermal growth factor Opdivo (nivolumab) receptor (EGFR) mutations or anaplastic lymphoma kinase (ALK) rearrangements, followed by OPDIVO as a single agent in the adjuvant setting after surgical resection. This approval is based on CHECKMATE-816, a randomized, open label trial where patients were offered platinum-doublet chemotherapy consisting of either paclitaxel and carboplatin; pemetrexed and cisplatin for non-squamous histology; or gemcitabine and cisplatin for squamous histology.",
+  "contributions": [
+    {
+      "id": 0,
+      "type": "Contribution",
+      "description": "Initial access of FDA approvals",
+      "date": "2024-10-30",
+      "contributor": {
+        "id": "vanallenlab",
+        "type": "Agent",
+        "agentType": "contributor",
+        "name": "Van Allen lab",
+        "description": "Van Allen lab, Dana-Farber Cancer Institute"
+      }
+    }
+  ],
+  "reportedIn": [
+    {
+      "id": "doc:hc.opdivo",
+      "type": "Document",
+      "documentType": "Regulatory approval",
+      "name": "Opdivo (nivolumab) [product monograph]. HC.",
+      "title": null,
+      "aliases": [],
+      "description": "Bristol-Myers Squibb Canada. Opdivo (nivolumab) [product monograph]. Health Canada website. https://pdf.hres.ca/dpd_pm/00083469.PDF. Revised February 2026. Accessed April 2026.",
+      "urls": [
+        "https://pdf.hres.ca/dpd_pm/00083469.PDF",
+        "https://health-products.canada.ca/dpd-bdpp/info?lang=eng&code=93204"
+      ],
+      "doi": null,
+      "pmid": null,
+      "extensions": [
+        {
+          "name": "agent",
+          "value": {
+            "id": "hc",
+            "type": "Agent",
+            "agentType": "organization",
+            "name": "Health Canada",
+            "description": "Regulatory agency that approves drugs for sale and use in Canada."
+          },
+          "description": "The organization that published this document."
+        },
+        {
+          "name": "company",
+          "value": "Bristol-Myers Squibb Canada",
+          "description": "The company that manufactures the cancer drug. Only applicable to market authorization documents."
+        },
+        {
+          "name": "drug_name_brand",
+          "value": "Opdivo",
+          "description": "The brand name of the cancer drug, per this document. Only applicable to market authorization documents."
+        },
+        {
+          "name": "drug_name_generic",
+          "value": "nivolumab",
+          "description": "The generic name of the cancer drug, per this document. Only applicable to market authorization documents."
+        },
+        {
+          "name": "first_publication_date",
+          "value": "2015-09-25",
+          "description": "The publication date for the initial version of this document."
+        },
+        {
+          "name": "identification_number",
+          "value": null,
+          "description": "Identification number used by the publishing organization."
+        },
+        {
+          "name": "publication_date",
+          "value": "2026-02-06",
+          "description": "The publication date for the document."
+        },
+        {
+          "name": "status",
+          "value": "Active",
+          "description": "Whether this document is Active or Deprecated within moalmanac-db."
+        }
+      ]
+    }
+  ],
+  "direction": "supports",
+  "indication": {
+    "id": "ind:hc.opdivo:8",
+    "indication": "OPDIVO (nivolumab), in combination with platinum-doublet chemotherapy, the neoadjuvant treatment of adult patients with resectable Stage II (>4 cm), IIIA, IIIB (T3-4N2) NSCLC and no known epidermal growth factor Opdivo (nivolumab) receptor (EGFR) mutations or anaplastic lymphoma kinase (ALK) rearrangements, followed by OPDIVO as a single agent in the adjuvant setting after surgical resection.",
+    "initial_approval_date": null,
+    "initial_approval_url": null,
+    "description": "Health Canada approved nivolumab in combination with platinum-doublet chemotherapy, the neoadjuvant treatment of adult patients with resectable Stage II (>4 cm), IIIA, IIIB (T3-4N2) NSCLC and no known epidermal growth factor Opdivo (nivolumab) receptor (EGFR) mutations or anaplastic lymphoma kinase (ALK) rearrangements, followed by OPDIVO as a single agent in the adjuvant setting after surgical resection. This approval is based on CHECKMATE-816, a randomized, open label trial where patients were offered platinum-doublet chemotherapy consisting of either paclitaxel and carboplatin; pemetrexed and cisplatin for non-squamous histology; or gemcitabine and cisplatin for squamous histology.",
+    "raw_biomarkers": "no known EGFR mutations or ALK rearrangements",
+    "raw_cancer_type": "non-small cell lung cancer NSCLC ",
+    "raw_therapeutics": "Opdivo (nivolumab), platinum-doublet chemotherapy",
+    "document": {
+      "id": "doc:hc.opdivo",
+      "type": "Document",
+      "documentType": "Regulatory approval",
+      "name": "Opdivo (nivolumab) [product monograph]. HC.",
+      "title": null,
+      "aliases": [],
+      "description": "Bristol-Myers Squibb Canada. Opdivo (nivolumab) [product monograph]. Health Canada website. https://pdf.hres.ca/dpd_pm/00083469.PDF. Revised February 2026. Accessed April 2026.",
+      "urls": [
+        "https://pdf.hres.ca/dpd_pm/00083469.PDF",
+        "https://health-products.canada.ca/dpd-bdpp/info?lang=eng&code=93204"
+      ],
+      "doi": null,
+      "pmid": null,
+      "extensions": [
+        {
+          "name": "agent",
+          "value": {
+            "id": "hc",
+            "type": "Agent",
+            "agentType": "organization",
+            "name": "Health Canada",
+            "description": "Regulatory agency that approves drugs for sale and use in Canada."
+          },
+          "description": "The organization that published this document."
+        },
+        {
+          "name": "company",
+          "value": "Bristol-Myers Squibb Canada",
+          "description": "The company that manufactures the cancer drug. Only applicable to market authorization documents."
+        },
+        {
+          "name": "drug_name_brand",
+          "value": "Opdivo",
+          "description": "The brand name of the cancer drug, per this document. Only applicable to market authorization documents."
+        },
+        {
+          "name": "drug_name_generic",
+          "value": "nivolumab",
+          "description": "The generic name of the cancer drug, per this document. Only applicable to market authorization documents."
+        },
+        {
+          "name": "first_publication_date",
+          "value": "2015-09-25",
+          "description": "The publication date for the initial version of this document."
+        },
+        {
+          "name": "identification_number",
+          "value": null,
+          "description": "Identification number used by the publishing organization."
+        },
+        {
+          "name": "publication_date",
+          "value": "2026-02-06",
+          "description": "The publication date for the document."
+        },
+        {
+          "name": "status",
+          "value": "Active",
+          "description": "Whether this document is Active or Deprecated within moalmanac-db."
+        }
+      ]
+    }
+  },
+  "proposition": {
+    "id": 229,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      {
+        "id": 34,
+        "type": "CategoricalVariant",
+        "name": "Wild type ALK",
+        "genes": [
+          {
+            "id": 2,
+            "conceptType": "Gene",
+            "name": "ALK",
+            "mappings": [
+              {
+                "relation": "exactMatch",
+                "coding": {
+                  "id": "ensembl:ensg00000171094",
+                  "code": "ENSG00000171094",
+                  "system": "https://www.ensembl.org",
+                  "iris": [
+                    "https://www.ensembl.org/id/ENSG00000171094"
+                  ]
+                }
+              },
+              {
+                "relation": "exactMatch",
+                "coding": {
+                  "id": "ncbi:238",
+                  "code": "238",
+                  "system": "https://www.ncbi.nlm.nih.gov/gene",
+                  "iris": [
+                    "https://www.ncbi.nlm.nih.gov/gene/238"
+                  ]
+                }
+              },
+              {
+                "relation": "relatedMatch",
+                "coding": {
+                  "id": "refseq:NM_004304.5",
+                  "code": "NM_004304.5",
+                  "system": "https://www.ncbi.nlm.nih.gov/nuccore",
+                  "iris": [
+                    "https://www.ncbi.nlm.nih.gov/nuccore/NM_004304.5"
+                  ]
+                }
+              }
+            ],
+            "extensions": [
+              {
+                "name": "location",
+                "value": "2p23.2-p23.1"
+              },
+              {
+                "name": "location_sortable",
+                "value": "02p23.2-p23.1"
+              }
+            ],
+            "primaryCoding": {
+              "id": "hgnc:427",
+              "code": "HGNC:427",
+              "system": "https://genenames.org",
+              "iris": [
+                "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/HGNC:427"
+              ]
+            }
+          }
+        ],
+        "extensions": [
+          {
+            "name": "biomarker_type",
+            "value": "Wild type"
+          },
+          {
+            "name": "_present",
+            "value": true
+          }
+        ]
+      },
+      {
+        "id": 35,
+        "type": "CategoricalVariant",
+        "name": "Wild type EGFR",
+        "genes": [
+          {
+            "id": 17,
+            "conceptType": "Gene",
+            "name": "EGFR",
+            "mappings": [
+              {
+                "relation": "exactMatch",
+                "coding": {
+                  "id": "ensembl:ensg00000146648",
+                  "code": "ENSG00000146648",
+                  "system": "https://www.ensembl.org",
+                  "iris": [
+                    "https://www.ensembl.org/id/ENSG00000146648"
+                  ]
+                }
+              },
+              {
+                "relation": "exactMatch",
+                "coding": {
+                  "id": "ncbi:1956",
+                  "code": "1956",
+                  "system": "https://www.ncbi.nlm.nih.gov/gene",
+                  "iris": [
+                    "https://www.ncbi.nlm.nih.gov/gene/1956"
+                  ]
+                }
+              },
+              {
+                "relation": "relatedMatch",
+                "coding": {
+                  "id": "refseq:NM_005228.5",
+                  "code": "NM_005228.5",
+                  "system": "https://www.ncbi.nlm.nih.gov/nuccore",
+                  "iris": [
+                    "https://www.ncbi.nlm.nih.gov/nuccore/NM_005228.5"
+                  ]
+                }
+              }
+            ],
+            "extensions": [
+              {
+                "name": "location",
+                "value": "7p11.2"
+              },
+              {
+                "name": "location_sortable",
+                "value": "07p11.2"
+              }
+            ],
+            "primaryCoding": {
+              "id": "hgnc:3236",
+              "code": "HGNC:3236",
+              "system": "https://genenames.org",
+              "iris": [
+                "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/HGNC:3236"
+              ]
+            }
+          }
+        ],
+        "extensions": [
+          {
+            "name": "biomarker_type",
+            "value": "Wild type"
+          },
+          {
+            "name": "_present",
+            "value": true
+          }
+        ]
+      }
+    ],
+    "subjectVariant": {},
+    "conditionQualifier": {
+      "id": 47,
+      "conceptType": "Disease",
+      "name": "Non-Small Cell Lung Cancer",
+      "mappings": [],
+      "extensions": [
+        {
+          "name": "solid_tumor",
+          "value": true,
+          "description": "Boolean value for if this tumor type is categorized as a solid tumor."
+        }
+      ],
+      "primaryCoding": {
+        "id": "oncotree:NSCLC",
+        "code": "NSCLC",
+        "name": "Non-Small Cell Lung Cancer",
+        "system": "https://oncotree.mskcc.org",
+        "systemVersion": "oncotree_2021_11_02",
+        "iris": [
+          "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=NSCLC"
+        ]
+      }
+    },
+    "objectTherapeutic": {
+      "id": 42,
+      "membershipOperator": "AND",
+      "therapies": [
+        {
+          "id": 37,
+          "conceptType": "Drug",
+          "name": "Carboplatin",
+          "mappings": [
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "rxcui:40048",
+                "code": "40048",
+                "name": "carboplatin",
+                "system": "RxNorm",
+                "systemVersion": "20250602",
+                "iris": [
+                  "https://mor.nlm.nih.gov/RxNav/search?searchBy=RXCUI&searchTerm=40048"
+                ]
+              }
+            },
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "omop:4299846",
+                "code": "4299846",
+                "name": "Carboplatin",
+                "system": "OMOP",
+                "systemVersion": "v20250827",
+                "iris": [
+                  "https://athena.ohdsi.org/search-terms/terms/4299846"
+                ]
+              }
+            },
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "sctid:386905002",
+                "code": "386905002",
+                "name": "Carboplatin",
+                "system": "SNOMED",
+                "systemVersion": "2026-03-01",
+                "iris": [
+                  "https://browser.ihtsdotools.org/?perspective=full&conceptId1=386905002&edition=MAIN/2026-03-01&release=&languages=en"
+                ]
+              }
+            },
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "omop:1344905",
+                "code": "1344905",
+                "name": "carboplatin",
+                "system": "OMOP",
+                "systemVersion": "v20250827",
+                "iris": [
+                  "https://athena.ohdsi.org/search-terms/terms/1344905"
+                ]
+              }
+            }
+          ],
+          "extensions": [
+            {
+              "name": "therapy_strategy",
+              "value": [
+                "Platinum-based chemotherapy"
+              ],
+              "description": "Associated therapeutic strategy or mechanism of action of the therapy."
+            },
+            {
+              "name": "therapy_type",
+              "value": "Chemotherapy",
+              "description": "Type of cancer treatment from cancer.gov: https://www.cancer.gov/about-cancer/treatment/types"
+            }
+          ],
+          "primaryCoding": {
+            "id": "ncit:C1282",
+            "code": "C1282",
+            "name": "Carboplatin",
+            "system": "https://evsexplore.semantics.cancer.gov",
+            "systemVersion": "25.01d",
+            "iris": [
+              "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C1282"
+            ]
+          }
+        },
+        {
+          "id": 72,
+          "conceptType": "Drug",
+          "name": "Nivolumab",
+          "mappings": [
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "rxcui:1597876",
+                "code": "1597876",
+                "name": "nivolumab",
+                "system": "RxNorm",
+                "systemVersion": "02-Mar-2026",
+                "iris": [
+                  "https://mor.nlm.nih.gov/RxNav/search?searchBy=RXCUI&searchTerm=1597876"
+                ]
+              }
+            },
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "omop:45892628",
+                "code": "45892628",
+                "name": "nivolumab",
+                "system": "OMOP",
+                "systemVersion": "v20260227",
+                "iris": [
+                  "https://athena.ohdsi.org/search-terms/terms/45892628"
+                ]
+              }
+            },
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "sctid:704191007",
+                "code": "704191007",
+                "name": "Nivolumab",
+                "system": "SNOMED",
+                "systemVersion": "2025-03-01",
+                "iris": [
+                  "https://browser.ihtsdotools.org/?perspective=full&conceptId1=704191007&edition=MAIN/2025-03-01&release=&languages=en"
+                ]
+              }
+            },
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "omop:45766924",
+                "code": "45766924",
+                "name": "Nivolumab",
+                "system": "OMOP",
+                "systemVersion": "v20260227",
+                "iris": [
+                  "https://athena.ohdsi.org/search-terms/terms/45766924"
+                ]
+              }
+            }
+          ],
+          "extensions": [
+            {
+              "name": "therapy_strategy",
+              "value": [
+                "PD-1/PD-L1 inhibition"
+              ],
+              "description": "Associated therapeutic strategy or mechanism of action of the therapy."
+            },
+            {
+              "name": "therapy_type",
+              "value": "Immunotherapy",
+              "description": "Type of cancer treatment from cancer.gov: https://www.cancer.gov/about-cancer/treatment/types"
+            }
+          ],
+          "primaryCoding": {
+            "id": "ncit:C68814",
+            "code": "C68814",
+            "name": "Nivolumab",
+            "system": "https://evsexplore.semantics.cancer.gov",
+            "systemVersion": "25.01d",
+            "iris": [
+              "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C68814"
+            ]
+          }
+        },
+        {
+          "id": 35,
+          "conceptType": "Drug",
+          "name": "Paclitaxel",
+          "mappings": [
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "rxcui:56946",
+                "code": "56946",
+                "name": "paclitaxel",
+                "system": "RxNorm",
+                "systemVersion": "20250602",
+                "iris": [
+                  "https://mor.nlm.nih.gov/RxNav/search?searchBy=RXCUI&searchTerm=56946"
+                ]
+              }
+            },
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "omop:4306859",
+                "code": "4306859",
+                "name": "Paclitaxel",
+                "system": "OMOP",
+                "systemVersion": "v20250827",
+                "iris": [
+                  "https://athena.ohdsi.org/search-terms/terms/4306859"
+                ]
+              }
+            },
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "sctid:387374002",
+                "code": "387374002",
+                "name": "Paclitaxel",
+                "system": "SNOMED",
+                "systemVersion": "2026-03-01",
+                "iris": [
+                  "https://browser.ihtsdotools.org/?perspective=full&conceptId1=387374002&edition=MAIN/2026-03-01&release=&languages=en"
+                ]
+              }
+            },
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "omop:1378382",
+                "code": "1378382",
+                "name": "paclitaxel",
+                "system": "OMOP",
+                "systemVersion": "v20250827",
+                "iris": [
+                  "https://athena.ohdsi.org/search-terms/terms/1378382"
+                ]
+              }
+            }
+          ],
+          "extensions": [
+            {
+              "name": "therapy_strategy",
+              "value": [
+                "Taxane-based chemotherapy"
+              ],
+              "description": "Associated therapeutic strategy or mechanism of action of the therapy."
+            },
+            {
+              "name": "therapy_type",
+              "value": "Chemotherapy",
+              "description": "Type of cancer treatment from cancer.gov: https://www.cancer.gov/about-cancer/treatment/types"
+            }
+          ],
+          "primaryCoding": {
+            "id": "ncit:C1411",
+            "code": "C1411",
+            "name": "Paclitaxel",
+            "system": "https://evsexplore.semantics.cancer.gov",
+            "systemVersion": "25.01d",
+            "iris": [
+              "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C1411"
+            ]
+          }
+        }
+      ]
+    }
+  },
+  "strength": {
+    "id": 0,
+    "conceptType": "Evidence",
+    "name": "Approval",
+    "mappings": [],
+    "primaryCoding": {
+      "id": "ncit:C25425",
+      "code": "C25425",
+      "name": "Approval",
+      "system": "https://evsexplore.semantics.cancer.gov",
+      "systemVersion": "25.01d",
+      "iris": [
+        "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C25425"
+      ]
+    }
+  }
+}

--- a/dereferenced/statements/2342.json
+++ b/dereferenced/statements/2342.json
@@ -1,0 +1,611 @@
+{
+  "id": 2342,
+  "type": "Statement",
+  "description": "Health Canada approved nivolumab in combination with platinum-doublet chemotherapy, the neoadjuvant treatment of adult patients with resectable Stage II (>4 cm), IIIA, IIIB (T3-4N2) NSCLC and no known epidermal growth factor Opdivo (nivolumab) receptor (EGFR) mutations or anaplastic lymphoma kinase (ALK) rearrangements, followed by OPDIVO as a single agent in the adjuvant setting after surgical resection. This approval is based on CHECKMATE-816, a randomized, open label trial where patients were offered platinum-doublet chemotherapy consisting of either paclitaxel and carboplatin; pemetrexed and cisplatin for non-squamous histology; or gemcitabine and cisplatin for squamous histology.",
+  "contributions": [
+    {
+      "id": 0,
+      "type": "Contribution",
+      "description": "Initial access of FDA approvals",
+      "date": "2024-10-30",
+      "contributor": {
+        "id": "vanallenlab",
+        "type": "Agent",
+        "agentType": "contributor",
+        "name": "Van Allen lab",
+        "description": "Van Allen lab, Dana-Farber Cancer Institute"
+      }
+    }
+  ],
+  "reportedIn": [
+    {
+      "id": "doc:hc.opdivo",
+      "type": "Document",
+      "documentType": "Regulatory approval",
+      "name": "Opdivo (nivolumab) [product monograph]. HC.",
+      "title": null,
+      "aliases": [],
+      "description": "Bristol-Myers Squibb Canada. Opdivo (nivolumab) [product monograph]. Health Canada website. https://pdf.hres.ca/dpd_pm/00083469.PDF. Revised February 2026. Accessed April 2026.",
+      "urls": [
+        "https://pdf.hres.ca/dpd_pm/00083469.PDF",
+        "https://health-products.canada.ca/dpd-bdpp/info?lang=eng&code=93204"
+      ],
+      "doi": null,
+      "pmid": null,
+      "extensions": [
+        {
+          "name": "agent",
+          "value": {
+            "id": "hc",
+            "type": "Agent",
+            "agentType": "organization",
+            "name": "Health Canada",
+            "description": "Regulatory agency that approves drugs for sale and use in Canada."
+          },
+          "description": "The organization that published this document."
+        },
+        {
+          "name": "company",
+          "value": "Bristol-Myers Squibb Canada",
+          "description": "The company that manufactures the cancer drug. Only applicable to market authorization documents."
+        },
+        {
+          "name": "drug_name_brand",
+          "value": "Opdivo",
+          "description": "The brand name of the cancer drug, per this document. Only applicable to market authorization documents."
+        },
+        {
+          "name": "drug_name_generic",
+          "value": "nivolumab",
+          "description": "The generic name of the cancer drug, per this document. Only applicable to market authorization documents."
+        },
+        {
+          "name": "first_publication_date",
+          "value": "2015-09-25",
+          "description": "The publication date for the initial version of this document."
+        },
+        {
+          "name": "identification_number",
+          "value": null,
+          "description": "Identification number used by the publishing organization."
+        },
+        {
+          "name": "publication_date",
+          "value": "2026-02-06",
+          "description": "The publication date for the document."
+        },
+        {
+          "name": "status",
+          "value": "Active",
+          "description": "Whether this document is Active or Deprecated within moalmanac-db."
+        }
+      ]
+    }
+  ],
+  "direction": "supports",
+  "indication": {
+    "id": "ind:hc.opdivo:8",
+    "indication": "OPDIVO (nivolumab), in combination with platinum-doublet chemotherapy, the neoadjuvant treatment of adult patients with resectable Stage II (>4 cm), IIIA, IIIB (T3-4N2) NSCLC and no known epidermal growth factor Opdivo (nivolumab) receptor (EGFR) mutations or anaplastic lymphoma kinase (ALK) rearrangements, followed by OPDIVO as a single agent in the adjuvant setting after surgical resection.",
+    "initial_approval_date": null,
+    "initial_approval_url": null,
+    "description": "Health Canada approved nivolumab in combination with platinum-doublet chemotherapy, the neoadjuvant treatment of adult patients with resectable Stage II (>4 cm), IIIA, IIIB (T3-4N2) NSCLC and no known epidermal growth factor Opdivo (nivolumab) receptor (EGFR) mutations or anaplastic lymphoma kinase (ALK) rearrangements, followed by OPDIVO as a single agent in the adjuvant setting after surgical resection. This approval is based on CHECKMATE-816, a randomized, open label trial where patients were offered platinum-doublet chemotherapy consisting of either paclitaxel and carboplatin; pemetrexed and cisplatin for non-squamous histology; or gemcitabine and cisplatin for squamous histology.",
+    "raw_biomarkers": "no known EGFR mutations or ALK rearrangements",
+    "raw_cancer_type": "non-small cell lung cancer NSCLC ",
+    "raw_therapeutics": "Opdivo (nivolumab), platinum-doublet chemotherapy",
+    "document": {
+      "id": "doc:hc.opdivo",
+      "type": "Document",
+      "documentType": "Regulatory approval",
+      "name": "Opdivo (nivolumab) [product monograph]. HC.",
+      "title": null,
+      "aliases": [],
+      "description": "Bristol-Myers Squibb Canada. Opdivo (nivolumab) [product monograph]. Health Canada website. https://pdf.hres.ca/dpd_pm/00083469.PDF. Revised February 2026. Accessed April 2026.",
+      "urls": [
+        "https://pdf.hres.ca/dpd_pm/00083469.PDF",
+        "https://health-products.canada.ca/dpd-bdpp/info?lang=eng&code=93204"
+      ],
+      "doi": null,
+      "pmid": null,
+      "extensions": [
+        {
+          "name": "agent",
+          "value": {
+            "id": "hc",
+            "type": "Agent",
+            "agentType": "organization",
+            "name": "Health Canada",
+            "description": "Regulatory agency that approves drugs for sale and use in Canada."
+          },
+          "description": "The organization that published this document."
+        },
+        {
+          "name": "company",
+          "value": "Bristol-Myers Squibb Canada",
+          "description": "The company that manufactures the cancer drug. Only applicable to market authorization documents."
+        },
+        {
+          "name": "drug_name_brand",
+          "value": "Opdivo",
+          "description": "The brand name of the cancer drug, per this document. Only applicable to market authorization documents."
+        },
+        {
+          "name": "drug_name_generic",
+          "value": "nivolumab",
+          "description": "The generic name of the cancer drug, per this document. Only applicable to market authorization documents."
+        },
+        {
+          "name": "first_publication_date",
+          "value": "2015-09-25",
+          "description": "The publication date for the initial version of this document."
+        },
+        {
+          "name": "identification_number",
+          "value": null,
+          "description": "Identification number used by the publishing organization."
+        },
+        {
+          "name": "publication_date",
+          "value": "2026-02-06",
+          "description": "The publication date for the document."
+        },
+        {
+          "name": "status",
+          "value": "Active",
+          "description": "Whether this document is Active or Deprecated within moalmanac-db."
+        }
+      ]
+    }
+  },
+  "proposition": {
+    "id": 505,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      {
+        "id": 34,
+        "type": "CategoricalVariant",
+        "name": "Wild type ALK",
+        "genes": [
+          {
+            "id": 2,
+            "conceptType": "Gene",
+            "name": "ALK",
+            "mappings": [
+              {
+                "relation": "exactMatch",
+                "coding": {
+                  "id": "ensembl:ensg00000171094",
+                  "code": "ENSG00000171094",
+                  "system": "https://www.ensembl.org",
+                  "iris": [
+                    "https://www.ensembl.org/id/ENSG00000171094"
+                  ]
+                }
+              },
+              {
+                "relation": "exactMatch",
+                "coding": {
+                  "id": "ncbi:238",
+                  "code": "238",
+                  "system": "https://www.ncbi.nlm.nih.gov/gene",
+                  "iris": [
+                    "https://www.ncbi.nlm.nih.gov/gene/238"
+                  ]
+                }
+              },
+              {
+                "relation": "relatedMatch",
+                "coding": {
+                  "id": "refseq:NM_004304.5",
+                  "code": "NM_004304.5",
+                  "system": "https://www.ncbi.nlm.nih.gov/nuccore",
+                  "iris": [
+                    "https://www.ncbi.nlm.nih.gov/nuccore/NM_004304.5"
+                  ]
+                }
+              }
+            ],
+            "extensions": [
+              {
+                "name": "location",
+                "value": "2p23.2-p23.1"
+              },
+              {
+                "name": "location_sortable",
+                "value": "02p23.2-p23.1"
+              }
+            ],
+            "primaryCoding": {
+              "id": "hgnc:427",
+              "code": "HGNC:427",
+              "system": "https://genenames.org",
+              "iris": [
+                "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/HGNC:427"
+              ]
+            }
+          }
+        ],
+        "extensions": [
+          {
+            "name": "biomarker_type",
+            "value": "Wild type"
+          },
+          {
+            "name": "_present",
+            "value": true
+          }
+        ]
+      },
+      {
+        "id": 35,
+        "type": "CategoricalVariant",
+        "name": "Wild type EGFR",
+        "genes": [
+          {
+            "id": 17,
+            "conceptType": "Gene",
+            "name": "EGFR",
+            "mappings": [
+              {
+                "relation": "exactMatch",
+                "coding": {
+                  "id": "ensembl:ensg00000146648",
+                  "code": "ENSG00000146648",
+                  "system": "https://www.ensembl.org",
+                  "iris": [
+                    "https://www.ensembl.org/id/ENSG00000146648"
+                  ]
+                }
+              },
+              {
+                "relation": "exactMatch",
+                "coding": {
+                  "id": "ncbi:1956",
+                  "code": "1956",
+                  "system": "https://www.ncbi.nlm.nih.gov/gene",
+                  "iris": [
+                    "https://www.ncbi.nlm.nih.gov/gene/1956"
+                  ]
+                }
+              },
+              {
+                "relation": "relatedMatch",
+                "coding": {
+                  "id": "refseq:NM_005228.5",
+                  "code": "NM_005228.5",
+                  "system": "https://www.ncbi.nlm.nih.gov/nuccore",
+                  "iris": [
+                    "https://www.ncbi.nlm.nih.gov/nuccore/NM_005228.5"
+                  ]
+                }
+              }
+            ],
+            "extensions": [
+              {
+                "name": "location",
+                "value": "7p11.2"
+              },
+              {
+                "name": "location_sortable",
+                "value": "07p11.2"
+              }
+            ],
+            "primaryCoding": {
+              "id": "hgnc:3236",
+              "code": "HGNC:3236",
+              "system": "https://genenames.org",
+              "iris": [
+                "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/HGNC:3236"
+              ]
+            }
+          }
+        ],
+        "extensions": [
+          {
+            "name": "biomarker_type",
+            "value": "Wild type"
+          },
+          {
+            "name": "_present",
+            "value": true
+          }
+        ]
+      }
+    ],
+    "subjectVariant": {},
+    "conditionQualifier": {
+      "id": 47,
+      "conceptType": "Disease",
+      "name": "Non-Small Cell Lung Cancer",
+      "mappings": [],
+      "extensions": [
+        {
+          "name": "solid_tumor",
+          "value": true,
+          "description": "Boolean value for if this tumor type is categorized as a solid tumor."
+        }
+      ],
+      "primaryCoding": {
+        "id": "oncotree:NSCLC",
+        "code": "NSCLC",
+        "name": "Non-Small Cell Lung Cancer",
+        "system": "https://oncotree.mskcc.org",
+        "systemVersion": "oncotree_2021_11_02",
+        "iris": [
+          "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=NSCLC"
+        ]
+      }
+    },
+    "objectTherapeutic": {
+      "id": 93,
+      "membershipOperator": "AND",
+      "therapies": [
+        {
+          "id": 39,
+          "conceptType": "Drug",
+          "name": "Cisplatin",
+          "mappings": [
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "rxcui:2555",
+                "code": "2555",
+                "name": "cisplatin",
+                "system": "RxNorm",
+                "systemVersion": "20250602",
+                "iris": [
+                  "https://mor.nlm.nih.gov/RxNav/search?searchBy=RXCUI&searchTerm=2555"
+                ]
+              }
+            },
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "omop:4301188",
+                "code": "4301188",
+                "name": "Cisplatin",
+                "system": "OMOP",
+                "systemVersion": "v20250827",
+                "iris": [
+                  "https://athena.ohdsi.org/search-terms/terms/4301188"
+                ]
+              }
+            },
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "sctid:387318005",
+                "code": "387318005",
+                "name": "Cisplatin",
+                "system": "SNOMED",
+                "systemVersion": "2026-03-01",
+                "iris": [
+                  "https://browser.ihtsdotools.org/?perspective=full&conceptId1=387318005&edition=MAIN/2026-03-01&release=&languages=en"
+                ]
+              }
+            },
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "omop:1397599",
+                "code": "1397599",
+                "name": "cisplatin",
+                "system": "OMOP",
+                "systemVersion": "v20250827",
+                "iris": [
+                  "https://athena.ohdsi.org/search-terms/terms/1397599"
+                ]
+              }
+            }
+          ],
+          "extensions": [
+            {
+              "name": "therapy_strategy",
+              "value": [
+                "Platinum-based chemotherapy"
+              ],
+              "description": "Associated therapeutic strategy or mechanism of action of the therapy."
+            },
+            {
+              "name": "therapy_type",
+              "value": "Chemotherapy",
+              "description": "Type of cancer treatment from cancer.gov: https://www.cancer.gov/about-cancer/treatment/types"
+            }
+          ],
+          "primaryCoding": {
+            "id": "ncit:C376",
+            "code": "C376",
+            "name": "Cisplatin",
+            "system": "https://evsexplore.semantics.cancer.gov",
+            "systemVersion": "25.01d",
+            "iris": [
+              "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C376"
+            ]
+          }
+        },
+        {
+          "id": 72,
+          "conceptType": "Drug",
+          "name": "Nivolumab",
+          "mappings": [
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "rxcui:1597876",
+                "code": "1597876",
+                "name": "nivolumab",
+                "system": "RxNorm",
+                "systemVersion": "02-Mar-2026",
+                "iris": [
+                  "https://mor.nlm.nih.gov/RxNav/search?searchBy=RXCUI&searchTerm=1597876"
+                ]
+              }
+            },
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "omop:45892628",
+                "code": "45892628",
+                "name": "nivolumab",
+                "system": "OMOP",
+                "systemVersion": "v20260227",
+                "iris": [
+                  "https://athena.ohdsi.org/search-terms/terms/45892628"
+                ]
+              }
+            },
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "sctid:704191007",
+                "code": "704191007",
+                "name": "Nivolumab",
+                "system": "SNOMED",
+                "systemVersion": "2025-03-01",
+                "iris": [
+                  "https://browser.ihtsdotools.org/?perspective=full&conceptId1=704191007&edition=MAIN/2025-03-01&release=&languages=en"
+                ]
+              }
+            },
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "omop:45766924",
+                "code": "45766924",
+                "name": "Nivolumab",
+                "system": "OMOP",
+                "systemVersion": "v20260227",
+                "iris": [
+                  "https://athena.ohdsi.org/search-terms/terms/45766924"
+                ]
+              }
+            }
+          ],
+          "extensions": [
+            {
+              "name": "therapy_strategy",
+              "value": [
+                "PD-1/PD-L1 inhibition"
+              ],
+              "description": "Associated therapeutic strategy or mechanism of action of the therapy."
+            },
+            {
+              "name": "therapy_type",
+              "value": "Immunotherapy",
+              "description": "Type of cancer treatment from cancer.gov: https://www.cancer.gov/about-cancer/treatment/types"
+            }
+          ],
+          "primaryCoding": {
+            "id": "ncit:C68814",
+            "code": "C68814",
+            "name": "Nivolumab",
+            "system": "https://evsexplore.semantics.cancer.gov",
+            "systemVersion": "25.01d",
+            "iris": [
+              "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C68814"
+            ]
+          }
+        },
+        {
+          "id": 49,
+          "conceptType": "Drug",
+          "name": "Pemetrexed",
+          "mappings": [
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "rxcui:68446",
+                "code": "68446",
+                "name": "pemetrexed",
+                "system": "RxNorm",
+                "systemVersion": "02-Mar-2026",
+                "iris": [
+                  "https://mor.nlm.nih.gov/RxNav/search?searchBy=RXCUI&searchTerm=68446"
+                ]
+              }
+            },
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "omop:1304919",
+                "code": "1304919",
+                "name": "pemetrexed",
+                "system": "OMOP",
+                "systemVersion": "v20260227",
+                "iris": [
+                  "https://athena.ohdsi.org/search-terms/terms/1304919"
+                ]
+              }
+            },
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "sctid:409159000",
+                "code": "409159000",
+                "name": "Pemetrexed",
+                "system": "SNOMED",
+                "systemVersion": "2025-03-01",
+                "iris": [
+                  "https://browser.ihtsdotools.org/?perspective=full&conceptId1=409159000&edition=MAIN/2025-03-01&release=&languages=en"
+                ]
+              }
+            },
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "omop:4247743",
+                "code": "4247743",
+                "name": "Pemetrexed",
+                "system": "OMOP",
+                "systemVersion": "v20260227",
+                "iris": [
+                  "https://athena.ohdsi.org/search-terms/terms/4247743"
+                ]
+              }
+            }
+          ],
+          "extensions": [
+            {
+              "name": "therapy_strategy",
+              "value": [
+                "Antifolate"
+              ],
+              "description": "Associated therapeutic strategy or mechanism of action of the therapy."
+            },
+            {
+              "name": "therapy_type",
+              "value": "Chemotherapy",
+              "description": "Type of cancer treatment from cancer.gov: https://www.cancer.gov/about-cancer/treatment/types"
+            }
+          ],
+          "primaryCoding": {
+            "id": "ncit:C61614",
+            "code": "C61614",
+            "name": "Pemetrexed",
+            "system": "https://evsexplore.semantics.cancer.gov",
+            "systemVersion": "25.01d",
+            "iris": [
+              "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C61614"
+            ]
+          }
+        }
+      ]
+    }
+  },
+  "strength": {
+    "id": 0,
+    "conceptType": "Evidence",
+    "name": "Approval",
+    "mappings": [],
+    "primaryCoding": {
+      "id": "ncit:C25425",
+      "code": "C25425",
+      "name": "Approval",
+      "system": "https://evsexplore.semantics.cancer.gov",
+      "systemVersion": "25.01d",
+      "iris": [
+        "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C25425"
+      ]
+    }
+  }
+}

--- a/dereferenced/statements/2343.json
+++ b/dereferenced/statements/2343.json
@@ -1,0 +1,611 @@
+{
+  "id": 2343,
+  "type": "Statement",
+  "description": "Health Canada approved nivolumab in combination with platinum-doublet chemotherapy, the neoadjuvant treatment of adult patients with resectable Stage II (>4 cm), IIIA, IIIB (T3-4N2) NSCLC and no known epidermal growth factor Opdivo (nivolumab) receptor (EGFR) mutations or anaplastic lymphoma kinase (ALK) rearrangements, followed by OPDIVO as a single agent in the adjuvant setting after surgical resection. This approval is based on CHECKMATE-816, a randomized, open label trial where patients were offered platinum-doublet chemotherapy consisting of either paclitaxel and carboplatin; pemetrexed and cisplatin for non-squamous histology; or gemcitabine and cisplatin for squamous histology.",
+  "contributions": [
+    {
+      "id": 0,
+      "type": "Contribution",
+      "description": "Initial access of FDA approvals",
+      "date": "2024-10-30",
+      "contributor": {
+        "id": "vanallenlab",
+        "type": "Agent",
+        "agentType": "contributor",
+        "name": "Van Allen lab",
+        "description": "Van Allen lab, Dana-Farber Cancer Institute"
+      }
+    }
+  ],
+  "reportedIn": [
+    {
+      "id": "doc:hc.opdivo",
+      "type": "Document",
+      "documentType": "Regulatory approval",
+      "name": "Opdivo (nivolumab) [product monograph]. HC.",
+      "title": null,
+      "aliases": [],
+      "description": "Bristol-Myers Squibb Canada. Opdivo (nivolumab) [product monograph]. Health Canada website. https://pdf.hres.ca/dpd_pm/00083469.PDF. Revised February 2026. Accessed April 2026.",
+      "urls": [
+        "https://pdf.hres.ca/dpd_pm/00083469.PDF",
+        "https://health-products.canada.ca/dpd-bdpp/info?lang=eng&code=93204"
+      ],
+      "doi": null,
+      "pmid": null,
+      "extensions": [
+        {
+          "name": "agent",
+          "value": {
+            "id": "hc",
+            "type": "Agent",
+            "agentType": "organization",
+            "name": "Health Canada",
+            "description": "Regulatory agency that approves drugs for sale and use in Canada."
+          },
+          "description": "The organization that published this document."
+        },
+        {
+          "name": "company",
+          "value": "Bristol-Myers Squibb Canada",
+          "description": "The company that manufactures the cancer drug. Only applicable to market authorization documents."
+        },
+        {
+          "name": "drug_name_brand",
+          "value": "Opdivo",
+          "description": "The brand name of the cancer drug, per this document. Only applicable to market authorization documents."
+        },
+        {
+          "name": "drug_name_generic",
+          "value": "nivolumab",
+          "description": "The generic name of the cancer drug, per this document. Only applicable to market authorization documents."
+        },
+        {
+          "name": "first_publication_date",
+          "value": "2015-09-25",
+          "description": "The publication date for the initial version of this document."
+        },
+        {
+          "name": "identification_number",
+          "value": null,
+          "description": "Identification number used by the publishing organization."
+        },
+        {
+          "name": "publication_date",
+          "value": "2026-02-06",
+          "description": "The publication date for the document."
+        },
+        {
+          "name": "status",
+          "value": "Active",
+          "description": "Whether this document is Active or Deprecated within moalmanac-db."
+        }
+      ]
+    }
+  ],
+  "direction": "supports",
+  "indication": {
+    "id": "ind:hc.opdivo:8",
+    "indication": "OPDIVO (nivolumab), in combination with platinum-doublet chemotherapy, the neoadjuvant treatment of adult patients with resectable Stage II (>4 cm), IIIA, IIIB (T3-4N2) NSCLC and no known epidermal growth factor Opdivo (nivolumab) receptor (EGFR) mutations or anaplastic lymphoma kinase (ALK) rearrangements, followed by OPDIVO as a single agent in the adjuvant setting after surgical resection.",
+    "initial_approval_date": null,
+    "initial_approval_url": null,
+    "description": "Health Canada approved nivolumab in combination with platinum-doublet chemotherapy, the neoadjuvant treatment of adult patients with resectable Stage II (>4 cm), IIIA, IIIB (T3-4N2) NSCLC and no known epidermal growth factor Opdivo (nivolumab) receptor (EGFR) mutations or anaplastic lymphoma kinase (ALK) rearrangements, followed by OPDIVO as a single agent in the adjuvant setting after surgical resection. This approval is based on CHECKMATE-816, a randomized, open label trial where patients were offered platinum-doublet chemotherapy consisting of either paclitaxel and carboplatin; pemetrexed and cisplatin for non-squamous histology; or gemcitabine and cisplatin for squamous histology.",
+    "raw_biomarkers": "no known EGFR mutations or ALK rearrangements",
+    "raw_cancer_type": "non-small cell lung cancer NSCLC ",
+    "raw_therapeutics": "Opdivo (nivolumab), platinum-doublet chemotherapy",
+    "document": {
+      "id": "doc:hc.opdivo",
+      "type": "Document",
+      "documentType": "Regulatory approval",
+      "name": "Opdivo (nivolumab) [product monograph]. HC.",
+      "title": null,
+      "aliases": [],
+      "description": "Bristol-Myers Squibb Canada. Opdivo (nivolumab) [product monograph]. Health Canada website. https://pdf.hres.ca/dpd_pm/00083469.PDF. Revised February 2026. Accessed April 2026.",
+      "urls": [
+        "https://pdf.hres.ca/dpd_pm/00083469.PDF",
+        "https://health-products.canada.ca/dpd-bdpp/info?lang=eng&code=93204"
+      ],
+      "doi": null,
+      "pmid": null,
+      "extensions": [
+        {
+          "name": "agent",
+          "value": {
+            "id": "hc",
+            "type": "Agent",
+            "agentType": "organization",
+            "name": "Health Canada",
+            "description": "Regulatory agency that approves drugs for sale and use in Canada."
+          },
+          "description": "The organization that published this document."
+        },
+        {
+          "name": "company",
+          "value": "Bristol-Myers Squibb Canada",
+          "description": "The company that manufactures the cancer drug. Only applicable to market authorization documents."
+        },
+        {
+          "name": "drug_name_brand",
+          "value": "Opdivo",
+          "description": "The brand name of the cancer drug, per this document. Only applicable to market authorization documents."
+        },
+        {
+          "name": "drug_name_generic",
+          "value": "nivolumab",
+          "description": "The generic name of the cancer drug, per this document. Only applicable to market authorization documents."
+        },
+        {
+          "name": "first_publication_date",
+          "value": "2015-09-25",
+          "description": "The publication date for the initial version of this document."
+        },
+        {
+          "name": "identification_number",
+          "value": null,
+          "description": "Identification number used by the publishing organization."
+        },
+        {
+          "name": "publication_date",
+          "value": "2026-02-06",
+          "description": "The publication date for the document."
+        },
+        {
+          "name": "status",
+          "value": "Active",
+          "description": "Whether this document is Active or Deprecated within moalmanac-db."
+        }
+      ]
+    }
+  },
+  "proposition": {
+    "id": 506,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      {
+        "id": 34,
+        "type": "CategoricalVariant",
+        "name": "Wild type ALK",
+        "genes": [
+          {
+            "id": 2,
+            "conceptType": "Gene",
+            "name": "ALK",
+            "mappings": [
+              {
+                "relation": "exactMatch",
+                "coding": {
+                  "id": "ensembl:ensg00000171094",
+                  "code": "ENSG00000171094",
+                  "system": "https://www.ensembl.org",
+                  "iris": [
+                    "https://www.ensembl.org/id/ENSG00000171094"
+                  ]
+                }
+              },
+              {
+                "relation": "exactMatch",
+                "coding": {
+                  "id": "ncbi:238",
+                  "code": "238",
+                  "system": "https://www.ncbi.nlm.nih.gov/gene",
+                  "iris": [
+                    "https://www.ncbi.nlm.nih.gov/gene/238"
+                  ]
+                }
+              },
+              {
+                "relation": "relatedMatch",
+                "coding": {
+                  "id": "refseq:NM_004304.5",
+                  "code": "NM_004304.5",
+                  "system": "https://www.ncbi.nlm.nih.gov/nuccore",
+                  "iris": [
+                    "https://www.ncbi.nlm.nih.gov/nuccore/NM_004304.5"
+                  ]
+                }
+              }
+            ],
+            "extensions": [
+              {
+                "name": "location",
+                "value": "2p23.2-p23.1"
+              },
+              {
+                "name": "location_sortable",
+                "value": "02p23.2-p23.1"
+              }
+            ],
+            "primaryCoding": {
+              "id": "hgnc:427",
+              "code": "HGNC:427",
+              "system": "https://genenames.org",
+              "iris": [
+                "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/HGNC:427"
+              ]
+            }
+          }
+        ],
+        "extensions": [
+          {
+            "name": "biomarker_type",
+            "value": "Wild type"
+          },
+          {
+            "name": "_present",
+            "value": true
+          }
+        ]
+      },
+      {
+        "id": 35,
+        "type": "CategoricalVariant",
+        "name": "Wild type EGFR",
+        "genes": [
+          {
+            "id": 17,
+            "conceptType": "Gene",
+            "name": "EGFR",
+            "mappings": [
+              {
+                "relation": "exactMatch",
+                "coding": {
+                  "id": "ensembl:ensg00000146648",
+                  "code": "ENSG00000146648",
+                  "system": "https://www.ensembl.org",
+                  "iris": [
+                    "https://www.ensembl.org/id/ENSG00000146648"
+                  ]
+                }
+              },
+              {
+                "relation": "exactMatch",
+                "coding": {
+                  "id": "ncbi:1956",
+                  "code": "1956",
+                  "system": "https://www.ncbi.nlm.nih.gov/gene",
+                  "iris": [
+                    "https://www.ncbi.nlm.nih.gov/gene/1956"
+                  ]
+                }
+              },
+              {
+                "relation": "relatedMatch",
+                "coding": {
+                  "id": "refseq:NM_005228.5",
+                  "code": "NM_005228.5",
+                  "system": "https://www.ncbi.nlm.nih.gov/nuccore",
+                  "iris": [
+                    "https://www.ncbi.nlm.nih.gov/nuccore/NM_005228.5"
+                  ]
+                }
+              }
+            ],
+            "extensions": [
+              {
+                "name": "location",
+                "value": "7p11.2"
+              },
+              {
+                "name": "location_sortable",
+                "value": "07p11.2"
+              }
+            ],
+            "primaryCoding": {
+              "id": "hgnc:3236",
+              "code": "HGNC:3236",
+              "system": "https://genenames.org",
+              "iris": [
+                "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/HGNC:3236"
+              ]
+            }
+          }
+        ],
+        "extensions": [
+          {
+            "name": "biomarker_type",
+            "value": "Wild type"
+          },
+          {
+            "name": "_present",
+            "value": true
+          }
+        ]
+      }
+    ],
+    "subjectVariant": {},
+    "conditionQualifier": {
+      "id": 47,
+      "conceptType": "Disease",
+      "name": "Non-Small Cell Lung Cancer",
+      "mappings": [],
+      "extensions": [
+        {
+          "name": "solid_tumor",
+          "value": true,
+          "description": "Boolean value for if this tumor type is categorized as a solid tumor."
+        }
+      ],
+      "primaryCoding": {
+        "id": "oncotree:NSCLC",
+        "code": "NSCLC",
+        "name": "Non-Small Cell Lung Cancer",
+        "system": "https://oncotree.mskcc.org",
+        "systemVersion": "oncotree_2021_11_02",
+        "iris": [
+          "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=NSCLC"
+        ]
+      }
+    },
+    "objectTherapeutic": {
+      "id": 94,
+      "membershipOperator": "AND",
+      "therapies": [
+        {
+          "id": 39,
+          "conceptType": "Drug",
+          "name": "Cisplatin",
+          "mappings": [
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "rxcui:2555",
+                "code": "2555",
+                "name": "cisplatin",
+                "system": "RxNorm",
+                "systemVersion": "20250602",
+                "iris": [
+                  "https://mor.nlm.nih.gov/RxNav/search?searchBy=RXCUI&searchTerm=2555"
+                ]
+              }
+            },
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "omop:4301188",
+                "code": "4301188",
+                "name": "Cisplatin",
+                "system": "OMOP",
+                "systemVersion": "v20250827",
+                "iris": [
+                  "https://athena.ohdsi.org/search-terms/terms/4301188"
+                ]
+              }
+            },
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "sctid:387318005",
+                "code": "387318005",
+                "name": "Cisplatin",
+                "system": "SNOMED",
+                "systemVersion": "2026-03-01",
+                "iris": [
+                  "https://browser.ihtsdotools.org/?perspective=full&conceptId1=387318005&edition=MAIN/2026-03-01&release=&languages=en"
+                ]
+              }
+            },
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "omop:1397599",
+                "code": "1397599",
+                "name": "cisplatin",
+                "system": "OMOP",
+                "systemVersion": "v20250827",
+                "iris": [
+                  "https://athena.ohdsi.org/search-terms/terms/1397599"
+                ]
+              }
+            }
+          ],
+          "extensions": [
+            {
+              "name": "therapy_strategy",
+              "value": [
+                "Platinum-based chemotherapy"
+              ],
+              "description": "Associated therapeutic strategy or mechanism of action of the therapy."
+            },
+            {
+              "name": "therapy_type",
+              "value": "Chemotherapy",
+              "description": "Type of cancer treatment from cancer.gov: https://www.cancer.gov/about-cancer/treatment/types"
+            }
+          ],
+          "primaryCoding": {
+            "id": "ncit:C376",
+            "code": "C376",
+            "name": "Cisplatin",
+            "system": "https://evsexplore.semantics.cancer.gov",
+            "systemVersion": "25.01d",
+            "iris": [
+              "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C376"
+            ]
+          }
+        },
+        {
+          "id": 50,
+          "conceptType": "Drug",
+          "name": "Gemcitabine",
+          "mappings": [
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "rxcui:12574",
+                "code": "12574",
+                "name": "gemcitabine",
+                "system": "RxNorm",
+                "systemVersion": "02-Mar-2026",
+                "iris": [
+                  "https://mor.nlm.nih.gov/RxNav/search?searchBy=RXCUI&searchTerm=12574"
+                ]
+              }
+            },
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "omop:1314924",
+                "code": "1314924",
+                "name": "gemcitabine",
+                "system": "OMOP",
+                "systemVersion": "v20260227",
+                "iris": [
+                  "https://athena.ohdsi.org/search-terms/terms/1314924"
+                ]
+              }
+            },
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "sctid:386920008",
+                "code": "386920008",
+                "name": "Gemcitabine",
+                "system": "SNOMED",
+                "systemVersion": "2025-03-01",
+                "iris": [
+                  "https://browser.ihtsdotools.org/?perspective=full&conceptId1=386920008&edition=MAIN/2025-03-01&release=&languages=en"
+                ]
+              }
+            },
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "omop:4305105",
+                "code": "4305105",
+                "name": "Gemcitabine",
+                "system": "OMOP",
+                "systemVersion": "v20260227",
+                "iris": [
+                  "https://athena.ohdsi.org/search-terms/terms/4305105"
+                ]
+              }
+            }
+          ],
+          "extensions": [
+            {
+              "name": "therapy_strategy",
+              "value": [
+                "Antimetabolite"
+              ],
+              "description": "Associated therapeutic strategy or mechanism of action of the therapy."
+            },
+            {
+              "name": "therapy_type",
+              "value": "Chemotherapy",
+              "description": "Type of cancer treatment from cancer.gov: https://www.cancer.gov/about-cancer/treatment/types"
+            }
+          ],
+          "primaryCoding": {
+            "id": "ncit:C66876",
+            "code": "C66876",
+            "name": "Gemcitabine",
+            "system": "https://evsexplore.semantics.cancer.gov",
+            "systemVersion": "25.01d",
+            "iris": [
+              "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C66876"
+            ]
+          }
+        },
+        {
+          "id": 72,
+          "conceptType": "Drug",
+          "name": "Nivolumab",
+          "mappings": [
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "rxcui:1597876",
+                "code": "1597876",
+                "name": "nivolumab",
+                "system": "RxNorm",
+                "systemVersion": "02-Mar-2026",
+                "iris": [
+                  "https://mor.nlm.nih.gov/RxNav/search?searchBy=RXCUI&searchTerm=1597876"
+                ]
+              }
+            },
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "omop:45892628",
+                "code": "45892628",
+                "name": "nivolumab",
+                "system": "OMOP",
+                "systemVersion": "v20260227",
+                "iris": [
+                  "https://athena.ohdsi.org/search-terms/terms/45892628"
+                ]
+              }
+            },
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "sctid:704191007",
+                "code": "704191007",
+                "name": "Nivolumab",
+                "system": "SNOMED",
+                "systemVersion": "2025-03-01",
+                "iris": [
+                  "https://browser.ihtsdotools.org/?perspective=full&conceptId1=704191007&edition=MAIN/2025-03-01&release=&languages=en"
+                ]
+              }
+            },
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "omop:45766924",
+                "code": "45766924",
+                "name": "Nivolumab",
+                "system": "OMOP",
+                "systemVersion": "v20260227",
+                "iris": [
+                  "https://athena.ohdsi.org/search-terms/terms/45766924"
+                ]
+              }
+            }
+          ],
+          "extensions": [
+            {
+              "name": "therapy_strategy",
+              "value": [
+                "PD-1/PD-L1 inhibition"
+              ],
+              "description": "Associated therapeutic strategy or mechanism of action of the therapy."
+            },
+            {
+              "name": "therapy_type",
+              "value": "Immunotherapy",
+              "description": "Type of cancer treatment from cancer.gov: https://www.cancer.gov/about-cancer/treatment/types"
+            }
+          ],
+          "primaryCoding": {
+            "id": "ncit:C68814",
+            "code": "C68814",
+            "name": "Nivolumab",
+            "system": "https://evsexplore.semantics.cancer.gov",
+            "systemVersion": "25.01d",
+            "iris": [
+              "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C68814"
+            ]
+          }
+        }
+      ]
+    }
+  },
+  "strength": {
+    "id": 0,
+    "conceptType": "Evidence",
+    "name": "Approval",
+    "mappings": [],
+    "primaryCoding": {
+      "id": "ncit:C25425",
+      "code": "C25425",
+      "name": "Approval",
+      "system": "https://evsexplore.semantics.cancer.gov",
+      "systemVersion": "25.01d",
+      "iris": [
+        "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C25425"
+      ]
+    }
+  }
+}

--- a/dereferenced/statements/2385.json
+++ b/dereferenced/statements/2385.json
@@ -157,50 +157,50 @@
     }
   },
   "proposition": {
-    "id": 538,
+    "id": 537,
     "type": "VariantTherapeuticResponseProposition",
     "predicate": "predictSensitivityTo",
     "biomarkers": [
       {
-        "id": 49,
+        "id": 47,
         "type": "CategoricalVariant",
-        "name": "BRCA2 oncogenic variants",
+        "name": "BRCA1 oncogenic variants",
         "genes": [
           {
-            "id": 10,
+            "id": 9,
             "conceptType": "Gene",
-            "name": "BRCA2",
+            "name": "BRCA1",
             "mappings": [
               {
                 "relation": "exactMatch",
                 "coding": {
-                  "id": "ensembl:ensg00000139618",
-                  "code": "ENSG00000139618",
+                  "id": "ensembl:ensg00000012048",
+                  "code": "ENSG00000012048",
                   "system": "https://www.ensembl.org",
                   "iris": [
-                    "https://www.ensembl.org/id/ENSG00000139618"
+                    "https://www.ensembl.org/id/ENSG00000012048"
                   ]
                 }
               },
               {
                 "relation": "exactMatch",
                 "coding": {
-                  "id": "ncbi:675",
-                  "code": "675",
+                  "id": "ncbi:672",
+                  "code": "672",
                   "system": "https://www.ncbi.nlm.nih.gov/gene",
                   "iris": [
-                    "https://www.ncbi.nlm.nih.gov/gene/675"
+                    "https://www.ncbi.nlm.nih.gov/gene/672"
                   ]
                 }
               },
               {
                 "relation": "relatedMatch",
                 "coding": {
-                  "id": "refseq:NM_000059.4",
-                  "code": "NM_000059.4",
+                  "id": "refseq:NM_007294.4",
+                  "code": "NM_007294.4",
                   "system": "https://www.ncbi.nlm.nih.gov/nuccore",
                   "iris": [
-                    "https://www.ncbi.nlm.nih.gov/nuccore/NM_000059.4"
+                    "https://www.ncbi.nlm.nih.gov/nuccore/NM_007294.4"
                   ]
                 }
               }
@@ -208,19 +208,19 @@
             "extensions": [
               {
                 "name": "location",
-                "value": "13q13.1"
+                "value": "17q21.31"
               },
               {
                 "name": "location_sortable",
-                "value": "13q13.1"
+                "value": "17q21.31"
               }
             ],
             "primaryCoding": {
-              "id": "hgnc:1101",
-              "code": "HGNC:1101",
+              "id": "hgnc:1100",
+              "code": "HGNC:1100",
               "system": "https://genenames.org",
               "iris": [
-                "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/HGNC:1101"
+                "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/HGNC:1100"
               ]
             }
           }
@@ -232,7 +232,7 @@
           },
           {
             "name": "chromosome",
-            "value": "13"
+            "value": "17"
           },
           {
             "name": "start_position",

--- a/dereferenced/statements/2393.json
+++ b/dereferenced/statements/2393.json
@@ -157,14 +157,14 @@
     }
   },
   "proposition": {
-    "id": 540,
+    "id": 538,
     "type": "VariantTherapeuticResponseProposition",
     "predicate": "predictSensitivityTo",
     "biomarkers": [
       {
-        "id": 50,
+        "id": 49,
         "type": "CategoricalVariant",
-        "name": "BRCA2 pathogenic variants",
+        "name": "BRCA2 oncogenic variants",
         "genes": [
           {
             "id": 10,
@@ -228,7 +228,7 @@
         "extensions": [
           {
             "name": "biomarker_type",
-            "value": "Germline Variant"
+            "value": "Somatic Variant"
           },
           {
             "name": "chromosome",
@@ -279,7 +279,7 @@
             "value": null
           },
           {
-            "name": "requires_pathogenic",
+            "name": "requires_oncogenic",
             "value": true
           },
           {

--- a/dereferenced/statements/2395.json
+++ b/dereferenced/statements/2395.json
@@ -1,0 +1,588 @@
+{
+  "id": 2395,
+  "type": "Statement",
+  "description": "Health Canada approved niraparib and abiraterone acetate in combination with prednisone or prednisolone for the treatment of adult patients with deleterious or suspected deleterious BRCA-mutated (germline and/or somatic) metastatic castration-resistant prostate cancer (mCRPC), who are asymptomatic or mildly symptomatic, and in whom chemotherapy is not clinically indicated.",
+  "contributions": [
+    {
+      "id": 0,
+      "type": "Contribution",
+      "description": "Initial access of FDA approvals",
+      "date": "2024-10-30",
+      "contributor": {
+        "id": "vanallenlab",
+        "type": "Agent",
+        "agentType": "contributor",
+        "name": "Van Allen lab",
+        "description": "Van Allen lab, Dana-Farber Cancer Institute"
+      }
+    }
+  ],
+  "reportedIn": [
+    {
+      "id": "doc:hc.akeega",
+      "type": "Document",
+      "documentType": "Regulatory approval",
+      "name": "Akeega (abiraterone acetate and niraparib) [product monograph]. HC.",
+      "title": null,
+      "aliases": [],
+      "description": "Janssen Inc. Akeega (abiraterone acetate and niraparib) [product monograph]. Health Canada website. https://pdf.hres.ca/dpd_pm/00078864.PDF. Revised March 2025. Accessed June 2025.",
+      "urls": [
+        "https://pdf.hres.ca/dpd_pm/00078864.PDF",
+        "https://health-products.canada.ca/dpd-bdpp/info?lang=eng&code=102726"
+      ],
+      "doi": null,
+      "pmid": null,
+      "extensions": [
+        {
+          "name": "agent",
+          "value": {
+            "id": "hc",
+            "type": "Agent",
+            "agentType": "organization",
+            "name": "Health Canada",
+            "description": "Regulatory agency that approves drugs for sale and use in Canada."
+          },
+          "description": "The organization that published this document."
+        },
+        {
+          "name": "company",
+          "value": "Janssen Inc.",
+          "description": "The company that manufactures the cancer drug. Only applicable to market authorization documents."
+        },
+        {
+          "name": "drug_name_brand",
+          "value": "Akeega",
+          "description": "The brand name of the cancer drug, per this document. Only applicable to market authorization documents."
+        },
+        {
+          "name": "drug_name_generic",
+          "value": "abiraterone acetate and niraparib",
+          "description": "The generic name of the cancer drug, per this document. Only applicable to market authorization documents."
+        },
+        {
+          "name": "first_publication_date",
+          "value": "2023-06-07",
+          "description": "The publication date for the initial version of this document."
+        },
+        {
+          "name": "identification_number",
+          "value": null,
+          "description": "Identification number used by the publishing organization."
+        },
+        {
+          "name": "publication_date",
+          "value": "2025-03-12",
+          "description": "The publication date for the document."
+        },
+        {
+          "name": "status",
+          "value": "Active",
+          "description": "Whether this document is Active or Deprecated within moalmanac-db."
+        }
+      ]
+    }
+  ],
+  "direction": "supports",
+  "indication": {
+    "id": "ind:hc.akeega:0",
+    "indication": "AKEEGA (niraparib and abiraterone acetate) is indicated with prednisone or prednisolone for the treatment of adult patients with deleterious or suspected deleterious BRCA mutated (germline and/or somatic) metastatic castration resistant prostate cancer (mCRPC), who are asymptomatic/mildly symptomatic, and in whom chemotherapy is not clinically indicated.",
+    "initial_approval_date": null,
+    "initial_approval_url": null,
+    "description": "Health Canada approved niraparib and abiraterone acetate in combination with prednisone or prednisolone for the treatment of adult patients with deleterious or suspected deleterious BRCA-mutated (germline and/or somatic) metastatic castration-resistant prostate cancer (mCRPC), who are asymptomatic or mildly symptomatic, and in whom chemotherapy is not clinically indicated.",
+    "raw_biomarkers": "deleterious or suspected deleterious BRCA mutated (germline and/or somatic)",
+    "raw_cancer_type": "metastatic castration resistant prostate cancer",
+    "raw_therapeutics": "Akeega (niraparib and abiraterone acetate) with prednisone or prednisolone",
+    "document": {
+      "id": "doc:hc.akeega",
+      "type": "Document",
+      "documentType": "Regulatory approval",
+      "name": "Akeega (abiraterone acetate and niraparib) [product monograph]. HC.",
+      "title": null,
+      "aliases": [],
+      "description": "Janssen Inc. Akeega (abiraterone acetate and niraparib) [product monograph]. Health Canada website. https://pdf.hres.ca/dpd_pm/00078864.PDF. Revised March 2025. Accessed June 2025.",
+      "urls": [
+        "https://pdf.hres.ca/dpd_pm/00078864.PDF",
+        "https://health-products.canada.ca/dpd-bdpp/info?lang=eng&code=102726"
+      ],
+      "doi": null,
+      "pmid": null,
+      "extensions": [
+        {
+          "name": "agent",
+          "value": {
+            "id": "hc",
+            "type": "Agent",
+            "agentType": "organization",
+            "name": "Health Canada",
+            "description": "Regulatory agency that approves drugs for sale and use in Canada."
+          },
+          "description": "The organization that published this document."
+        },
+        {
+          "name": "company",
+          "value": "Janssen Inc.",
+          "description": "The company that manufactures the cancer drug. Only applicable to market authorization documents."
+        },
+        {
+          "name": "drug_name_brand",
+          "value": "Akeega",
+          "description": "The brand name of the cancer drug, per this document. Only applicable to market authorization documents."
+        },
+        {
+          "name": "drug_name_generic",
+          "value": "abiraterone acetate and niraparib",
+          "description": "The generic name of the cancer drug, per this document. Only applicable to market authorization documents."
+        },
+        {
+          "name": "first_publication_date",
+          "value": "2023-06-07",
+          "description": "The publication date for the initial version of this document."
+        },
+        {
+          "name": "identification_number",
+          "value": null,
+          "description": "Identification number used by the publishing organization."
+        },
+        {
+          "name": "publication_date",
+          "value": "2025-03-12",
+          "description": "The publication date for the document."
+        },
+        {
+          "name": "status",
+          "value": "Active",
+          "description": "Whether this document is Active or Deprecated within moalmanac-db."
+        }
+      ]
+    }
+  },
+  "proposition": {
+    "id": 540,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      {
+        "id": 50,
+        "type": "CategoricalVariant",
+        "name": "BRCA2 pathogenic variants",
+        "genes": [
+          {
+            "id": 10,
+            "conceptType": "Gene",
+            "name": "BRCA2",
+            "mappings": [
+              {
+                "relation": "exactMatch",
+                "coding": {
+                  "id": "ensembl:ensg00000139618",
+                  "code": "ENSG00000139618",
+                  "system": "https://www.ensembl.org",
+                  "iris": [
+                    "https://www.ensembl.org/id/ENSG00000139618"
+                  ]
+                }
+              },
+              {
+                "relation": "exactMatch",
+                "coding": {
+                  "id": "ncbi:675",
+                  "code": "675",
+                  "system": "https://www.ncbi.nlm.nih.gov/gene",
+                  "iris": [
+                    "https://www.ncbi.nlm.nih.gov/gene/675"
+                  ]
+                }
+              },
+              {
+                "relation": "relatedMatch",
+                "coding": {
+                  "id": "refseq:NM_000059.4",
+                  "code": "NM_000059.4",
+                  "system": "https://www.ncbi.nlm.nih.gov/nuccore",
+                  "iris": [
+                    "https://www.ncbi.nlm.nih.gov/nuccore/NM_000059.4"
+                  ]
+                }
+              }
+            ],
+            "extensions": [
+              {
+                "name": "location",
+                "value": "13q13.1"
+              },
+              {
+                "name": "location_sortable",
+                "value": "13q13.1"
+              }
+            ],
+            "primaryCoding": {
+              "id": "hgnc:1101",
+              "code": "HGNC:1101",
+              "system": "https://genenames.org",
+              "iris": [
+                "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/HGNC:1101"
+              ]
+            }
+          }
+        ],
+        "extensions": [
+          {
+            "name": "biomarker_type",
+            "value": "Germline Variant"
+          },
+          {
+            "name": "chromosome",
+            "value": "13"
+          },
+          {
+            "name": "start_position",
+            "value": null
+          },
+          {
+            "name": "end_position",
+            "value": null
+          },
+          {
+            "name": "reference_allele",
+            "value": null
+          },
+          {
+            "name": "alternate_allele",
+            "value": null
+          },
+          {
+            "name": "cdna_change",
+            "value": null
+          },
+          {
+            "name": "protein_change",
+            "value": null
+          },
+          {
+            "name": "variant_annotation",
+            "value": null
+          },
+          {
+            "name": "exon",
+            "value": null
+          },
+          {
+            "name": "rsid",
+            "value": null
+          },
+          {
+            "name": "hgvsg",
+            "value": null
+          },
+          {
+            "name": "hgvsc",
+            "value": null
+          },
+          {
+            "name": "requires_pathogenic",
+            "value": true
+          },
+          {
+            "name": "_present",
+            "value": true
+          }
+        ]
+      }
+    ],
+    "subjectVariant": {},
+    "conditionQualifier": {
+      "id": 55,
+      "conceptType": "Disease",
+      "name": "Prostate Adenocarcinoma",
+      "mappings": [],
+      "extensions": [
+        {
+          "name": "solid_tumor",
+          "value": true,
+          "description": "Boolean value for if this tumor type is categorized as a solid tumor."
+        }
+      ],
+      "primaryCoding": {
+        "id": "oncotree:PRAD",
+        "code": "PRAD",
+        "name": "Prostate Adenocarcinoma",
+        "system": "https://oncotree.mskcc.org",
+        "systemVersion": "oncotree_2021_11_02",
+        "iris": [
+          "https://oncotree.mskcc.org/?version=oncotree_2021_11_02&field=CODE&search=PRAD"
+        ]
+      }
+    },
+    "objectTherapeutic": {
+      "id": 105,
+      "membershipOperator": "AND",
+      "therapies": [
+        {
+          "id": 6,
+          "conceptType": "Drug",
+          "name": "Niraparib",
+          "mappings": [
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "rxcui:1918231",
+                "code": "1918231",
+                "name": "niraparib",
+                "system": "RxNorm",
+                "systemVersion": "20250602",
+                "iris": [
+                  "https://mor.nlm.nih.gov/RxNav/search?searchBy=RXCUI&searchTerm=1918231"
+                ]
+              }
+            },
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "omop:37116802",
+                "code": "37116802",
+                "name": "Niraparib",
+                "system": "OMOP",
+                "systemVersion": "v20250827",
+                "iris": [
+                  "https://athena.ohdsi.org/search-terms/terms/37116802"
+                ]
+              }
+            },
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "sctid:733733005",
+                "code": "733733005",
+                "name": "Niraparib",
+                "system": "SNOMED",
+                "systemVersion": "2026-03-01",
+                "iris": [
+                  "https://browser.ihtsdotools.org/?perspective=full&conceptId1=733733005&edition=MAIN/2026-03-01&release=&languages=en"
+                ]
+              }
+            },
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "omop:1593861",
+                "code": "1593861",
+                "name": "niraparib",
+                "system": "OMOP",
+                "systemVersion": "v20250827",
+                "iris": [
+                  "https://athena.ohdsi.org/search-terms/terms/1593861"
+                ]
+              }
+            }
+          ],
+          "extensions": [
+            {
+              "name": "therapy_strategy",
+              "value": [
+                "PARP inhibition"
+              ],
+              "description": "Associated therapeutic strategy or mechanism of action of the therapy."
+            },
+            {
+              "name": "therapy_type",
+              "value": "Targeted therapy",
+              "description": "Type of cancer treatment from cancer.gov: https://www.cancer.gov/about-cancer/treatment/types"
+            }
+          ],
+          "primaryCoding": {
+            "id": "ncit:C80059",
+            "code": "C80059",
+            "name": "Niraparib",
+            "system": "https://evsexplore.semantics.cancer.gov",
+            "systemVersion": "25.01d",
+            "iris": [
+              "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C80059"
+            ]
+          }
+        },
+        {
+          "id": 7,
+          "conceptType": "Drug",
+          "name": "Abiraterone acetate",
+          "mappings": [
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "rxcui:1100071",
+                "code": "1100071",
+                "name": "abiraterone acetate",
+                "system": "RxNorm",
+                "systemVersion": "20250602",
+                "iris": [
+                  "https://mor.nlm.nih.gov/RxNav/search?searchBy=RXCUI&searchTerm=1100071"
+                ]
+              }
+            },
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "omop:44783577",
+                "code": "44783577",
+                "name": "Abiraterone acetate",
+                "system": "OMOP",
+                "systemVersion": "v20250827",
+                "iris": [
+                  "https://athena.ohdsi.org/search-terms/terms/44783577"
+                ]
+              }
+            },
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "sctid:699679004",
+                "code": "699679004",
+                "name": "Abiraterone acetate",
+                "system": "SNOMED",
+                "systemVersion": "2026-03-01",
+                "iris": [
+                  "https://browser.ihtsdotools.org/?perspective=full&conceptId1=699679004&edition=MAIN/2026-03-01&release=&languages=en"
+                ]
+              }
+            },
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "omop:46274231",
+                "code": "46274231",
+                "name": "abiraterone acetate",
+                "system": "OMOP",
+                "systemVersion": "v20250827",
+                "iris": [
+                  "https://athena.ohdsi.org/search-terms/terms/46274231"
+                ]
+              }
+            }
+          ],
+          "extensions": [
+            {
+              "name": "therapy_strategy",
+              "value": [
+                "Antiandrogen"
+              ],
+              "description": "Associated therapeutic strategy or mechanism of action of the therapy."
+            },
+            {
+              "name": "therapy_type",
+              "value": "Hormone therapy",
+              "description": "Type of cancer treatment from cancer.gov: https://www.cancer.gov/about-cancer/treatment/types"
+            }
+          ],
+          "primaryCoding": {
+            "id": "ncit:C68845",
+            "code": "C68845",
+            "name": "Abiraterone Acetate",
+            "system": "https://evsexplore.semantics.cancer.gov",
+            "systemVersion": "25.01d",
+            "iris": [
+              "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C68845"
+            ]
+          }
+        },
+        {
+          "id": 8,
+          "conceptType": "Drug",
+          "name": "Prednisolone",
+          "mappings": [
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "rxcui:8638",
+                "code": "8638",
+                "name": "prednisolone",
+                "system": "RxNorm",
+                "systemVersion": "20250602",
+                "iris": [
+                  "https://mor.nlm.nih.gov/RxNav/search?searchBy=RXCUI&searchTerm=8638"
+                ]
+              }
+            },
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "omop:4020623",
+                "code": "4020623",
+                "name": "Prednisolone",
+                "system": "OMOP",
+                "systemVersion": "v20250827",
+                "iris": [
+                  "https://athena.ohdsi.org/search-terms/terms/4020623"
+                ]
+              }
+            },
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "sctid:116601002",
+                "code": "116601002",
+                "name": "Prednisolone",
+                "system": "SNOMED",
+                "systemVersion": "2026-03-01",
+                "iris": [
+                  "https://browser.ihtsdotools.org/?perspective=full&conceptId1=116601002&edition=MAIN/2026-03-01&release=&languages=en"
+                ]
+              }
+            },
+            {
+              "relation": "relatedMatch",
+              "coding": {
+                "id": "omop:1550557",
+                "code": "1550557",
+                "name": "prednisolone",
+                "system": "OMOP",
+                "systemVersion": "v20250827",
+                "iris": [
+                  "https://athena.ohdsi.org/search-terms/terms/1550557"
+                ]
+              }
+            }
+          ],
+          "extensions": [
+            {
+              "name": "therapy_strategy",
+              "value": [
+                "Corticosteroid"
+              ],
+              "description": "Associated therapeutic strategy or mechanism of action of the therapy."
+            },
+            {
+              "name": "therapy_type",
+              "value": "Chemotherapy",
+              "description": "Type of cancer treatment from cancer.gov: https://www.cancer.gov/about-cancer/treatment/types"
+            }
+          ],
+          "primaryCoding": {
+            "id": "ncit:C769",
+            "code": "C769",
+            "name": "Prednisolone",
+            "system": "https://evsexplore.semantics.cancer.gov",
+            "systemVersion": "25.01d",
+            "iris": [
+              "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C769"
+            ]
+          }
+        }
+      ]
+    }
+  },
+  "strength": {
+    "id": 0,
+    "conceptType": "Evidence",
+    "name": "Approval",
+    "mappings": [],
+    "primaryCoding": {
+      "id": "ncit:C25425",
+      "code": "C25425",
+      "name": "Approval",
+      "system": "https://evsexplore.semantics.cancer.gov",
+      "systemVersion": "25.01d",
+      "iris": [
+        "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C25425"
+      ]
+    }
+  }
+}

--- a/dereferenced/statements/2396.json
+++ b/dereferenced/statements/2396.json
@@ -1,0 +1,320 @@
+{
+  "id": 2396,
+  "type": "Statement",
+  "description": "Health Canada approved trastuzumab deruxtecan as monotherapy is indicated for the treatment of adult patients with unresectable or metastatic HER2-positive (IHC 3+) solid tumours who have received prior systemic treatment and have no satisfactory alternative treatment options.",
+  "contributions": [
+    {
+      "id": 0,
+      "type": "Contribution",
+      "description": "Initial access of FDA approvals",
+      "date": "2024-10-30",
+      "contributor": {
+        "id": "vanallenlab",
+        "type": "Agent",
+        "agentType": "contributor",
+        "name": "Van Allen lab",
+        "description": "Van Allen lab, Dana-Farber Cancer Institute"
+      }
+    }
+  ],
+  "reportedIn": [
+    {
+      "id": "doc:hc.enhertu",
+      "type": "Document",
+      "documentType": "Regulatory approval",
+      "name": "Enhertu (trastuzumab deruxtecan) [product monograph]. HC.",
+      "title": null,
+      "aliases": [],
+      "description": "AstraZeneca Canada Inc. Enhertu (trastuzumab deruxtecan) [product monograph]. Health Canada website. https://pdf.hres.ca/dpd_pm/00082205.PDF. Revised October 2025. Accessed April 2026.",
+      "urls": [
+        "https://pdf.hres.ca/dpd_pm/00082205.PDF",
+        "https://health-products.canada.ca/dpd-bdpp/info?lang=eng&code=100355"
+      ],
+      "doi": null,
+      "pmid": null,
+      "extensions": [
+        {
+          "name": "agent",
+          "value": {
+            "id": "hc",
+            "type": "Agent",
+            "agentType": "organization",
+            "name": "Health Canada",
+            "description": "Regulatory agency that approves drugs for sale and use in Canada."
+          },
+          "description": "The organization that published this document."
+        },
+        {
+          "name": "company",
+          "value": "AstraZeneca Canada Inc.",
+          "description": "The company that manufactures the cancer drug. Only applicable to market authorization documents."
+        },
+        {
+          "name": "drug_name_brand",
+          "value": "Enhertu",
+          "description": "The brand name of the cancer drug, per this document. Only applicable to market authorization documents."
+        },
+        {
+          "name": "drug_name_generic",
+          "value": "trastuzumab deruxtecan",
+          "description": "The generic name of the cancer drug, per this document. Only applicable to market authorization documents."
+        },
+        {
+          "name": "first_publication_date",
+          "value": "2021-04-15",
+          "description": "The publication date for the initial version of this document."
+        },
+        {
+          "name": "identification_number",
+          "value": null,
+          "description": "Identification number used by the publishing organization."
+        },
+        {
+          "name": "publication_date",
+          "value": "2025-10-27",
+          "description": "The publication date for the document."
+        },
+        {
+          "name": "status",
+          "value": "Active",
+          "description": "Whether this document is Active or Deprecated within moalmanac-db."
+        }
+      ]
+    }
+  ],
+  "direction": "supports",
+  "indication": {
+    "id": "ind:hc.enhertu:4",
+    "indication": "ENHERTU as monotherapy is indicated for the treatment of adult patients with unresectable or metastatic HER2-positive (IHC 3+) solid tumours who have received prior systemic treatment and have no satisfactory alternative treatment options.",
+    "initial_approval_date": null,
+    "initial_approval_url": null,
+    "description": "Health Canada approved trastuzumab deruxtecan as monotherapy is indicated for the treatment of adult patients with unresectable or metastatic HER2-positive (IHC 3+) solid tumours who have received prior systemic treatment and have no satisfactory alternative treatment options.",
+    "raw_biomarkers": "HER2-positive (IHC 3+)",
+    "raw_cancer_type": "unresectable or metastatic solid tumours",
+    "raw_therapeutics": "Enhertu (trastuzumab deruxtecan)",
+    "document": {
+      "id": "doc:hc.enhertu",
+      "type": "Document",
+      "documentType": "Regulatory approval",
+      "name": "Enhertu (trastuzumab deruxtecan) [product monograph]. HC.",
+      "title": null,
+      "aliases": [],
+      "description": "AstraZeneca Canada Inc. Enhertu (trastuzumab deruxtecan) [product monograph]. Health Canada website. https://pdf.hres.ca/dpd_pm/00082205.PDF. Revised October 2025. Accessed April 2026.",
+      "urls": [
+        "https://pdf.hres.ca/dpd_pm/00082205.PDF",
+        "https://health-products.canada.ca/dpd-bdpp/info?lang=eng&code=100355"
+      ],
+      "doi": null,
+      "pmid": null,
+      "extensions": [
+        {
+          "name": "agent",
+          "value": {
+            "id": "hc",
+            "type": "Agent",
+            "agentType": "organization",
+            "name": "Health Canada",
+            "description": "Regulatory agency that approves drugs for sale and use in Canada."
+          },
+          "description": "The organization that published this document."
+        },
+        {
+          "name": "company",
+          "value": "AstraZeneca Canada Inc.",
+          "description": "The company that manufactures the cancer drug. Only applicable to market authorization documents."
+        },
+        {
+          "name": "drug_name_brand",
+          "value": "Enhertu",
+          "description": "The brand name of the cancer drug, per this document. Only applicable to market authorization documents."
+        },
+        {
+          "name": "drug_name_generic",
+          "value": "trastuzumab deruxtecan",
+          "description": "The generic name of the cancer drug, per this document. Only applicable to market authorization documents."
+        },
+        {
+          "name": "first_publication_date",
+          "value": "2021-04-15",
+          "description": "The publication date for the initial version of this document."
+        },
+        {
+          "name": "identification_number",
+          "value": null,
+          "description": "Identification number used by the publishing organization."
+        },
+        {
+          "name": "publication_date",
+          "value": "2025-10-27",
+          "description": "The publication date for the document."
+        },
+        {
+          "name": "status",
+          "value": "Active",
+          "description": "Whether this document is Active or Deprecated within moalmanac-db."
+        }
+      ]
+    }
+  },
+  "proposition": {
+    "id": 424,
+    "type": "VariantTherapeuticResponseProposition",
+    "predicate": "predictSensitivityTo",
+    "biomarkers": [
+      {
+        "id": 20,
+        "type": "CategoricalVariant",
+        "name": "HER2-positive",
+        "extensions": [
+          {
+            "name": "biomarker_type",
+            "value": "Protein expression"
+          },
+          {
+            "name": "marker",
+            "value": "Human epidermal growth factor receptor 2 (HER2)"
+          },
+          {
+            "name": "unit",
+            "value": "status"
+          },
+          {
+            "name": "equality",
+            "value": "="
+          },
+          {
+            "name": "value",
+            "value": "Positive"
+          },
+          {
+            "name": "_present",
+            "value": true
+          }
+        ]
+      }
+    ],
+    "subjectVariant": {},
+    "conditionQualifier": {
+      "id": 5,
+      "conceptType": "Disease",
+      "name": "Any solid tumor",
+      "mappings": [],
+      "extensions": [
+        {
+          "name": "solid_tumor",
+          "value": true,
+          "description": "Boolean value for if this tumor type is categorized as a solid tumor."
+        }
+      ],
+      "primaryCoding": {
+        "id": "ncit:C132146",
+        "code": "C132146",
+        "name": "Malignant Solid Neoplasm",
+        "system": "https://evsexplore.semantics.cancer.gov",
+        "systemVersion": "25.01d",
+        "iris": [
+          "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C132146"
+        ]
+      }
+    },
+    "objectTherapeutic": {
+      "id": 26,
+      "conceptType": "Drug",
+      "name": "Trastuzumab deruxtecan",
+      "mappings": [
+        {
+          "relation": "relatedMatch",
+          "coding": {
+            "id": "rxcui:2267582",
+            "code": "2267582",
+            "name": "trastuzumab deruxtecan",
+            "system": "RxNorm",
+            "systemVersion": "20250602",
+            "iris": [
+              "https://mor.nlm.nih.gov/RxNav/search?searchBy=RXCUI&searchTerm=2267582"
+            ]
+          }
+        },
+        {
+          "relation": "relatedMatch",
+          "coding": {
+            "id": "omop:3666979",
+            "code": "3666979",
+            "name": "Trastuzumab deruxtecan",
+            "system": "OMOP",
+            "systemVersion": "v20250827",
+            "iris": [
+              "https://athena.ohdsi.org/search-terms/terms/3666979"
+            ]
+          }
+        },
+        {
+          "relation": "relatedMatch",
+          "coding": {
+            "id": "sctid:838469001",
+            "code": "838469001",
+            "name": "Trastuzumab deruxtecan",
+            "system": "SNOMED",
+            "systemVersion": "2026-03-01",
+            "iris": [
+              "https://browser.ihtsdotools.org/?perspective=full&conceptId1=838469001&edition=MAIN/2026-03-01&release=&languages=en"
+            ]
+          }
+        },
+        {
+          "relation": "relatedMatch",
+          "coding": {
+            "id": "omop:37498192",
+            "code": "37498192",
+            "name": "trastuzumab deruxtecan",
+            "system": "OMOP",
+            "systemVersion": "v20250827",
+            "iris": [
+              "https://athena.ohdsi.org/search-terms/terms/37498192"
+            ]
+          }
+        }
+      ],
+      "extensions": [
+        {
+          "name": "therapy_strategy",
+          "value": [
+            "HER2 inhibition"
+          ],
+          "description": "Associated therapeutic strategy or mechanism of action of the therapy."
+        },
+        {
+          "name": "therapy_type",
+          "value": "Targeted therapy",
+          "description": "Type of cancer treatment from cancer.gov: https://www.cancer.gov/about-cancer/treatment/types"
+        }
+      ],
+      "primaryCoding": {
+        "id": "ncit:C128799",
+        "code": "C128799",
+        "name": "Trastuzumab Deruxtecan",
+        "system": "https://evsexplore.semantics.cancer.gov",
+        "systemVersion": "25.01d",
+        "iris": [
+          "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C128799"
+        ]
+      }
+    }
+  },
+  "strength": {
+    "id": 0,
+    "conceptType": "Evidence",
+    "name": "Approval",
+    "mappings": [],
+    "primaryCoding": {
+      "id": "ncit:C25425",
+      "code": "C25425",
+      "name": "Approval",
+      "system": "https://evsexplore.semantics.cancer.gov",
+      "systemVersion": "25.01d",
+      "iris": [
+        "https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/C25425"
+      ]
+    }
+  }
+}

--- a/referenced/agents.json
+++ b/referenced/agents.json
@@ -91,7 +91,7 @@
     "extensions": [
       {
         "name": "last_updated",
-        "value": "2026-05-07",
+        "value": "2026-05-22",
         "description": ""
       },
       {

--- a/referenced/indications.json
+++ b/referenced/indications.json
@@ -5222,17 +5222,6 @@
     "raw_therapeutics": "Akeega (niraparib and abiraterone acetate) with prednisone or prednisolone"
   },
   {
-    "id": "ind:hc.akeega:1",
-    "document_id": "doc:hc.akeega",
-    "indication": "AKEEGA (niraparib and abiraterone acetate) is indicated for the treatment of adult patients with deleterious or suspected deleterious BRCA mutated (germline and/or somatic) metastatic castration resistant prostate cancer (mCRPC), who are asymptomatic/mildly symptomatic, and in whom chemotherapy is not clinically indicated. Patients must have confirmation of BRCA mutation before AKEEGA treatment is initiated.",
-    "initial_approval_date": null,
-    "initial_approval_url": null,
-    "description": "Health Canada approved niraparib/abiraterone acetate for the treatment of adult patients with deleterious or suspected deleterious BRCA mutated (germline and/or somatic) metastatic castration resistant prostate cancer (mCRPC), who are asymptomatic/mildly symptomatic, and in whom chemotherapy is not clinically indicated.",
-    "raw_biomarkers": "deleterious or suspected deleterious BRCA mutated (germline and/or somatic)",
-    "raw_cancer_type": "metastatic castration resistant prostate cancer",
-    "raw_therapeutics": "Akeega (niraparib and abiraterone acetate)"
-  },
-  {
     "id": "ind:hc.alecensaro:0",
     "document_id": "doc:hc.alecensaro",
     "indication": "ALECENSARO (alectinib) is indicated for the first-line treatment of patients with anaplastic lymphoma kinase (ALK)-positive, locally advanced (not amenable to curative therapy) or metastatic non-small cell lung cancer (NSCLC).",
@@ -5447,7 +5436,7 @@
     "indication": "ENHERTU as monotherapy is indicated for the treatment of adult patients with unresectable or metastatic HER2-positive (IHC 3+) solid tumours who have received prior systemic treatment and have no satisfactory alternative treatment options.",
     "initial_approval_date": null,
     "initial_approval_url": null,
-    "description": "HHealth Canada approved fam-trastuzumab deruxtecan-nxki as monotherapy is indicated for the treatment of adult patients with unresectable or metastatic HER2-positive (IHC 3+) solid tumours who have received prior systemic treatment and have no satisfactory alternative treatment options.",
+    "description": "Health Canada approved trastuzumab deruxtecan as monotherapy is indicated for the treatment of adult patients with unresectable or metastatic HER2-positive (IHC 3+) solid tumours who have received prior systemic treatment and have no satisfactory alternative treatment options.",
     "raw_biomarkers": "HER2-positive (IHC 3+)",
     "raw_cancer_type": "unresectable or metastatic solid tumours",
     "raw_therapeutics": "Enhertu (trastuzumab deruxtecan)"

--- a/referenced/statements.json
+++ b/referenced/statements.json
@@ -24795,7 +24795,7 @@
   {
     "id": 2083,
     "type": "Statement",
-    "description": "Health Canada approved pembrolizumab, in combination with chemotherapy with or without bevacizumab, for the treatment of adult patients with persistent, recurrent, or metastatic cervical cancer whose tumours express PD-L1 (CPS >= 1) as determined by a validated test.",
+    "description": "Health Canada approved Pembrolizumab for the treatment of adult patients with resectable locally advanced head and neck squamous cell carcinoma (HNSCC) whose tumours express PD-L1 (Combined Positive Score [CPS] \u22651), as neoadjuvant treatment as monotherapy, continued as adjuvant treatment in combination with radiotherapy (RT) with or without cisplatin and then as monotherapy.",
     "contributions": [
       0
     ],
@@ -24810,7 +24810,7 @@
   {
     "id": 2084,
     "type": "Statement",
-    "description": "Health Canada approved pembrolizumab, in combination with chemotherapy with or without bevacizumab, for the treatment of adult patients with persistent, recurrent, or metastatic cervical cancer whose tumours express PD-L1 (CPS >= 1) as determined by a validated test.",
+    "description": "Health Canada approved Pembrolizumab for the treatment of adult patients with resectable locally advanced head and neck squamous cell carcinoma (HNSCC) whose tumours express PD-L1 (Combined Positive Score [CPS] \u22651), as neoadjuvant treatment as monotherapy, continued as adjuvant treatment in combination with radiotherapy (RT) with or without cisplatin and then as monotherapy.",
     "contributions": [
       0
     ],
@@ -24825,7 +24825,7 @@
   {
     "id": 2085,
     "type": "Statement",
-    "description": "Health Canada approved pembrolizumab, in combination with chemotherapy with or without bevacizumab, for the treatment of adult patients with persistent, recurrent, or metastatic cervical cancer whose tumours express PD-L1 (CPS >= 1) as determined by a validated test.",
+    "description": "Health Canada approved Pembrolizumab for the treatment of adult patients with resectable locally advanced head and neck squamous cell carcinoma (HNSCC) whose tumours express PD-L1 (Combined Positive Score [CPS] \u22651), as neoadjuvant treatment as monotherapy, continued as adjuvant treatment in combination with radiotherapy (RT) with or without cisplatin and then as monotherapy.",
     "contributions": [
       0
     ],
@@ -24840,7 +24840,7 @@
   {
     "id": 2086,
     "type": "Statement",
-    "description": "Health Canada approved pembrolizumab, in combination with chemotherapy with or without bevacizumab, for the treatment of adult patients with persistent, recurrent, or metastatic cervical cancer whose tumours express PD-L1 (CPS >= 1) as determined by a validated test.",
+    "description": "Health Canada approved Pembrolizumab for the treatment of adult patients with resectable locally advanced head and neck squamous cell carcinoma (HNSCC) whose tumours express PD-L1 (Combined Positive Score [CPS] \u22651), as neoadjuvant treatment as monotherapy, continued as adjuvant treatment in combination with radiotherapy (RT) with or without cisplatin and then as monotherapy.",
     "contributions": [
       0
     ],
@@ -24855,7 +24855,7 @@
   {
     "id": 2334,
     "type": "Statement",
-    "description": "Health Canada approved Pembrolizumab for the treatment of adult patients with resectable locally advanced head and neck squamous cell carcinoma (HNSCC) whose tumours express PD-L1 (Combined Positive Score [CPS] ≥1), as neoadjuvant treatment as monotherapy, continued as adjuvant treatment in combination with radiotherapy (RT) with or without cisplatin and then as monotherapy.",
+    "description": "Health Canada approved pembrolizumab, in combination with chemotherapy with or without bevacizumab, for the treatment of adult patients with persistent, recurrent, or metastatic cervical cancer whose tumours express PD-L1 (CPS >= 1) as determined by a validated test.",
     "contributions": [
       0
     ],
@@ -28701,7 +28701,7 @@
   {
     "id": 2346,
     "type": "Statement",
-    "description": "Health Canada approved niraparib/abiraterone acetate for the treatment of adult patients with deleterious or suspected deleterious BRCA mutated (germline and/or somatic) metastatic castration resistant prostate cancer (mCRPC), who are asymptomatic/mildly symptomatic, and in whom chemotherapy is not clinically indicated.",
+    "description": "Health Canada approved niraparib and abiraterone acetate in combination with prednisone or prednisolone for the treatment of adult patients with deleterious or suspected deleterious BRCA-mutated (germline and/or somatic) metastatic castration-resistant prostate cancer (mCRPC), who are asymptomatic or mildly symptomatic, and in whom chemotherapy is not clinically indicated.",
     "contributions": [
       0
     ],
@@ -28716,7 +28716,7 @@
   {
     "id": 2347,
     "type": "Statement",
-    "description": "Health Canada approved niraparib/abiraterone acetate for the treatment of adult patients with deleterious or suspected deleterious BRCA mutated (germline and/or somatic) metastatic castration resistant prostate cancer (mCRPC), who are asymptomatic/mildly symptomatic, and in whom chemotherapy is not clinically indicated.",
+    "description": "Health Canada approved niraparib and abiraterone acetate in combination with prednisone or prednisolone for the treatment of adult patients with deleterious or suspected deleterious BRCA-mutated (germline and/or somatic) metastatic castration-resistant prostate cancer (mCRPC), who are asymptomatic or mildly symptomatic, and in whom chemotherapy is not clinically indicated.",
     "contributions": [
       0
     ],
@@ -29404,9 +29404,9 @@
     "indication_id": "ind:hc.tasigna:3"
   },
   {
-    "id": 2393,
+    "id": 2396,
     "type": "Statement",
-    "description": "",
+    "description": "Health Canada approved trastuzumab deruxtecan as monotherapy is indicated for the treatment of adult patients with unresectable or metastatic HER2-positive (IHC 3+) solid tumours who have received prior systemic treatment and have no satisfactory alternative treatment options.",
     "contributions": [
       0
     ],

--- a/referenced/statements.json
+++ b/referenced/statements.json
@@ -23848,6 +23848,21 @@
     "indication_id": "ind:hc.braftovi:1"
   },
   {
+    "id": 2332,
+    "type": "Statement",
+    "description": "Health Canada approved encorafenib in combination with cetuximab and mFOLFOX6, for the treatment of patients with metastatic colorectal cancer (mCRC) with a BRAF V600E mutation.",
+    "contributions": [
+      0
+    ],
+    "reportedIn": [
+      "doc:hc.braftovi"
+    ],
+    "proposition_id": 521,
+    "direction": "supports",
+    "strength_id": 0,
+    "indication_id": "ind:hc.braftovi:2"
+  },
+  {
     "id": 2021,
     "type": "Statement",
     "description": "Health Canada approved cobimetinib in combination wih vemurafenib for the treatment of patients with unresectable or metastatic melanoma with a BRAF V600 mutation.",
@@ -24780,7 +24795,7 @@
   {
     "id": 2083,
     "type": "Statement",
-    "description": "Health Canada approved Pembrolizumab for the treatment of adult patients with resectable locally advanced head and neck squamous cell carcinoma (HNSCC) whose tumours express PD-L1 (Combined Positive Score [CPS] \u22651), as neoadjuvant treatment as monotherapy, continued as adjuvant treatment in combination with radiotherapy (RT) with or without cisplatin and then as monotherapy.",
+    "description": "Health Canada approved pembrolizumab, in combination with chemotherapy with or without bevacizumab, for the treatment of adult patients with persistent, recurrent, or metastatic cervical cancer whose tumours express PD-L1 (CPS >= 1) as determined by a validated test.",
     "contributions": [
       0
     ],
@@ -24795,7 +24810,7 @@
   {
     "id": 2084,
     "type": "Statement",
-    "description": "Health Canada approved Pembrolizumab for the treatment of adult patients with resectable locally advanced head and neck squamous cell carcinoma (HNSCC) whose tumours express PD-L1 (Combined Positive Score [CPS] \u22651), as neoadjuvant treatment as monotherapy, continued as adjuvant treatment in combination with radiotherapy (RT) with or without cisplatin and then as monotherapy.",
+    "description": "Health Canada approved pembrolizumab, in combination with chemotherapy with or without bevacizumab, for the treatment of adult patients with persistent, recurrent, or metastatic cervical cancer whose tumours express PD-L1 (CPS >= 1) as determined by a validated test.",
     "contributions": [
       0
     ],
@@ -24810,7 +24825,7 @@
   {
     "id": 2085,
     "type": "Statement",
-    "description": "Health Canada approved Pembrolizumab for the treatment of adult patients with resectable locally advanced head and neck squamous cell carcinoma (HNSCC) whose tumours express PD-L1 (Combined Positive Score [CPS] \u22651), as neoadjuvant treatment as monotherapy, continued as adjuvant treatment in combination with radiotherapy (RT) with or without cisplatin and then as monotherapy.",
+    "description": "Health Canada approved pembrolizumab, in combination with chemotherapy with or without bevacizumab, for the treatment of adult patients with persistent, recurrent, or metastatic cervical cancer whose tumours express PD-L1 (CPS >= 1) as determined by a validated test.",
     "contributions": [
       0
     ],
@@ -24825,7 +24840,7 @@
   {
     "id": 2086,
     "type": "Statement",
-    "description": "Health Canada approved Pembrolizumab for the treatment of adult patients with resectable locally advanced head and neck squamous cell carcinoma (HNSCC) whose tumours express PD-L1 (Combined Positive Score [CPS] \u22651), as neoadjuvant treatment as monotherapy, continued as adjuvant treatment in combination with radiotherapy (RT) with or without cisplatin and then as monotherapy.",
+    "description": "Health Canada approved pembrolizumab, in combination with chemotherapy with or without bevacizumab, for the treatment of adult patients with persistent, recurrent, or metastatic cervical cancer whose tumours express PD-L1 (CPS >= 1) as determined by a validated test.",
     "contributions": [
       0
     ],
@@ -24836,6 +24851,21 @@
     "direction": "supports",
     "strength_id": 0,
     "indication_id": "ind:hc.keytruda:11"
+  },
+  {
+    "id": 2334,
+    "type": "Statement",
+    "description": "Health Canada approved Pembrolizumab for the treatment of adult patients with resectable locally advanced head and neck squamous cell carcinoma (HNSCC) whose tumours express PD-L1 (Combined Positive Score [CPS] ≥1), as neoadjuvant treatment as monotherapy, continued as adjuvant treatment in combination with radiotherapy (RT) with or without cisplatin and then as monotherapy.",
+    "contributions": [
+      0
+    ],
+    "reportedIn": [
+      "doc:hc.keytruda"
+    ],
+    "proposition_id": 320,
+    "direction": "supports",
+    "strength_id": 0,
+    "indication_id": "ind:hc.keytruda:12"
   },
   {
     "id": 2087,
@@ -24971,6 +25001,96 @@
     "direction": "supports",
     "strength_id": 0,
     "indication_id": "ind:hc.kisqali:1"
+  },
+  {
+    "id": 2335,
+    "type": "Statement",
+    "description": "Health Canada approved ribociclib in combination with an aromatase inhibitor for the adjuvant treatment of adult patients with hormone receptor (HR)-positive, human epidermal growth factor receptor 2 (HER2)-negative stage II-III early breast cancer at high risk of recurrence. This indication is based on NATALEE (LEE011 O12301C) was a randomized (1:1), open-label, multicenter study, where participants received goserelin and either letrozole or anastrozole, in addition to ribociclib.",
+    "contributions": [
+      0
+    ],
+    "reportedIn": [
+      "doc:hc.kisqali"
+    ],
+    "proposition_id": 499,
+    "direction": "supports",
+    "strength_id": 0,
+    "indication_id": "ind:hc.kisqali:2"
+  },
+  {
+    "id": 2336,
+    "type": "Statement",
+    "description": "Health Canada approved ribociclib in combination with an aromatase inhibitor for the adjuvant treatment of adult patients with hormone receptor (HR)-positive, human epidermal growth factor receptor 2 (HER2)-negative stage II-III early breast cancer at high risk of recurrence. This indication is based on NATALEE (LEE011 O12301C) was a randomized (1:1), open-label, multicenter study, where participants received goserelin and either letrozole or anastrozole, in addition to ribociclib.",
+    "contributions": [
+      0
+    ],
+    "reportedIn": [
+      "doc:hc.kisqali"
+    ],
+    "proposition_id": 500,
+    "direction": "supports",
+    "strength_id": 0,
+    "indication_id": "ind:hc.kisqali:2"
+  },
+  {
+    "id": 2337,
+    "type": "Statement",
+    "description": "Health Canada approved ribociclib in combination with an aromatase inhibitor for the adjuvant treatment of adult patients with hormone receptor (HR)-positive, human epidermal growth factor receptor 2 (HER2)-negative stage II-III early breast cancer at high risk of recurrence. This indication is based on NATALEE (LEE011 O12301C) was a randomized (1:1), open-label, multicenter study, where participants received goserelin and either letrozole or anastrozole, in addition to ribociclib.",
+    "contributions": [
+      0
+    ],
+    "reportedIn": [
+      "doc:hc.kisqali"
+    ],
+    "proposition_id": 501,
+    "direction": "supports",
+    "strength_id": 0,
+    "indication_id": "ind:hc.kisqali:2"
+  },
+  {
+    "id": 2338,
+    "type": "Statement",
+    "description": "Health Canada approved ribociclib in combination with an aromatase inhibitor for the adjuvant treatment of adult patients with hormone receptor (HR)-positive, human epidermal growth factor receptor 2 (HER2)-negative stage II-III early breast cancer at high risk of recurrence. This indication is based on NATALEE (LEE011 O12301C) was a randomized (1:1), open-label, multicenter study, where participants received goserelin and either letrozole or anastrozole, in addition to ribociclib.",
+    "contributions": [
+      0
+    ],
+    "reportedIn": [
+      "doc:hc.kisqali"
+    ],
+    "proposition_id": 502,
+    "direction": "supports",
+    "strength_id": 0,
+    "indication_id": "ind:hc.kisqali:2"
+  },
+  {
+    "id": 2339,
+    "type": "Statement",
+    "description": "Health Canada approved ribociclib in combination with an aromatase inhibitor for the adjuvant treatment of adult patients with hormone receptor (HR)-positive, human epidermal growth factor receptor 2 (HER2)-negative stage II-III early breast cancer at high risk of recurrence. This indication is based on NATALEE (LEE011 O12301C) was a randomized (1:1), open-label, multicenter study, where participants received goserelin and either letrozole or anastrozole, in addition to ribociclib.",
+    "contributions": [
+      0
+    ],
+    "reportedIn": [
+      "doc:hc.kisqali"
+    ],
+    "proposition_id": 503,
+    "direction": "supports",
+    "strength_id": 0,
+    "indication_id": "ind:hc.kisqali:2"
+  },
+  {
+    "id": 2340,
+    "type": "Statement",
+    "description": "Health Canada approved ribociclib in combination with an aromatase inhibitor for the adjuvant treatment of adult patients with hormone receptor (HR)-positive, human epidermal growth factor receptor 2 (HER2)-negative stage II-III early breast cancer at high risk of recurrence. This indication is based on NATALEE (LEE011 O12301C) was a randomized (1:1), open-label, multicenter study, where participants received goserelin and either letrozole or anastrozole, in addition to ribociclib.",
+    "contributions": [
+      0
+    ],
+    "reportedIn": [
+      "doc:hc.kisqali"
+    ],
+    "proposition_id": 504,
+    "direction": "supports",
+    "strength_id": 0,
+    "indication_id": "ind:hc.kisqali:2"
   },
   {
     "id": 2096,
@@ -26006,6 +26126,51 @@
     "direction": "supports",
     "strength_id": 0,
     "indication_id": "ind:hc.opdivo:7"
+  },
+  {
+    "id": 2341,
+    "type": "Statement",
+    "description": "Health Canada approved nivolumab in combination with platinum-doublet chemotherapy, the neoadjuvant treatment of adult patients with resectable Stage II (>4 cm), IIIA, IIIB (T3-4N2) NSCLC and no known epidermal growth factor Opdivo (nivolumab) receptor (EGFR) mutations or anaplastic lymphoma kinase (ALK) rearrangements, followed by OPDIVO as a single agent in the adjuvant setting after surgical resection. This approval is based on CHECKMATE-816, a randomized, open label trial where patients were offered platinum-doublet chemotherapy consisting of either paclitaxel and carboplatin; pemetrexed and cisplatin for non-squamous histology; or gemcitabine and cisplatin for squamous histology.",
+    "contributions": [
+      0
+    ],
+    "reportedIn": [
+      "doc:hc.opdivo"
+    ],
+    "proposition_id": 229,
+    "direction": "supports",
+    "strength_id": 0,
+    "indication_id": "ind:hc.opdivo:8"
+  },
+  {
+    "id": 2342,
+    "type": "Statement",
+    "description": "Health Canada approved nivolumab in combination with platinum-doublet chemotherapy, the neoadjuvant treatment of adult patients with resectable Stage II (>4 cm), IIIA, IIIB (T3-4N2) NSCLC and no known epidermal growth factor Opdivo (nivolumab) receptor (EGFR) mutations or anaplastic lymphoma kinase (ALK) rearrangements, followed by OPDIVO as a single agent in the adjuvant setting after surgical resection. This approval is based on CHECKMATE-816, a randomized, open label trial where patients were offered platinum-doublet chemotherapy consisting of either paclitaxel and carboplatin; pemetrexed and cisplatin for non-squamous histology; or gemcitabine and cisplatin for squamous histology.",
+    "contributions": [
+      0
+    ],
+    "reportedIn": [
+      "doc:hc.opdivo"
+    ],
+    "proposition_id": 505,
+    "direction": "supports",
+    "strength_id": 0,
+    "indication_id": "ind:hc.opdivo:8"
+  },
+  {
+    "id": 2343,
+    "type": "Statement",
+    "description": "Health Canada approved nivolumab in combination with platinum-doublet chemotherapy, the neoadjuvant treatment of adult patients with resectable Stage II (>4 cm), IIIA, IIIB (T3-4N2) NSCLC and no known epidermal growth factor Opdivo (nivolumab) receptor (EGFR) mutations or anaplastic lymphoma kinase (ALK) rearrangements, followed by OPDIVO as a single agent in the adjuvant setting after surgical resection. This approval is based on CHECKMATE-816, a randomized, open label trial where patients were offered platinum-doublet chemotherapy consisting of either paclitaxel and carboplatin; pemetrexed and cisplatin for non-squamous histology; or gemcitabine and cisplatin for squamous histology.",
+    "contributions": [
+      0
+    ],
+    "reportedIn": [
+      "doc:hc.opdivo"
+    ],
+    "proposition_id": 506,
+    "direction": "supports",
+    "strength_id": 0,
+    "indication_id": "ind:hc.opdivo:8"
   },
   {
     "id": 2165,
@@ -28536,7 +28701,7 @@
   {
     "id": 2346,
     "type": "Statement",
-    "description": "Health Canada approved niraparib and abiraterone acetate in combination with prednisone or prednisolone for the treatment of adult patients with deleterious or suspected deleterious BRCA-mutated (germline and/or somatic) metastatic castration-resistant prostate cancer (mCRPC), who are asymptomatic or mildly symptomatic, and in whom chemotherapy is not clinically indicated.",
+    "description": "Health Canada approved niraparib/abiraterone acetate for the treatment of adult patients with deleterious or suspected deleterious BRCA mutated (germline and/or somatic) metastatic castration resistant prostate cancer (mCRPC), who are asymptomatic/mildly symptomatic, and in whom chemotherapy is not clinically indicated.",
     "contributions": [
       0
     ],
@@ -28551,7 +28716,7 @@
   {
     "id": 2347,
     "type": "Statement",
-    "description": "Health Canada approved niraparib and abiraterone acetate in combination with prednisone or prednisolone for the treatment of adult patients with deleterious or suspected deleterious BRCA-mutated (germline and/or somatic) metastatic castration-resistant prostate cancer (mCRPC), who are asymptomatic or mildly symptomatic, and in whom chemotherapy is not clinically indicated.",
+    "description": "Health Canada approved niraparib/abiraterone acetate for the treatment of adult patients with deleterious or suspected deleterious BRCA mutated (germline and/or somatic) metastatic castration resistant prostate cancer (mCRPC), who are asymptomatic/mildly symptomatic, and in whom chemotherapy is not clinically indicated.",
     "contributions": [
       0
     ],
@@ -28559,21 +28724,6 @@
       "doc:hc.akeega"
     ],
     "proposition_id": 18,
-    "direction": "supports",
-    "strength_id": 0,
-    "indication_id": "ind:hc.akeega:0"
-  },
-  {
-    "id": 2384,
-    "type": "Statement",
-    "description": "Health Canada approved niraparib and abiraterone acetate in combination with prednisone or prednisolone for the treatment of adult patients with deleterious or suspected deleterious BRCA-mutated (germline and/or somatic) metastatic castration-resistant prostate cancer (mCRPC), who are asymptomatic or mildly symptomatic, and in whom chemotherapy is not clinically indicated.",
-    "contributions": [
-      0
-    ],
-    "reportedIn": [
-      "doc:hc.akeega"
-    ],
-    "proposition_id": 537,
     "direction": "supports",
     "strength_id": 0,
     "indication_id": "ind:hc.akeega:0"
@@ -28588,7 +28738,7 @@
     "reportedIn": [
       "doc:hc.akeega"
     ],
-    "proposition_id": 538,
+    "proposition_id": 537,
     "direction": "supports",
     "strength_id": 0,
     "indication_id": "ind:hc.akeega:0"
@@ -28603,7 +28753,7 @@
     "reportedIn": [
       "doc:hc.akeega"
     ],
-    "proposition_id": 540,
+    "proposition_id": 538,
     "direction": "supports",
     "strength_id": 0,
     "indication_id": "ind:hc.akeega:0"
@@ -28619,6 +28769,21 @@
       "doc:hc.akeega"
     ],
     "proposition_id": 539,
+    "direction": "supports",
+    "strength_id": 0,
+    "indication_id": "ind:hc.akeega:0"
+  },
+  {
+    "id": 2395,
+    "type": "Statement",
+    "description": "Health Canada approved niraparib and abiraterone acetate in combination with prednisone or prednisolone for the treatment of adult patients with deleterious or suspected deleterious BRCA-mutated (germline and/or somatic) metastatic castration-resistant prostate cancer (mCRPC), who are asymptomatic or mildly symptomatic, and in whom chemotherapy is not clinically indicated.",
+    "contributions": [
+      0
+    ],
+    "reportedIn": [
+      "doc:hc.akeega"
+    ],
+    "proposition_id": 540,
     "direction": "supports",
     "strength_id": 0,
     "indication_id": "ind:hc.akeega:0"
@@ -29237,5 +29402,20 @@
     "direction": "supports",
     "strength_id": 0,
     "indication_id": "ind:hc.tasigna:3"
+  },
+  {
+    "id": 2393,
+    "type": "Statement",
+    "description": "",
+    "contributions": [
+      0
+    ],
+    "reportedIn": [
+      "doc:hc.enhertu"
+    ],
+    "proposition_id": 424,
+    "direction": "supports",
+    "strength_id": 0,
+    "indication_id": "ind:hc.enhertu:4"
   }
 ]


### PR DESCRIPTION
## Overview
Here, we perform a few more revisions to Health Canada approvals and committed the .gitignore file to the repository.

## Database content updates

Statements were derived for several Health Canada approvals:

- `ind:hc.akeega:0`
- `ind:hc.braftovi:2`
- `ind:hc.enhertu:4`
- `ind:hc.keytruda:12`
- `ind:hc.kisqali:2`
- `ind:hc.opdivo:8`

## Feature updates

**Description**:
- Added the .gitignore to the repository
- the pyproject.toml was edited so that toml linting is enabled on save

## Checklist
- [x] `referenced/about.json` and `referenced/agents.json` last updated dates were updated.
- [x] All files changed have been reviewed.
- [x] All relevant documentation has been updated.
- [x] All unit tests have passed.
