### PR TITLE
Updated description of ind:ema.enhertu:4

### DIFF
--- a/dereferenced/indications/ind_ema.enhertu_4.json
+++ b/dereferenced/indications/ind_ema.enhertu_4.json
@@ -3,7 +3,7 @@
   "indication": "Enhertu as monotherapy is indicated for the treatment of adult patients with unresectable or metastatic hormone receptor (HR)-positive, HER2-low or HER2-ultralow breast cancer who have received at least one endocrine therapy in the metastatic setting and who are not considered suitable for endocrine therapy as the next line of treatment.",
   "initial_approval_date": "2025-03-31",
   "initial_approval_url": "https://www.ema.europa.eu/en/documents/variation-report/enhertu-h-c-005124-ii-0048-epar-assessment-report-variation_en.pdf",
-  "description": "The European Medicines Agency (EMA) has authorized trastuzumab deruxtecan as a monotherapy for the treatment of adult patients with advanced HER2-positive gastric or gastroesophageal junction (GEJ) adenocarcinoma who have received a prior trastuzumab-based regime.",
+  "description": "The European Medicines Agency (EMA) has authorized trastuzumab deruxtecan as a monotherapy for the treatment of adult patients with metastatic hormone receptor (HR)-positive, HER2-low or HER2-ultralow breast cancer who have received at least one endocrine therapy in the metastatic setting and who are not considered suitable for endocrine therapy as the next line of treatment.",
   "raw_biomarkers": "Hormone receptor (HR)-positive, HER2-low or HER2-ultralow",
   "raw_cancer_type": "breast cancer",
   "raw_therapeutics": "Enhertu (trastuzumab deruxtecan)",

--- a/dereferenced/statements/1073.json
+++ b/dereferenced/statements/1073.json
@@ -1,7 +1,7 @@
 {
   "id": 1073,
   "type": "Statement",
-  "description": "The European Medicines Agency (EMA) has authorized trastuzumab deruxtecan as a monotherapy for the treatment of adult patients with advanced HER2-positive gastric or gastroesophageal junction (GEJ) adenocarcinoma who have received a prior trastuzumab-based regime.",
+  "description": "The European Medicines Agency (EMA) has authorized trastuzumab deruxtecan as a monotherapy for the treatment of adult patients with metastatic hormone receptor (HR)-positive, HER2-low or HER2-ultralow breast cancer who have received at least one endocrine therapy in the metastatic setting and who are not considered suitable for endocrine therapy as the next line of treatment.",
   "contributions": [
     {
       "id": 17,
@@ -89,7 +89,7 @@
     "indication": "Enhertu as monotherapy is indicated for the treatment of adult patients with unresectable or metastatic hormone receptor (HR)-positive, HER2-low or HER2-ultralow breast cancer who have received at least one endocrine therapy in the metastatic setting and who are not considered suitable for endocrine therapy as the next line of treatment.",
     "initial_approval_date": "2025-03-31",
     "initial_approval_url": "https://www.ema.europa.eu/en/documents/variation-report/enhertu-h-c-005124-ii-0048-epar-assessment-report-variation_en.pdf",
-    "description": "The European Medicines Agency (EMA) has authorized trastuzumab deruxtecan as a monotherapy for the treatment of adult patients with advanced HER2-positive gastric or gastroesophageal junction (GEJ) adenocarcinoma who have received a prior trastuzumab-based regime.",
+    "description": "The European Medicines Agency (EMA) has authorized trastuzumab deruxtecan as a monotherapy for the treatment of adult patients with metastatic hormone receptor (HR)-positive, HER2-low or HER2-ultralow breast cancer who have received at least one endocrine therapy in the metastatic setting and who are not considered suitable for endocrine therapy as the next line of treatment.",
     "raw_biomarkers": "Hormone receptor (HR)-positive, HER2-low or HER2-ultralow",
     "raw_cancer_type": "breast cancer",
     "raw_therapeutics": "Enhertu (trastuzumab deruxtecan)",

--- a/dereferenced/statements/1074.json
+++ b/dereferenced/statements/1074.json
@@ -1,7 +1,7 @@
 {
   "id": 1074,
   "type": "Statement",
-  "description": "The European Medicines Agency (EMA) has authorized trastuzumab deruxtecan as a monotherapy for the treatment of adult patients with advanced HER2-positive gastric or gastroesophageal junction (GEJ) adenocarcinoma who have received a prior trastuzumab-based regime.",
+  "description": "The European Medicines Agency (EMA) has authorized trastuzumab deruxtecan as a monotherapy for the treatment of adult patients with metastatic hormone receptor (HR)-positive, HER2-low or HER2-ultralow breast cancer who have received at least one endocrine therapy in the metastatic setting and who are not considered suitable for endocrine therapy as the next line of treatment.",
   "contributions": [
     {
       "id": 17,
@@ -89,7 +89,7 @@
     "indication": "Enhertu as monotherapy is indicated for the treatment of adult patients with unresectable or metastatic hormone receptor (HR)-positive, HER2-low or HER2-ultralow breast cancer who have received at least one endocrine therapy in the metastatic setting and who are not considered suitable for endocrine therapy as the next line of treatment.",
     "initial_approval_date": "2025-03-31",
     "initial_approval_url": "https://www.ema.europa.eu/en/documents/variation-report/enhertu-h-c-005124-ii-0048-epar-assessment-report-variation_en.pdf",
-    "description": "The European Medicines Agency (EMA) has authorized trastuzumab deruxtecan as a monotherapy for the treatment of adult patients with advanced HER2-positive gastric or gastroesophageal junction (GEJ) adenocarcinoma who have received a prior trastuzumab-based regime.",
+    "description": "The European Medicines Agency (EMA) has authorized trastuzumab deruxtecan as a monotherapy for the treatment of adult patients with metastatic hormone receptor (HR)-positive, HER2-low or HER2-ultralow breast cancer who have received at least one endocrine therapy in the metastatic setting and who are not considered suitable for endocrine therapy as the next line of treatment.",
     "raw_biomarkers": "Hormone receptor (HR)-positive, HER2-low or HER2-ultralow",
     "raw_cancer_type": "breast cancer",
     "raw_therapeutics": "Enhertu (trastuzumab deruxtecan)",

--- a/dereferenced/statements/1075.json
+++ b/dereferenced/statements/1075.json
@@ -1,7 +1,7 @@
 {
   "id": 1075,
   "type": "Statement",
-  "description": "The European Medicines Agency (EMA) has authorized trastuzumab deruxtecan as a monotherapy for the treatment of adult patients with advanced HER2-positive gastric or gastroesophageal junction (GEJ) adenocarcinoma who have received a prior trastuzumab-based regime.",
+  "description": "The European Medicines Agency (EMA) has authorized trastuzumab deruxtecan as a monotherapy for the treatment of adult patients with metastatic hormone receptor (HR)-positive, HER2-low or HER2-ultralow breast cancer who have received at least one endocrine therapy in the metastatic setting and who are not considered suitable for endocrine therapy as the next line of treatment.",
   "contributions": [
     {
       "id": 17,
@@ -89,7 +89,7 @@
     "indication": "Enhertu as monotherapy is indicated for the treatment of adult patients with unresectable or metastatic hormone receptor (HR)-positive, HER2-low or HER2-ultralow breast cancer who have received at least one endocrine therapy in the metastatic setting and who are not considered suitable for endocrine therapy as the next line of treatment.",
     "initial_approval_date": "2025-03-31",
     "initial_approval_url": "https://www.ema.europa.eu/en/documents/variation-report/enhertu-h-c-005124-ii-0048-epar-assessment-report-variation_en.pdf",
-    "description": "The European Medicines Agency (EMA) has authorized trastuzumab deruxtecan as a monotherapy for the treatment of adult patients with advanced HER2-positive gastric or gastroesophageal junction (GEJ) adenocarcinoma who have received a prior trastuzumab-based regime.",
+    "description": "The European Medicines Agency (EMA) has authorized trastuzumab deruxtecan as a monotherapy for the treatment of adult patients with metastatic hormone receptor (HR)-positive, HER2-low or HER2-ultralow breast cancer who have received at least one endocrine therapy in the metastatic setting and who are not considered suitable for endocrine therapy as the next line of treatment.",
     "raw_biomarkers": "Hormone receptor (HR)-positive, HER2-low or HER2-ultralow",
     "raw_cancer_type": "breast cancer",
     "raw_therapeutics": "Enhertu (trastuzumab deruxtecan)",

--- a/dereferenced/statements/1076.json
+++ b/dereferenced/statements/1076.json
@@ -1,7 +1,7 @@
 {
   "id": 1076,
   "type": "Statement",
-  "description": "The European Medicines Agency (EMA) has authorized trastuzumab deruxtecan as a monotherapy for the treatment of adult patients with advanced HER2-positive gastric or gastroesophageal junction (GEJ) adenocarcinoma who have received a prior trastuzumab-based regime.",
+  "description": "The European Medicines Agency (EMA) has authorized trastuzumab deruxtecan as a monotherapy for the treatment of adult patients with metastatic hormone receptor (HR)-positive, HER2-low or HER2-ultralow breast cancer who have received at least one endocrine therapy in the metastatic setting and who are not considered suitable for endocrine therapy as the next line of treatment.",
   "contributions": [
     {
       "id": 17,
@@ -89,7 +89,7 @@
     "indication": "Enhertu as monotherapy is indicated for the treatment of adult patients with unresectable or metastatic hormone receptor (HR)-positive, HER2-low or HER2-ultralow breast cancer who have received at least one endocrine therapy in the metastatic setting and who are not considered suitable for endocrine therapy as the next line of treatment.",
     "initial_approval_date": "2025-03-31",
     "initial_approval_url": "https://www.ema.europa.eu/en/documents/variation-report/enhertu-h-c-005124-ii-0048-epar-assessment-report-variation_en.pdf",
-    "description": "The European Medicines Agency (EMA) has authorized trastuzumab deruxtecan as a monotherapy for the treatment of adult patients with advanced HER2-positive gastric or gastroesophageal junction (GEJ) adenocarcinoma who have received a prior trastuzumab-based regime.",
+    "description": "The European Medicines Agency (EMA) has authorized trastuzumab deruxtecan as a monotherapy for the treatment of adult patients with metastatic hormone receptor (HR)-positive, HER2-low or HER2-ultralow breast cancer who have received at least one endocrine therapy in the metastatic setting and who are not considered suitable for endocrine therapy as the next line of treatment.",
     "raw_biomarkers": "Hormone receptor (HR)-positive, HER2-low or HER2-ultralow",
     "raw_cancer_type": "breast cancer",
     "raw_therapeutics": "Enhertu (trastuzumab deruxtecan)",

--- a/dereferenced/statements/1077.json
+++ b/dereferenced/statements/1077.json
@@ -1,7 +1,7 @@
 {
   "id": 1077,
   "type": "Statement",
-  "description": "The European Medicines Agency (EMA) has authorized trastuzumab deruxtecan as a monotherapy for the treatment of adult patients with advanced HER2-positive gastric or gastroesophageal junction (GEJ) adenocarcinoma who have received a prior trastuzumab-based regime.",
+  "description": "The European Medicines Agency (EMA) has authorized trastuzumab deruxtecan as a monotherapy for the treatment of adult patients with metastatic hormone receptor (HR)-positive, HER2-low or HER2-ultralow breast cancer who have received at least one endocrine therapy in the metastatic setting and who are not considered suitable for endocrine therapy as the next line of treatment.",
   "contributions": [
     {
       "id": 17,
@@ -89,7 +89,7 @@
     "indication": "Enhertu as monotherapy is indicated for the treatment of adult patients with unresectable or metastatic hormone receptor (HR)-positive, HER2-low or HER2-ultralow breast cancer who have received at least one endocrine therapy in the metastatic setting and who are not considered suitable for endocrine therapy as the next line of treatment.",
     "initial_approval_date": "2025-03-31",
     "initial_approval_url": "https://www.ema.europa.eu/en/documents/variation-report/enhertu-h-c-005124-ii-0048-epar-assessment-report-variation_en.pdf",
-    "description": "The European Medicines Agency (EMA) has authorized trastuzumab deruxtecan as a monotherapy for the treatment of adult patients with advanced HER2-positive gastric or gastroesophageal junction (GEJ) adenocarcinoma who have received a prior trastuzumab-based regime.",
+    "description": "The European Medicines Agency (EMA) has authorized trastuzumab deruxtecan as a monotherapy for the treatment of adult patients with metastatic hormone receptor (HR)-positive, HER2-low or HER2-ultralow breast cancer who have received at least one endocrine therapy in the metastatic setting and who are not considered suitable for endocrine therapy as the next line of treatment.",
     "raw_biomarkers": "Hormone receptor (HR)-positive, HER2-low or HER2-ultralow",
     "raw_cancer_type": "breast cancer",
     "raw_therapeutics": "Enhertu (trastuzumab deruxtecan)",

--- a/dereferenced/statements/1078.json
+++ b/dereferenced/statements/1078.json
@@ -1,7 +1,7 @@
 {
   "id": 1078,
   "type": "Statement",
-  "description": "The European Medicines Agency (EMA) has authorized trastuzumab deruxtecan as a monotherapy for the treatment of adult patients with advanced HER2-positive gastric or gastroesophageal junction (GEJ) adenocarcinoma who have received a prior trastuzumab-based regime.",
+  "description": "The European Medicines Agency (EMA) has authorized trastuzumab deruxtecan as a monotherapy for the treatment of adult patients with metastatic hormone receptor (HR)-positive, HER2-low or HER2-ultralow breast cancer who have received at least one endocrine therapy in the metastatic setting and who are not considered suitable for endocrine therapy as the next line of treatment.",
   "contributions": [
     {
       "id": 17,
@@ -89,7 +89,7 @@
     "indication": "Enhertu as monotherapy is indicated for the treatment of adult patients with unresectable or metastatic hormone receptor (HR)-positive, HER2-low or HER2-ultralow breast cancer who have received at least one endocrine therapy in the metastatic setting and who are not considered suitable for endocrine therapy as the next line of treatment.",
     "initial_approval_date": "2025-03-31",
     "initial_approval_url": "https://www.ema.europa.eu/en/documents/variation-report/enhertu-h-c-005124-ii-0048-epar-assessment-report-variation_en.pdf",
-    "description": "The European Medicines Agency (EMA) has authorized trastuzumab deruxtecan as a monotherapy for the treatment of adult patients with advanced HER2-positive gastric or gastroesophageal junction (GEJ) adenocarcinoma who have received a prior trastuzumab-based regime.",
+    "description": "The European Medicines Agency (EMA) has authorized trastuzumab deruxtecan as a monotherapy for the treatment of adult patients with metastatic hormone receptor (HR)-positive, HER2-low or HER2-ultralow breast cancer who have received at least one endocrine therapy in the metastatic setting and who are not considered suitable for endocrine therapy as the next line of treatment.",
     "raw_biomarkers": "Hormone receptor (HR)-positive, HER2-low or HER2-ultralow",
     "raw_cancer_type": "breast cancer",
     "raw_therapeutics": "Enhertu (trastuzumab deruxtecan)",

--- a/referenced/indications.json
+++ b/referenced/indications.json
@@ -3465,7 +3465,7 @@
     "indication": "Enhertu as monotherapy is indicated for the treatment of adult patients with unresectable or metastatic hormone receptor (HR)-positive, HER2-low or HER2-ultralow breast cancer who have received at least one endocrine therapy in the metastatic setting and who are not considered suitable for endocrine therapy as the next line of treatment.",
     "initial_approval_date": "2025-03-31",
     "initial_approval_url": "https://www.ema.europa.eu/en/documents/variation-report/enhertu-h-c-005124-ii-0048-epar-assessment-report-variation_en.pdf",
-    "description": "The European Medicines Agency (EMA) has authorized trastuzumab deruxtecan as a monotherapy for the treatment of adult patients with advanced HER2-positive gastric or gastroesophageal junction (GEJ) adenocarcinoma who have received a prior trastuzumab-based regime.",
+    "description": "The European Medicines Agency (EMA) has authorized trastuzumab deruxtecan as a monotherapy for the treatment of adult patients with metastatic hormone receptor (HR)-positive, HER2-low or HER2-ultralow breast cancer who have received at least one endocrine therapy in the metastatic setting and who are not considered suitable for endocrine therapy as the next line of treatment.",
     "raw_biomarkers": "Hormone receptor (HR)-positive, HER2-low or HER2-ultralow",
     "raw_cancer_type": "breast cancer",
     "raw_therapeutics": "Enhertu (trastuzumab deruxtecan)",

--- a/referenced/statements.json
+++ b/referenced/statements.json
@@ -17077,7 +17077,7 @@
   {
     "id": 1073,
     "type": "Statement",
-    "description": "The European Medicines Agency (EMA) has authorized trastuzumab deruxtecan as a monotherapy for the treatment of adult patients with advanced HER2-positive gastric or gastroesophageal junction (GEJ) adenocarcinoma who have received a prior trastuzumab-based regime.",
+    "description": "The European Medicines Agency (EMA) has authorized trastuzumab deruxtecan as a monotherapy for the treatment of adult patients with metastatic hormone receptor (HR)-positive, HER2-low or HER2-ultralow breast cancer who have received at least one endocrine therapy in the metastatic setting and who are not considered suitable for endocrine therapy as the next line of treatment.",
     "contributions": [
       17
     ],
@@ -17093,7 +17093,7 @@
   {
     "id": 1074,
     "type": "Statement",
-    "description": "The European Medicines Agency (EMA) has authorized trastuzumab deruxtecan as a monotherapy for the treatment of adult patients with advanced HER2-positive gastric or gastroesophageal junction (GEJ) adenocarcinoma who have received a prior trastuzumab-based regime.",
+    "description": "The European Medicines Agency (EMA) has authorized trastuzumab deruxtecan as a monotherapy for the treatment of adult patients with metastatic hormone receptor (HR)-positive, HER2-low or HER2-ultralow breast cancer who have received at least one endocrine therapy in the metastatic setting and who are not considered suitable for endocrine therapy as the next line of treatment.",
     "contributions": [
       17
     ],
@@ -17109,7 +17109,7 @@
   {
     "id": 1075,
     "type": "Statement",
-    "description": "The European Medicines Agency (EMA) has authorized trastuzumab deruxtecan as a monotherapy for the treatment of adult patients with advanced HER2-positive gastric or gastroesophageal junction (GEJ) adenocarcinoma who have received a prior trastuzumab-based regime.",
+    "description": "The European Medicines Agency (EMA) has authorized trastuzumab deruxtecan as a monotherapy for the treatment of adult patients with metastatic hormone receptor (HR)-positive, HER2-low or HER2-ultralow breast cancer who have received at least one endocrine therapy in the metastatic setting and who are not considered suitable for endocrine therapy as the next line of treatment.",
     "contributions": [
       17
     ],
@@ -17125,7 +17125,7 @@
   {
     "id": 1076,
     "type": "Statement",
-    "description": "The European Medicines Agency (EMA) has authorized trastuzumab deruxtecan as a monotherapy for the treatment of adult patients with advanced HER2-positive gastric or gastroesophageal junction (GEJ) adenocarcinoma who have received a prior trastuzumab-based regime.",
+    "description": "The European Medicines Agency (EMA) has authorized trastuzumab deruxtecan as a monotherapy for the treatment of adult patients with metastatic hormone receptor (HR)-positive, HER2-low or HER2-ultralow breast cancer who have received at least one endocrine therapy in the metastatic setting and who are not considered suitable for endocrine therapy as the next line of treatment.",
     "contributions": [
       17
     ],
@@ -17141,7 +17141,7 @@
   {
     "id": 1077,
     "type": "Statement",
-    "description": "The European Medicines Agency (EMA) has authorized trastuzumab deruxtecan as a monotherapy for the treatment of adult patients with advanced HER2-positive gastric or gastroesophageal junction (GEJ) adenocarcinoma who have received a prior trastuzumab-based regime.",
+    "description": "The European Medicines Agency (EMA) has authorized trastuzumab deruxtecan as a monotherapy for the treatment of adult patients with metastatic hormone receptor (HR)-positive, HER2-low or HER2-ultralow breast cancer who have received at least one endocrine therapy in the metastatic setting and who are not considered suitable for endocrine therapy as the next line of treatment.",
     "contributions": [
       17
     ],
@@ -17157,7 +17157,7 @@
   {
     "id": 1078,
     "type": "Statement",
-    "description": "The European Medicines Agency (EMA) has authorized trastuzumab deruxtecan as a monotherapy for the treatment of adult patients with advanced HER2-positive gastric or gastroesophageal junction (GEJ) adenocarcinoma who have received a prior trastuzumab-based regime.",
+    "description": "The European Medicines Agency (EMA) has authorized trastuzumab deruxtecan as a monotherapy for the treatment of adult patients with metastatic hormone receptor (HR)-positive, HER2-low or HER2-ultralow breast cancer who have received at least one endocrine therapy in the metastatic setting and who are not considered suitable for endocrine therapy as the next line of treatment.",
     "contributions": [
       17
     ],


### PR DESCRIPTION
## Overview

The description for derived statements of ind:ema.enhertu:4 incorrectly described a separate indication for enhertu, specifically ind:ema.enhertu:3.

## Database content updates

**Revised entries**:
- The description for derived statements of ind:ema.enhertu:4 incorrectly described a separate indication for enhertu, specifically ind:ema.enhertu:3.

## Checklist
- [x] `referenced/about.json` and `referenced/agents.json` last updated dates were updated.
- [x] All files changed have been reviewed.
- [x] All relevant documentation has been updated.
- [x] All unit tests have passed.
